### PR TITLE
BEANUTILS-520: Mitigate CVE-2014-0114 by enabling SuppressPropertiesB…

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java
+++ b/src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java
@@ -185,6 +185,7 @@ public class PropertyUtilsBean {
     public final void resetBeanIntrospectors() {
         introspectors.clear();
         introspectors.add(DefaultBeanIntrospector.INSTANCE);
+        introspectors.add(SuppressPropertiesBeanIntrospector.SUPPRESS_CLASS);
     }
 
     /**

--- a/src/test/java/org/apache/commons/beanutils2/BeanIntrospectionDataTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/BeanIntrospectionDataTestCase.java
@@ -41,6 +41,7 @@ public class BeanIntrospectionDataTestCase extends TestCase {
      */
     private static PropertyDescriptor[] fetchDescriptors() {
         final PropertyUtilsBean pub = new PropertyUtilsBean();
+        pub.removeBeanIntrospector(SuppressPropertiesBeanIntrospector.SUPPRESS_CLASS);
         pub.addBeanIntrospector(new FluentPropertyBeanIntrospector());
         return pub.getPropertyDescriptors(BEAN_CLASS);
     }

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira157TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira157TestCase.java
@@ -20,6 +20,9 @@ import java.io.Serializable;
 import java.util.Map;
 
 import org.apache.commons.beanutils2.BeanUtils;
+import org.apache.commons.beanutils2.BeanUtilsBean;
+import org.apache.commons.beanutils2.PropertyUtilsBean;
+import org.apache.commons.beanutils2.SuppressPropertiesBeanIntrospector;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -73,6 +76,10 @@ public class Jira157TestCase extends TestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
+        
+        BeanUtilsBean custom = new BeanUtilsBean();
+    	custom.getPropertyUtils().removeBeanIntrospector(SuppressPropertiesBeanIntrospector.SUPPRESS_CLASS);
+    	BeanUtilsBean.setInstance(custom);
     }
 
     /**

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira520TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira520TestCase.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.beanutils2.bugs;
+
+import org.apache.commons.beanutils2.AlphaBean;
+import org.apache.commons.beanutils2.BeanUtilsBean;
+import org.apache.commons.beanutils2.SuppressPropertiesBeanIntrospector;
+
+import junit.framework.TestCase;
+
+/**
+ * Fix CVE: https://nvd.nist.gov/vuln/detail/CVE-2014-0114
+ *
+ * @see <a href="https://issues.apache.org/jira/browse/BEANUTILS-520">https://issues.apache.org/jira/browse/BEANUTILS-520</a>
+ */
+public class Jira520TestCase extends TestCase {
+    /**
+     * By default opt-in to security that does not allow access to "class".
+     */
+    public void testSuppressClassPropertyByDefault() throws Exception {
+        final BeanUtilsBean bub = new BeanUtilsBean();
+        final AlphaBean bean = new AlphaBean();
+        try {
+            bub.getProperty(bean, "class");
+            fail("Could access class property!");
+        } catch (final NoSuchMethodException ex) {
+            // ok
+        }
+    }
+    
+    /**
+     * Allow opt-out to make your app less secure but allow access to "class".
+     */
+    public void testAllowAccessToClassProperty() throws Exception {
+        final BeanUtilsBean bub = new BeanUtilsBean();
+        bub.getPropertyUtils().removeBeanIntrospector(SuppressPropertiesBeanIntrospector.SUPPRESS_CLASS);
+        final AlphaBean bean = new AlphaBean();
+        String result = bub.getProperty(bean, "class");
+        assertEquals("Class property should have been accessed", "class org.apache.commons.beanutils2.AlphaBean", result);
+    }
+}


### PR DESCRIPTION
Fixes CVE-2014-0114: https://nvd.nist.gov/vuln/detail/CVE-2014-0114

This patch by default enables the `SuppressPropertiesBeanIntrospector.SUPPRESS_CLASS`. So you are secure by default.

To opt-out and allow access to the "class" property making it work like BeanUtils 1.9.3 or lower simply add this one line of code to remove the feature.

```java
final BeanUtilsBean bub = new BeanUtilsBean(); 
bub.getPropertyUtils().removeBeanIntrospector(SuppressPropertiesBeanIntrospector.SUPPRESS_CLASS);
```

This makes the library more secure by default and but still allows backward compatibility.
