### PR TITLE
Convert Collections4 to java.util.function

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/BeanPredicate.java
+++ b/src/main/java/org/apache/commons/beanutils2/BeanPredicate.java
@@ -18,8 +18,8 @@
 package org.apache.commons.beanutils2;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.function.Predicate;
 
-import org.apache.commons.collections4.Predicate;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -29,14 +29,14 @@ import org.apache.commons.logging.LogFactory;
  * </p>
  *
  */
-public class BeanPredicate implements Predicate {
+public class BeanPredicate implements Predicate<Object> {
 
     private final Log log = LogFactory.getLog(this.getClass());
 
     /** Name of the property whose value will be predicated */
     private String propertyName;
     /** <code>Predicate</code> to be applied to the property value */
-    private Predicate predicate;
+    private Predicate<Object> predicate;
 
     /**
      * Constructs a <code>BeanPredicate</code> that applies the given
@@ -50,6 +50,18 @@ public class BeanPredicate implements Predicate {
         this.propertyName = propertyName;
         this.predicate = predicate;
     }
+    
+    /**
+     * Evaluates the given object by applying the {@link #getPredicate()}
+     * to a property value named by {@link #getPropertyName()}.
+     *
+     * @param object The object being evaluated
+     * @return the result of the predicate evaluation
+     * @throws IllegalArgumentException when the property cannot be evaluated
+     */
+	public boolean evaluate(Object object) {
+		return test(object);
+	}
 
     /**
      * Evaluates the given object by applying the {@link #getPredicate()}
@@ -59,14 +71,13 @@ public class BeanPredicate implements Predicate {
      * @return the result of the predicate evaluation
      * @throws IllegalArgumentException when the property cannot be evaluated
      */
-    @Override
-    public boolean evaluate(final Object object) {
-
-        boolean evaluation = false;
+	@Override
+	public boolean test(Object object) {
+		boolean evaluation = false;
 
         try {
             final Object propValue = PropertyUtils.getProperty( object, propertyName );
-            evaluation = predicate.evaluate(propValue);
+            evaluation = predicate.test(propValue);
         } catch (final IllegalArgumentException e) {
             final String errorMsg = "Problem during evaluation.";
             log.error("ERROR: " + errorMsg, e);
@@ -86,8 +97,8 @@ public class BeanPredicate implements Predicate {
         }
 
         return evaluation;
-    }
-
+	}
+	
     /**
      * Gets the name of the property whose value is to be predicated.
      * in the evaluation.
@@ -111,7 +122,7 @@ public class BeanPredicate implements Predicate {
      * during {@link #evaluate}.
      * @return <code>Predicate</code>, not null
      */
-    public Predicate getPredicate() {
+    public Predicate<Object> getPredicate() {
         return predicate;
     }
 
@@ -120,8 +131,12 @@ public class BeanPredicate implements Predicate {
      * during {@link #evaluate(Object)}.
      * @param predicate <code>Predicate</code>, not null
      */
-    public void setPredicate(final Predicate predicate) {
+    public void setPredicate(final Predicate<Object> predicate) {
         this.predicate = predicate;
     }
+
+
+
+
 
 }

--- a/src/main/java/org/apache/commons/beanutils2/BeanPredicate.java
+++ b/src/main/java/org/apache/commons/beanutils2/BeanPredicate.java
@@ -59,9 +59,9 @@ public class BeanPredicate implements Predicate<Object> {
      * @return the result of the predicate evaluation
      * @throws IllegalArgumentException when the property cannot be evaluated
      */
-	public boolean evaluate(Object object) {
-		return test(object);
-	}
+    public boolean evaluate(Object object) {
+        return test(object);
+    }
 
     /**
      * Evaluates the given object by applying the {@link #getPredicate()}
@@ -71,9 +71,9 @@ public class BeanPredicate implements Predicate<Object> {
      * @return the result of the predicate evaluation
      * @throws IllegalArgumentException when the property cannot be evaluated
      */
-	@Override
-	public boolean test(Object object) {
-		boolean evaluation = false;
+    @Override
+    public boolean test(Object object) {
+        boolean evaluation = false;
 
         try {
             final Object propValue = PropertyUtils.getProperty( object, propertyName );
@@ -97,8 +97,8 @@ public class BeanPredicate implements Predicate<Object> {
         }
 
         return evaluation;
-	}
-	
+    }
+    
     /**
      * Gets the name of the property whose value is to be predicated.
      * in the evaluation.

--- a/src/test/java/org/apache/commons/beanutils2/BeanPredicateTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/BeanPredicateTestCase.java
@@ -17,14 +17,14 @@
 
 package org.apache.commons.beanutils2;
 
-import org.apache.commons.collections4.functors.EqualPredicate;
-import org.apache.commons.collections4.functors.InstanceofPredicate;
-import org.apache.commons.collections4.functors.NotPredicate;
-import org.apache.commons.collections4.functors.NullPredicate;
+
+import java.util.function.Predicate;
 
 import junit.framework.TestCase;
 
 /**
+ * Unit test for {@link BeanPredicate}
+ *
  */
 public class BeanPredicateTestCase extends TestCase {
 
@@ -33,29 +33,29 @@ public class BeanPredicateTestCase extends TestCase {
     }
 
     public void testEqual() {
-        final BeanPredicate predicate =
-            new BeanPredicate("stringProperty",new EqualPredicate("foo"));
+    	Predicate<String> p = (s) -> s.equals("foo");
+        final BeanPredicate predicate = new BeanPredicate("stringProperty", p);
         assertTrue(predicate.evaluate(new TestBean("foo")));
         assertTrue(!predicate.evaluate(new TestBean("bar")));
     }
 
     public void testNotEqual() {
-        final BeanPredicate predicate =
-            new BeanPredicate("stringProperty",new NotPredicate( new EqualPredicate("foo")));
+    	Predicate<String> p = (s) -> !s.equals("foo");
+        final BeanPredicate predicate = new BeanPredicate("stringProperty", p);
         assertTrue(!predicate.evaluate(new TestBean("foo")));
         assertTrue(predicate.evaluate(new TestBean("bar")));
     }
 
     public void testInstanceOf() {
-        final BeanPredicate predicate =
-            new BeanPredicate("stringProperty",new InstanceofPredicate( String.class ));
+    	Predicate<String> p = (s) -> (s instanceof String);
+        final BeanPredicate predicate = new BeanPredicate("stringProperty",p);
         assertTrue(predicate.evaluate(new TestBean("foo")));
         assertTrue(predicate.evaluate(new TestBean("bar")));
     }
 
     public void testNull() {
-        final BeanPredicate predicate =
-            new BeanPredicate("stringProperty", NullPredicate.INSTANCE);
+    	Predicate<String> p = (s) -> s == null;
+        final BeanPredicate predicate = new BeanPredicate("stringProperty", p);
         final String nullString = null;
         assertTrue(predicate.evaluate(new TestBean(nullString)));
         assertTrue(!predicate.evaluate(new TestBean("bar")));

--- a/src/test/java/org/apache/commons/beanutils2/BeanPredicateTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/BeanPredicateTestCase.java
@@ -17,7 +17,6 @@
 
 package org.apache.commons.beanutils2;
 
-
 import java.util.function.Predicate;
 
 import junit.framework.TestCase;
@@ -33,28 +32,28 @@ public class BeanPredicateTestCase extends TestCase {
     }
 
     public void testEqual() {
-    	Predicate<String> p = (s) -> s.equals("foo");
+        Predicate<String> p = (s) -> s.equals("foo");
         final BeanPredicate predicate = new BeanPredicate("stringProperty", p);
         assertTrue(predicate.evaluate(new TestBean("foo")));
         assertTrue(!predicate.evaluate(new TestBean("bar")));
     }
 
     public void testNotEqual() {
-    	Predicate<String> p = (s) -> !s.equals("foo");
+        Predicate<String> p = (s) -> !s.equals("foo");
         final BeanPredicate predicate = new BeanPredicate("stringProperty", p);
         assertTrue(!predicate.evaluate(new TestBean("foo")));
         assertTrue(predicate.evaluate(new TestBean("bar")));
     }
 
     public void testInstanceOf() {
-    	Predicate<String> p = (s) -> (s instanceof String);
-        final BeanPredicate predicate = new BeanPredicate("stringProperty",p);
+        Predicate<String> p = (s) -> (s instanceof String);
+        final BeanPredicate predicate = new BeanPredicate("stringProperty", p);
         assertTrue(predicate.evaluate(new TestBean("foo")));
         assertTrue(predicate.evaluate(new TestBean("bar")));
     }
 
     public void testNull() {
-    	Predicate<String> p = (s) -> s == null;
+        Predicate<String> p = (s) -> s == null;
         final BeanPredicate predicate = new BeanPredicate("stringProperty", p);
         final String nullString = null;
         assertTrue(predicate.evaluate(new TestBean(nullString)));


### PR DESCRIPTION
@garydgregory I think this is what you were thinking for Predicate?

Feel free to let me know if have the generics wrong or anything else you want changed.
I kept the evaluate() method as is even though it just delegates to test() method.  Wasn't sure if that was what you wanted either?

**Notes:**
Should evaluate method be marked Deprecated since test() is the real function in java.util.Predicate?