### PR TITLE
BEANUTILS-527: Remove Commons Collection4 dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,11 +330,6 @@
       <version>1.2</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-collections4</artifactId>
-      <version>4.4</version>
-    </dependency>
-    <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections-testframework</artifactId>
       <version>3.2.1</version>

--- a/src/main/java/org/apache/commons/beanutils2/BeanComparator.java
+++ b/src/main/java/org/apache/commons/beanutils2/BeanComparator.java
@@ -83,7 +83,7 @@ public class BeanComparator<T> implements Comparator<T>, Serializable {
      * If the property passed in is null then the actual objects will be compared
      */
     public BeanComparator( final String property ) {
-        this( property, DefaultComparator.INSTANCE );
+        this( property, NaturalOrderingComparator.INSTANCE );
     }
 
     /**
@@ -107,7 +107,7 @@ public class BeanComparator<T> implements Comparator<T>, Serializable {
         if (comparator != null) {
             this.comparator = comparator;
         } else {
-            this.comparator = DefaultComparator.INSTANCE;
+            this.comparator = NaturalOrderingComparator.INSTANCE;
         }
     }
 
@@ -248,19 +248,19 @@ public class BeanComparator<T> implements Comparator<T>, Serializable {
      * @param <E> the type of objects compared by this comparator
      * @see java.util.Collections#reverseOrder()
      */
-    private static class DefaultComparator<E extends Comparable<? super E>> implements Comparator<E>, Serializable {
+    private static class NaturalOrderingComparator<E extends Comparable<? super E>> implements Comparator<E>, Serializable {
 
         /** Serialization version. */
         private static final long serialVersionUID=-291439688585137865L;
 
         /** The singleton instance. */
         @SuppressWarnings("rawtypes")
-        public static final DefaultComparator INSTANCE = new DefaultComparator();
+        public static final NaturalOrderingComparator INSTANCE = new NaturalOrderingComparator();
 
         /**
          * Private constructor to prevent instantiation. Only use INSTANCE.
          */
-        private DefaultComparator() {
+        private NaturalOrderingComparator() {
             super();
         }
 
@@ -276,7 +276,7 @@ public class BeanComparator<T> implements Comparator<T>, Serializable {
 
         @Override
         public int hashCode() {
-            return "ComparableComparator".hashCode();
+            return "NaturalOrderingComparator".hashCode();
         }
 
         @Override

--- a/src/main/java/org/apache/commons/beanutils2/BeanComparator.java
+++ b/src/main/java/org/apache/commons/beanutils2/BeanComparator.java
@@ -21,7 +21,6 @@ import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Comparator;
 
-import org.apache.commons.collections4.comparators.ComparableComparator;
 
 /**
  * <p>
@@ -84,7 +83,7 @@ public class BeanComparator<T> implements Comparator<T>, Serializable {
      * If the property passed in is null then the actual objects will be compared
      */
     public BeanComparator( final String property ) {
-        this( property, ComparableComparator.INSTANCE );
+        this( property, DefaultComparator.INSTANCE );
     }
 
     /**
@@ -108,7 +107,7 @@ public class BeanComparator<T> implements Comparator<T>, Serializable {
         if (comparator != null) {
             this.comparator = comparator;
         } else {
-            this.comparator = ComparableComparator.INSTANCE;
+            this.comparator = DefaultComparator.INSTANCE;
         }
     }
 
@@ -217,9 +216,7 @@ public class BeanComparator<T> implements Comparator<T>, Serializable {
      */
     @Override
     public int hashCode() {
-        int result;
-        result = comparator.hashCode();
-        return result;
+        return comparator.hashCode();
     }
 
     /**
@@ -237,5 +234,55 @@ public class BeanComparator<T> implements Comparator<T>, Serializable {
         // to make the compiler happy
         Comparator c = comparator;
         return c.compare(val1, val2);
+    }
+    
+    /**
+     * A {@link Comparator Comparator} that compares {@link Comparable Comparable}
+     * objects.
+     * <p>
+     * This Comparator is useful, for example, for enforcing the natural order in
+     * custom implementations of {@link java.util.SortedSet SortedSet} and
+     * {@link java.util.SortedMap SortedMap}.
+     * </p>
+     *
+     * @param <E> the type of objects compared by this comparator
+     * @see java.util.Collections#reverseOrder()
+     */
+    private static class DefaultComparator<E extends Comparable<? super E>> implements Comparator<E>, Serializable {
+
+        /** Serialization version. */
+        private static final long serialVersionUID=-291439688585137865L;
+
+        /** The singleton instance. */
+        @SuppressWarnings("rawtypes")
+        public static final DefaultComparator INSTANCE = new DefaultComparator();
+
+        /**
+         * Private constructor to prevent instantiation. Only use INSTANCE.
+         */
+        private DefaultComparator() {
+            super();
+        }
+
+        /**
+         * Compare the two {@link Comparable Comparable} arguments.
+         * This method is equivalent to:
+         * <pre>((Comparable)obj1).compareTo(obj2)</pre>
+         */
+        @Override
+        public int compare(final E obj1, final E obj2) {
+            return obj1.compareTo(obj2);
+        }
+
+        @Override
+        public int hashCode() {
+            return "ComparableComparator".hashCode();
+        }
+
+        @Override
+        public boolean equals(final Object object) {
+            return this == object ||
+                   null != object && object.getClass().equals(this.getClass());
+        }
     }
 }

--- a/src/main/java/org/apache/commons/beanutils2/package-info.java
+++ b/src/main/java/org/apache/commons/beanutils2/package-info.java
@@ -1017,8 +1017,7 @@
  * <h2>How Do I Set The BeanComparator Order To Be Ascending/Descending?</h2>
  * <p>
  * BeanComparator relies on an internal Comparator to perform the actual
- * comparisions. By default,
- * <code>org.apache.commons.collections4.comparators.ComparableComparator</code>
+ * comparisions. By default, a natural ordering comparator 
  * is used which imposes a natural order. If you want to change the order,
  * then a custom Comparator should be created and passed into the
  * appropriate constructor.


### PR DESCRIPTION
- The last reference to Collections4 was the ComparableComparator.
- I made a private static internal reference to the same class but called it NaturalOrderingComparator
- NaturalOrderingComparator cannot be used outside of this class and its just used by INSTANCE