### PR TITLE
[BEANUTILS-524] Copy properties improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .classpath
 .project
 .settings/
+.idea
+.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,8 @@
     <commons.release.isDistModule>true</commons.release.isDistModule>
     <commons.releaseManagerName>Gary Gregory</commons.releaseManagerName>
     <commons.releaseManagerKey>86fdc7e2a11262cb</commons.releaseManagerKey>
+    <!-- Third party libraries -->
+    <bull-bean-transformer.version>1.1.25</bull-bean-transformer.version>
   </properties>
 
   <issueManagement>
@@ -321,6 +323,9 @@
       <name>Bernhard Seebass</name>
       <email></email>
     </contributor>
+    <contributor>
+      <name>Fabio Borriello</name>
+    </contributor>
   </contributors>
 
   <dependencies>
@@ -340,6 +345,11 @@
       <artifactId>junit</artifactId>
       <version>4.12</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.hotels.beans</groupId>
+      <artifactId>bull-bean-transformer</artifactId>
+      <version>${bull-bean-transformer.version}</version>
     </dependency>
   </dependencies>
 
@@ -469,6 +479,17 @@
                         </configuration>
                     </reportSet>
                 </reportSets>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                    <parameters>true</parameters>
+                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                </configuration>
             </plugin>
 	      <plugin>
 		<groupId>com.github.siom79.japicmp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <commons.releaseManagerName>Gary Gregory</commons.releaseManagerName>
     <commons.releaseManagerKey>86fdc7e2a11262cb</commons.releaseManagerKey>
     <!-- Third party libraries -->
-    <bull-bean-transformer.version>1.1.25</bull-bean-transformer.version>
+    <bull-bean-transformer.version>1.6.2-jdk8</bull-bean-transformer.version>
   </properties>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <commons.releaseManagerName>Gary Gregory</commons.releaseManagerName>
     <commons.releaseManagerKey>86fdc7e2a11262cb</commons.releaseManagerKey>
     <!-- Third party libraries -->
-    <bull-bean-transformer.version>1.6.2-jdk8</bull-bean-transformer.version>
+    <bull-bean-transformer.version>1.6.3-jdk8</bull-bean-transformer.version>
   </properties>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -480,17 +480,6 @@
                     </reportSet>
                 </reportSets>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
-                    <parameters>true</parameters>
-                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                </configuration>
-            </plugin>
 	      <plugin>
 		<groupId>com.github.siom79.japicmp</groupId>
 		<artifactId>japicmp-maven-plugin</artifactId>

--- a/src/main/java/org/apache/commons/beanutils2/BeanUtils.java
+++ b/src/main/java/org/apache/commons/beanutils2/BeanUtils.java
@@ -21,6 +21,8 @@ package org.apache.commons.beanutils2;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
+import com.hotels.beans.transformer.BeanTransformer;
+import com.hotels.transformer.error.InvalidBeanException;
 
 
 /**
@@ -34,16 +36,6 @@ import java.util.Map;
  */
 
 public class BeanUtils {
-
-
-    
-
-
-
-
-    
-
-
     /**
      * <p>Clone a bean based on the available property getters and setters,
      * even if the bean class itself does not implement Cloneable.</p>
@@ -95,6 +87,53 @@ public class BeanUtils {
         throws IllegalAccessException, InvocationTargetException {
 
         BeanUtilsBean.getInstance().copyProperties(dest, orig);
+    }
+
+    /**
+     * <p>Copy property values from the origin bean to the destination bean
+     * class for all cases where the property names are the same. For each
+     * property, a conversion is attempted as necessary. All combinations of
+     * standard JavaBeans and DynaBeans as origin and destination are
+     * supported.  Properties that exist in the origin bean, but do not exist
+     * in the destination bean (or are read-only in the destination bean) are
+     * silently ignored and the default value for that type is set.</p>
+     *
+     * <p>To define specific mappings please refer to {@link com.hotels.beans.BeanUtils}
+     * documentation available see:
+     * @see <a href="https://hotelsdotcom.github.io/bull/transformer/bean/samples.html">Bean Transformer documentation</a>
+     * </p>
+     *
+     * @param destClass Destination bean class
+     * @param orig Origin bean whose properties are retrieved
+     *
+     * @throws InvalidBeanException if the destination bean is not valid
+     */
+    public static <T> T copyProperties(final Class<T> destClass, final Object orig) {
+        return BeanUtilsBean.getInstance().copyProperties(destClass, orig);
+    }
+
+    /**
+     * <p>Copy property values from the origin bean to the destination bean
+     * class for all cases using the given {@link BeanTransformer} properly configured. For each
+     * property, a conversion is attempted as necessary.  All combinations of
+     * standard JavaBeans and DynaBeans as origin and destination are
+     * supported.  Properties that exist in the origin bean, but do not exist
+     * in the destination bean (or are read-only in the destination bean) are
+     * silently ignored and the default value for that type is set.</p>
+     *
+     * <p>To define specific mappings please refer to {@link com.hotels.beans.BeanUtils}
+     * documentation available see:
+     * @see <a href="https://hotelsdotcom.github.io/bull/transformer/bean/samples.html">Bean Transformer documentation</a>
+     * </p>
+     *
+     * @param destClass Destination bean class
+     * @param orig Origin bean whose properties are retrieved
+     * @param beanTransformer the transformer containing all mappings and transformation functions.
+     *
+     * @throws InvalidBeanException if the destination bean is not valid
+     */
+    public <T> T copyProperties(final Class<T> destClass, final Object orig, final BeanTransformer beanTransformer) {
+        return BeanUtilsBean.getInstance().copyProperties(destClass, orig, beanTransformer);
     }
 
 

--- a/src/main/java/org/apache/commons/beanutils2/BeanUtils.java
+++ b/src/main/java/org/apache/commons/beanutils2/BeanUtils.java
@@ -132,7 +132,7 @@ public class BeanUtils {
      *
      * @throws InvalidBeanException if the destination bean is not valid
      */
-    public <T> T copyProperties(final Class<T> destClass, final Object orig, final BeanTransformer beanTransformer) {
+    public static <T> T copyProperties(final Class<T> destClass, final Object orig, final BeanTransformer beanTransformer) {
         return BeanUtilsBean.getInstance().copyProperties(destClass, orig, beanTransformer);
     }
 

--- a/src/main/java/org/apache/commons/beanutils2/BeanUtilsBean.java
+++ b/src/main/java/org/apache/commons/beanutils2/BeanUtilsBean.java
@@ -32,6 +32,9 @@ import org.apache.commons.beanutils2.expression.Resolver;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import com.hotels.beans.transformer.BeanTransformer;
+import com.hotels.transformer.error.InvalidBeanException;
+
 /**
  * <p>JavaBean property population methods.</p>
  *
@@ -45,9 +48,6 @@ import org.apache.commons.logging.LogFactory;
  */
 
 public class BeanUtilsBean {
-
-    
-
     /**
      * Contains {@code BeanUtilsBean} instances indexed by context classloader.
      */
@@ -283,6 +283,56 @@ public class BeanUtilsBean {
             }
         }
 
+    }
+
+    /**
+     * <p>Copy property values from the origin bean to the destination bean
+     * class for all cases where the property names are the same. For each
+     * property, a conversion is attempted as necessary. All combinations of
+     * standard JavaBeans and DynaBeans as origin and destination are
+     * supported.  Properties that exist in the origin bean, but do not exist
+     * in the destination bean (or are read-only in the destination bean) are
+     * silently ignored and the default value for that type is set.</p>
+     *
+     * <p>To define specific mappings please refer to {@link com.hotels.beans.BeanUtils}
+     * documentation available see:
+     * @see <a href="https://hotelsdotcom.github.io/bull/transformer/bean/samples.html">Bean Transformer documentation</a>
+     * </p>
+     *
+     * @param destClass Destination bean class
+     * @param orig Origin bean whose properties are retrieved
+     *
+     * @throws InvalidBeanException if the destination bean is not valid
+     */
+    public <T> T copyProperties(final Class<T> destClass, final Object orig) {
+        final BeanTransformer beanTransformer = new com.hotels.beans.BeanUtils()
+                .getTransformer()
+                .setDefaultValueForMissingField(true);
+        return copyProperties(destClass, orig, beanTransformer);
+    }
+
+    /**
+     * <p>Copy property values from the origin bean to the destination bean
+     * class for all cases using the given {@link BeanTransformer} properly configured. For each
+     * property, a conversion is attempted as necessary.  All combinations of
+     * standard JavaBeans and DynaBeans as origin and destination are
+     * supported.  Properties that exist in the origin bean, but do not exist
+     * in the destination bean (or are read-only in the destination bean) are
+     * silently ignored and the default value for that type is set.</p>
+     *
+     * <p>To define specific mappings please refer to {@link com.hotels.beans.BeanUtils}
+     * documentation available see:
+     * @see <a href="https://hotelsdotcom.github.io/bull/transformer/bean/samples.html">Bean Transformer documentation</a>
+     * </p>
+     *
+     * @param destClass Destination bean class
+     * @param orig Origin bean whose properties are retrieved
+     * @param beanTransformer the transformer containing all mappings and transformation functions.
+     *
+     * @throws InvalidBeanException if the destination bean is not valid
+     */
+    public <T> T copyProperties(final Class<T> destClass, final Object orig, final BeanTransformer beanTransformer) {
+        return beanTransformer.transform(orig, destClass);
     }
 
     /**

--- a/src/test/java/org/apache/commons/beanutils2/BeanUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/BeanUtilsTestCase.java
@@ -60,9 +60,6 @@ import junit.framework.TestSuite;
  */
 
 public class BeanUtilsTestCase extends TestCase {
-
-    
-
     /**
      * The test bean for each test.
      */
@@ -103,8 +100,6 @@ public class BeanUtilsTestCase extends TestCase {
     /** Test String Date value */
     protected String testStringDate;
 
-    
-
     /**
      * Construct a new instance of this test case.
      *
@@ -113,8 +108,6 @@ public class BeanUtilsTestCase extends TestCase {
     public BeanUtilsTestCase(final String name) {
         super(name);
     }
-
-    
 
     /**
      * Set up instance variables required by this test case.
@@ -162,8 +155,6 @@ public class BeanUtilsTestCase extends TestCase {
     public void tearDown() {
         bean = null;
     }
-
-    
 
     /**
      * Test the copyProperties() method from a DynaBean.
@@ -366,7 +357,67 @@ public class BeanUtilsTestCase extends TestCase {
         assertEquals("stringArray length", 2, stringArray.length);
         assertEquals("stringArray[0]", "New 0", stringArray[0]);
         assertEquals("stringArray[1]", "New 1", stringArray[1]);
+    }
 
+    /**
+     * Test the copyProperties() method from a standard JavaBean with automatic destination bean instantiation.
+     */
+    public void testCopyPropertiesPassingDestinationClassType() {
+        // Set up an origin bean with customized properties
+        final TestBean orig = new TestBean();
+        orig.setBooleanProperty(false);
+        orig.setByteProperty((byte) 111);
+        orig.setDoubleProperty(333.33);
+        orig.setDupProperty(new String[] { "New 0", "New 1", "New 2" });
+        orig.setIntArray(new int[] { 100, 200, 300 });
+        orig.setIntProperty(333);
+        orig.setLongProperty(3333);
+        orig.setShortProperty((short) 33);
+        orig.setStringArray(new String[] { "New 0", "New 1" });
+        orig.setStringProperty("Custom string");
+
+        // Copy the origin bean to our destination test bean
+        final TestBean actual = BeanUtils.copyProperties(TestBean.class, orig);
+
+        assertFalse("Copied boolean property", actual.getBooleanProperty());
+        assertEquals("Copied byte property",
+                (byte) 111,
+                actual.getByteProperty());
+        assertEquals("Copied double property",
+                333.33,
+                actual.getDoubleProperty(),
+                0.005);
+        assertEquals("Copied int property",
+                333,
+                actual.getIntProperty());
+        assertEquals("Copied long property",
+                3333,
+                actual.getLongProperty());
+        assertEquals("Copied short property",
+                (short) 33,
+                actual.getShortProperty());
+        assertEquals("Copied string property",
+                "Custom string",
+                actual.getStringProperty());
+
+        // Validate the results for array properties
+        final String[] dupProperty = actual.getDupProperty();
+        assertNotNull("dupProperty present", dupProperty);
+        assertEquals("dupProperty length", 3, dupProperty.length);
+        assertEquals("dupProperty[0]", "New 0", dupProperty[0]);
+        assertEquals("dupProperty[1]", "New 1", dupProperty[1]);
+        assertEquals("dupProperty[2]", "New 2", dupProperty[2]);
+        final int[] intArray = actual.getIntArray();
+        assertNotNull("intArray present", intArray);
+        assertEquals("intArray length", 3, intArray.length);
+        assertEquals("intArray[0]", 100, intArray[0]);
+        assertEquals("intArray[1]", 200, intArray[1]);
+        assertEquals("intArray[2]", 300, intArray[2]);
+        final String[] stringArray = actual.getStringArray();
+        assertNotNull("stringArray present", stringArray);
+        assertEquals("stringArray length", 2, stringArray.length);
+        assertEquals("stringArray[0]", "New 0", stringArray[0]);
+        assertEquals("stringArray[1]", "New 1", stringArray[1]);
     }
 
     /**

--- a/src/test/java/org/apache/commons/beanutils2/BeanUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/BeanUtilsTestCase.java
@@ -68,7 +68,7 @@ public class BeanUtilsTestCase extends TestCase {
     /**
      * The set of properties that should be described.
      */
-    protected String describes[] =
+    protected String[] describes =
     { "booleanProperty",
       "booleanSecond",
       "byteProperty",
@@ -189,48 +189,7 @@ public class BeanUtilsTestCase extends TestCase {
         }
 
         // Validate the results for scalar properties
-        assertEquals("Copied boolean property",
-                     false,
-                     bean.getBooleanProperty());
-        assertEquals("Copied byte property",
-                     (byte) 111,
-                     bean.getByteProperty());
-        assertEquals("Copied double property",
-                     333.33,
-                     bean.getDoubleProperty(),
-                     0.005);
-        assertEquals("Copied int property",
-                     333,
-                     bean.getIntProperty());
-        assertEquals("Copied long property",
-                     3333,
-                     bean.getLongProperty());
-        assertEquals("Copied short property",
-                     (short) 33,
-                     bean.getShortProperty());
-        assertEquals("Copied string property",
-                     "Custom string",
-                     bean.getStringProperty());
-
-        // Validate the results for array properties
-        final String dupProperty[] = bean.getDupProperty();
-        assertNotNull("dupProperty present", dupProperty);
-        assertEquals("dupProperty length", 3, dupProperty.length);
-        assertEquals("dupProperty[0]", "New 0", dupProperty[0]);
-        assertEquals("dupProperty[1]", "New 1", dupProperty[1]);
-        assertEquals("dupProperty[2]", "New 2", dupProperty[2]);
-        final int intArray[] = bean.getIntArray();
-        assertNotNull("intArray present", intArray);
-        assertEquals("intArray length", 3, intArray.length);
-        assertEquals("intArray[0]", 100, intArray[0]);
-        assertEquals("intArray[1]", 200, intArray[1]);
-        assertEquals("intArray[2]", 300, intArray[2]);
-        final String stringArray[] = bean.getStringArray();
-        assertNotNull("stringArray present", stringArray);
-        assertEquals("stringArray length", 2, stringArray.length);
-        assertEquals("stringArray[0]", "New 0", stringArray[0]);
-        assertEquals("stringArray[1]", "New 1", stringArray[1]);
-
+        validateBeanCopyResults(bean);
     }
 
     /**
@@ -296,17 +255,7 @@ public class BeanUtilsTestCase extends TestCase {
     public void testCopyPropertiesStandard() {
 
         // Set up an origin bean with customized properties
-        final TestBean orig = new TestBean();
-        orig.setBooleanProperty(false);
-        orig.setByteProperty((byte) 111);
-        orig.setDoubleProperty(333.33);
-        orig.setDupProperty(new String[] { "New 0", "New 1", "New 2" });
-        orig.setIntArray(new int[] { 100, 200, 300 });
-        orig.setIntProperty(333);
-        orig.setLongProperty(3333);
-        orig.setShortProperty((short) 33);
-        orig.setStringArray(new String[] { "New 0", "New 1" });
-        orig.setStringProperty("Custom string");
+        final TestBean orig = createTestBean();
 
         // Copy the origin bean to our destination test bean
         try {
@@ -314,49 +263,8 @@ public class BeanUtilsTestCase extends TestCase {
         } catch (final Exception e) {
             fail("Threw exception: " + e);
         }
+        validateBeanCopyResults(bean);
 
-        // Validate the results for scalar properties
-        assertEquals("Copied boolean property",
-                     false,
-                     bean.getBooleanProperty());
-        assertEquals("Copied byte property",
-                     (byte) 111,
-                     bean.getByteProperty());
-        assertEquals("Copied double property",
-                     333.33,
-                     bean.getDoubleProperty(),
-                     0.005);
-        assertEquals("Copied int property",
-                     333,
-                     bean.getIntProperty());
-        assertEquals("Copied long property",
-                     3333,
-                     bean.getLongProperty());
-        assertEquals("Copied short property",
-                     (short) 33,
-                     bean.getShortProperty());
-        assertEquals("Copied string property",
-                     "Custom string",
-                     bean.getStringProperty());
-
-        // Validate the results for array properties
-        final String dupProperty[] = bean.getDupProperty();
-        assertNotNull("dupProperty present", dupProperty);
-        assertEquals("dupProperty length", 3, dupProperty.length);
-        assertEquals("dupProperty[0]", "New 0", dupProperty[0]);
-        assertEquals("dupProperty[1]", "New 1", dupProperty[1]);
-        assertEquals("dupProperty[2]", "New 2", dupProperty[2]);
-        final int intArray[] = bean.getIntArray();
-        assertNotNull("intArray present", intArray);
-        assertEquals("intArray length", 3, intArray.length);
-        assertEquals("intArray[0]", 100, intArray[0]);
-        assertEquals("intArray[1]", 200, intArray[1]);
-        assertEquals("intArray[2]", 300, intArray[2]);
-        final String stringArray[] = bean.getStringArray();
-        assertNotNull("stringArray present", stringArray);
-        assertEquals("stringArray length", 2, stringArray.length);
-        assertEquals("stringArray[0]", "New 0", stringArray[0]);
-        assertEquals("stringArray[1]", "New 1", stringArray[1]);
     }
 
     /**
@@ -364,22 +272,20 @@ public class BeanUtilsTestCase extends TestCase {
      */
     public void testCopyPropertiesPassingDestinationClassType() {
         // Set up an origin bean with customized properties
-        final TestBean orig = new TestBean();
-        orig.setBooleanProperty(false);
-        orig.setByteProperty((byte) 111);
-        orig.setDoubleProperty(333.33);
-        orig.setDupProperty(new String[] { "New 0", "New 1", "New 2" });
-        orig.setIntArray(new int[] { 100, 200, 300 });
-        orig.setIntProperty(333);
-        orig.setLongProperty(3333);
-        orig.setShortProperty((short) 33);
-        orig.setStringArray(new String[] { "New 0", "New 1" });
-        orig.setStringProperty("Custom string");
+        final TestBean orig = createTestBean();
 
         // Copy the origin bean to our destination test bean
         final TestBean actual = BeanUtils.copyProperties(TestBean.class, orig);
 
-        assertFalse("Copied boolean property", actual.getBooleanProperty());
+        // validate results
+        validateBeanCopyResults(actual);
+    }
+
+    private void validateBeanCopyResults(final TestBean actual) {
+        // Validate the results for scalar properties
+        assertEquals("Copied boolean property",
+                false,
+                actual.getBooleanProperty());
         assertEquals("Copied byte property",
                 (byte) 111,
                 actual.getByteProperty());
@@ -418,6 +324,21 @@ public class BeanUtilsTestCase extends TestCase {
         assertEquals("stringArray length", 2, stringArray.length);
         assertEquals("stringArray[0]", "New 0", stringArray[0]);
         assertEquals("stringArray[1]", "New 1", stringArray[1]);
+    }
+
+    private TestBean createTestBean() {
+        final TestBean orig = new TestBean();
+        orig.setBooleanProperty(false);
+        orig.setByteProperty((byte) 111);
+        orig.setDoubleProperty(333.33);
+        orig.setDupProperty(new String[]{"New 0", "New 1", "New 2"});
+        orig.setIntArray(new int[]{100, 200, 300});
+        orig.setIntProperty(333);
+        orig.setLongProperty(3333);
+        orig.setShortProperty((short) 33);
+        orig.setStringArray(new String[]{"New 0", "New 1"});
+        orig.setStringProperty("Custom string");
+        return orig;
     }
 
     /**

--- a/src/test/java/org/apache/commons/beanutils2/BeanUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/BeanUtilsTestCase.java
@@ -28,6 +28,9 @@ import java.util.StringTokenizer;
 import org.apache.commons.beanutils2.converters.ArrayConverter;
 import org.apache.commons.beanutils2.converters.DateConverter;
 
+import com.hotels.beans.transformer.BeanTransformer;
+import com.hotels.transformer.model.FieldTransformer;
+
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
@@ -276,6 +279,24 @@ public class BeanUtilsTestCase extends TestCase {
 
         // Copy the origin bean to our destination test bean
         final TestBean actual = BeanUtils.copyProperties(TestBean.class, orig);
+
+        // validate results
+        validateBeanCopyResults(actual);
+    }
+
+    /**
+     * Test the copyProperties() method from a standard JavaBean with automatic destination bean instantiation.
+     * This methods pass as a parameter the BeanTransformer class too.
+     */
+    public void testCopyPropertiesPassingDestinationClassTypeAndBeanTransformer() {
+        // Set up an origin bean with customized properties
+        final TestBean orig = createTestBean();
+        // Set up an BeanTransformer that performs a transformation on a given field.
+        final BeanTransformer beanTransformer = new com.hotels.beans.BeanUtils().getTransformer();
+        beanTransformer.withFieldTransformer(new FieldTransformer<Integer, Integer>("intProperty", val -> (val + 2) - 2));
+
+        // Copy the origin bean to our destination test bean
+        final TestBean actual = BeanUtils.copyProperties(TestBean.class, orig, beanTransformer);
 
         // validate results
         validateBeanCopyResults(actual);


### PR DESCRIPTION
- Improved `copyProperties` method in order to copy any kind of Java Bean: Mutable, Immutable, Mixed
- Overloaded the method `copyProperties` in order to accept the destination object class as input, leaving the library the responsibility to instantiate the object 
