### PR TITLE
CheckStyle issues resolved

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/BeanMap.java
+++ b/src/main/java/org/apache/commons/beanutils2/BeanMap.java
@@ -267,7 +267,8 @@ public class BeanMap extends AbstractMap<String, Object> implements Cloneable {
             if (method != null) {
                 try {
                     return method.invoke(bean, NULL_ARGUMENTS);
-                } catch (final IllegalAccessException | NullPointerException | InvocationTargetException | IllegalArgumentException e) {
+                } catch (final IllegalAccessException | NullPointerException |
+                               InvocationTargetException | IllegalArgumentException e) {
                     logWarn(e);
                 }
             }

--- a/src/main/java/org/apache/commons/beanutils2/BeanPropertyValueEqualsPredicate.java
+++ b/src/main/java/org/apache/commons/beanutils2/BeanPropertyValueEqualsPredicate.java
@@ -164,7 +164,8 @@ public class BeanPropertyValueEqualsPredicate<T, V> implements Predicate<T> {
      * generate an {@code IllegalArgumentException} or not.
      * @throws IllegalArgumentException If the property name provided is null or empty.
      */
-    public BeanPropertyValueEqualsPredicate(final String propertyName, final V propertyValue, final boolean ignoreNull) {
+    public BeanPropertyValueEqualsPredicate(final String propertyName, final V propertyValue,
+            final boolean ignoreNull) {
         super();
 
         if (propertyName != null && propertyName.length() > 0) {

--- a/src/main/java/org/apache/commons/beanutils2/BeanUtilsBean.java
+++ b/src/main/java/org/apache/commons/beanutils2/BeanUtilsBean.java
@@ -905,7 +905,7 @@ public class BeanUtilsBean {
             }
             type = dynaPropertyType(dynaProperty, value);
             if (index >= 0 && List.class.isAssignableFrom(type)) {
-            	type = Object.class;
+                type = Object.class;
             }
         } else if (target instanceof Map) {
             type = Object.class;

--- a/src/main/java/org/apache/commons/beanutils2/ConvertUtilsBean.java
+++ b/src/main/java/org/apache/commons/beanutils2/ConvertUtilsBean.java
@@ -514,7 +514,7 @@ public class ConvertUtilsBean {
      * {@code false} if a default value should be used.
      */
     private void registerOther(final boolean throwException) {
-    	  // @formatter:off
+        // @formatter:off
         register(Class.class,          throwException ? new ClassConverter()          : new ClassConverter(null));
         register(Enum.class,           throwException ? new EnumConverter()           : new EnumConverter(null));
         register(java.util.Date.class, throwException ? new DateConverter()           : new DateConverter(null));
@@ -523,16 +523,16 @@ public class ConvertUtilsBean {
         register(Path.class,           throwException ? new PathConverter()           : new PathConverter(null));
         register(java.sql.Date.class,  throwException ? new SqlDateConverter()        : new SqlDateConverter(null));
         register(java.sql.Time.class,  throwException ? new SqlTimeConverter()        : new SqlTimeConverter(null));
-        register(Timestamp.class,      throwException ? new SqlTimestampConverter()   : new SqlTimestampConverter(null));
+        register(Timestamp.class,      throwException ? new SqlTimestampConverter()  : new SqlTimestampConverter(null));
         register(URL.class,            throwException ? new URLConverter()            : new URLConverter(null));
         register(URI.class,            throwException ? new URIConverter()            : new URIConverter(null));
         register(UUID.class,           throwException ? new UUIDConverter()           : new UUIDConverter(null));
         register(LocalDate.class,      throwException ? new LocalDateConverter()      : new LocalDateConverter(null));
-        register(LocalDateTime.class,  throwException ? new LocalDateTimeConverter()  : new LocalDateTimeConverter(null));
+        register(LocalDateTime.class, throwException ? new LocalDateTimeConverter() : new LocalDateTimeConverter(null));
         register(LocalTime.class,      throwException ? new LocalTimeConverter()      : new LocalTimeConverter(null));
-        register(OffsetDateTime.class, throwException ? new OffsetDateTimeConverter() : new OffsetDateTimeConverter(null));
+        register(OffsetDateTime.class,throwException ? new OffsetDateTimeConverter():new OffsetDateTimeConverter(null));
         register(OffsetTime.class,     throwException ? new OffsetTimeConverter()     : new OffsetTimeConverter(null));
-        register(ZonedDateTime.class,  throwException ? new ZonedDateTimeConverter()  : new ZonedDateTimeConverter(null));
+        register(ZonedDateTime.class, throwException ? new ZonedDateTimeConverter() : new ZonedDateTimeConverter(null));
         register(Duration.class,       throwException ? new DurationConverter()       : new DurationConverter(null));
         register(MonthDay.class,       throwException ? new MonthDayConverter()       : new MonthDayConverter(null));
         register(Period.class,         throwException ? new PeriodConverter()         : new PeriodConverter(null));
@@ -555,7 +555,7 @@ public class ConvertUtilsBean {
      * the default.
      */
     private void registerArrays(final boolean throwException, final int defaultArraySize) {
-    	// @formatter:off
+        // @formatter:off
 
         // Primitives
         registerArrayConverter(Boolean.TYPE,   new BooleanConverter(),   throwException, defaultArraySize);

--- a/src/main/java/org/apache/commons/beanutils2/DynaProperty.java
+++ b/src/main/java/org/apache/commons/beanutils2/DynaProperty.java
@@ -42,8 +42,8 @@ public class DynaProperty implements Serializable {
 
 
 
-	private static final long serialVersionUID = -3084907613499830175L;
-	/*
+    private static final long serialVersionUID = -3084907613499830175L;
+    /*
      * There are issues with serializing primitive class types on certain JVM versions
      * (including java 1.3).
      * This class uses a custom serialization implementation that writes an integer

--- a/src/main/java/org/apache/commons/beanutils2/MethodUtils.java
+++ b/src/main/java/org/apache/commons/beanutils2/MethodUtils.java
@@ -1299,7 +1299,8 @@ public class MethodUtils {
          * @param paramTypes the array of classes representing the parameter types
          * @param exact whether the match has to be exact.
          */
-        public MethodDescriptor(final Class<?> cls, final String methodName, Class<?>[] paramTypes, final boolean exact) {
+        public MethodDescriptor(final Class<?> cls, final String methodName, Class<?>[] paramTypes,
+                final boolean exact) {
             if (cls == null) {
                 throw new IllegalArgumentException("Class cannot be null");
             }

--- a/src/main/java/org/apache/commons/beanutils2/RowSetDynaClass.java
+++ b/src/main/java/org/apache/commons/beanutils2/RowSetDynaClass.java
@@ -229,8 +229,9 @@ public class RowSetDynaClass extends JDBCDynaClass {
      *  cannot be introspected
      * @since 1.8.3
      */
-    public RowSetDynaClass(final ResultSet resultSet, final boolean lowerCase, final int limit, final boolean useColumnLabel)
-                                                            throws SQLException {
+    public RowSetDynaClass(final ResultSet resultSet, final boolean lowerCase, final int limit,
+            final boolean useColumnLabel)
+            throws SQLException {
         Objects.requireNonNull(resultSet, "resultSet");
         this.lowerCase = lowerCase;
         this.limit = limit;

--- a/src/main/java/org/apache/commons/beanutils2/WeakFastHashMap.java
+++ b/src/main/java/org/apache/commons/beanutils2/WeakFastHashMap.java
@@ -59,6 +59,8 @@ import java.util.WeakHashMap;
  * Double-Checked Locking Idiom Is Broken Declaration</a>.</p>
  *
  * @since Commons Collections 1.0
+ * @param <K> the key
+ * @param <V> the value
  */
 public class WeakFastHashMap<K, V> extends HashMap<K, V> {
 

--- a/src/main/java/org/apache/commons/beanutils2/converters/DateTimeConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/converters/DateTimeConverter.java
@@ -440,25 +440,25 @@ public abstract class DateTimeConverter extends AbstractConverter {
 
         // java.time.LocalDateTime
         if (type.equals(LocalDate.class)) {
-        	final LocalDate localDate =  Instant.ofEpochMilli(value).atZone(getZoneId()).toLocalDate();
+            final LocalDate localDate =  Instant.ofEpochMilli(value).atZone(getZoneId()).toLocalDate();
             return type.cast(localDate);
         }
 
         // java.time.LocalDateTime
         if (type.equals(LocalDateTime.class)) {
-        	final LocalDateTime localDateTime =  Instant.ofEpochMilli(value).atZone(getZoneId()).toLocalDateTime();
+            final LocalDateTime localDateTime =  Instant.ofEpochMilli(value).atZone(getZoneId()).toLocalDateTime();
             return type.cast(localDateTime);
         }
 
         // java.time.ZonedDateTime
         if (type.equals(ZonedDateTime.class)) {
-        	final ZonedDateTime zonedDateTime =  ZonedDateTime.ofInstant(Instant.ofEpochMilli(value), getZoneId());
+            final ZonedDateTime zonedDateTime =  ZonedDateTime.ofInstant(Instant.ofEpochMilli(value), getZoneId());
             return type.cast(zonedDateTime);
         }
 
         // java.time.OffsetDateTime
         if (type.equals(OffsetDateTime.class)) {
-        	final OffsetDateTime offsetDateTime =  OffsetDateTime.ofInstant(Instant.ofEpochMilli(value), getZoneId());
+            final OffsetDateTime offsetDateTime =  OffsetDateTime.ofInstant(Instant.ofEpochMilli(value), getZoneId());
             return type.cast(offsetDateTime);
         }
 
@@ -623,7 +623,8 @@ public abstract class DateTimeConverter extends AbstractConverter {
      * @return The converted Calendar object.
      * @throws ConversionException if the String cannot be converted.
      */
-    private Calendar parse(final Class<?> sourceType, final Class<?> targetType, final String value, final DateFormat format) {
+    private Calendar parse(final Class<?> sourceType, final Class<?> targetType, final String value,
+            final DateFormat format) {
         logFormat("Parsing", format);
         format.setLenient(false);
         final ParsePosition pos = new ParsePosition(0);
@@ -711,6 +712,6 @@ public abstract class DateTimeConverter extends AbstractConverter {
      * @return the {@code ZoneId}
      */
     private ZoneId getZoneId() {
-    	return timeZone == null ? ZoneId.systemDefault() : timeZone.toZoneId();
+        return timeZone == null ? ZoneId.systemDefault() : timeZone.toZoneId();
     }
 }

--- a/src/main/java/org/apache/commons/beanutils2/converters/NumberConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/converters/NumberConverter.java
@@ -543,7 +543,8 @@ public abstract class NumberConverter extends AbstractConverter {
      * @return The converted Number object.
      * @throws ConversionException if the String cannot be converted.
      */
-    private Number parse(final Class<?> sourceType, final Class<?> targetType, final String value, final NumberFormat format) {
+    private Number parse(final Class<?> sourceType, final Class<?> targetType, final String value,
+            final NumberFormat format) {
         final ParsePosition pos = new ParsePosition(0);
         final Number parsedNumber = format.parse(value, pos);
         if (pos.getErrorIndex() >= 0 || pos.getIndex() != value.length() || parsedNumber == null) {

--- a/src/main/java/org/apache/commons/beanutils2/locale/BaseLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/BaseLocaleConverter.java
@@ -107,7 +107,8 @@ public abstract class BaseLocaleConverter implements LocaleConverter {
      * @param pattern       The conversion pattern
      * @param locPattern    Indicate whether the pattern is localized or not
      */
-    protected BaseLocaleConverter(final Object defaultValue, final Locale locale, final String pattern, final boolean locPattern) {
+    protected BaseLocaleConverter(final Object defaultValue, final Locale locale, final String pattern,
+            final boolean locPattern) {
 
         this(defaultValue, locale, pattern, true, locPattern);
     }

--- a/src/main/java/org/apache/commons/beanutils2/locale/LocaleBeanUtils.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/LocaleBeanUtils.java
@@ -607,7 +607,8 @@ public class LocaleBeanUtils extends BeanUtils {
      *
      * @see LocaleBeanUtilsBean#invokeSetter(Object, String, String, int, Object)
      */
-    protected static void invokeSetter(final Object target, final String propName, final String key, final int index, final Object newValue)
+    protected static void invokeSetter(final Object target, final String propName, final String key, final int index,
+            final Object newValue)
             throws IllegalAccessException, InvocationTargetException {
 
        LocaleBeanUtilsBean.getLocaleBeanUtilsInstance().invokeSetter(target, propName, key, index, newValue);

--- a/src/main/java/org/apache/commons/beanutils2/locale/LocaleBeanUtilsBean.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/LocaleBeanUtilsBean.java
@@ -866,7 +866,8 @@ public class LocaleBeanUtilsBean extends BeanUtilsBean {
      * @throws InvocationTargetException if the property accessor method
      *  throws an exception
      */
-    protected void invokeSetter(final Object target, final String propName, final String key, final int index, final Object newValue)
+    protected void invokeSetter(final Object target, final String propName, final String key, final int index,
+            final Object newValue)
             throws IllegalAccessException, InvocationTargetException {
 
         try {

--- a/src/main/java/org/apache/commons/beanutils2/locale/LocaleConvertUtils.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/LocaleConvertUtils.java
@@ -232,7 +232,8 @@ public class LocaleConvertUtils {
      * @return the converted value
      * @see LocaleConvertUtilsBean#convert(String[], Class, Locale, String)
      */
-    public static Object convert(final String[] values, final Class<?> clazz, final Locale locale, final String pattern) {
+    public static Object convert(final String[] values, final Class<?> clazz, final Locale locale,
+            final String pattern) {
 
         return LocaleConvertUtilsBean.getInstance().convert(values, clazz, locale, pattern);
     }

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/BigDecimalLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/BigDecimalLocaleConverter.java
@@ -178,7 +178,8 @@ public class BigDecimalLocaleConverter extends DecimalLocaleConverter {
      * @param pattern       The conversion pattern
      * @param locPattern    Indicate whether the pattern is localized or not
      */
-    public BigDecimalLocaleConverter(final Object defaultValue, final Locale locale, final String pattern, final boolean locPattern) {
+    public BigDecimalLocaleConverter(final Object defaultValue, final Locale locale, final String pattern,
+            final boolean locPattern) {
         super(defaultValue, locale, pattern, locPattern);
     }
 

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/BigIntegerLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/BigIntegerLocaleConverter.java
@@ -178,7 +178,8 @@ public class BigIntegerLocaleConverter extends DecimalLocaleConverter {
      * @param pattern       The conversion pattern
      * @param locPattern    Indicate whether the pattern is localized or not
      */
-    public BigIntegerLocaleConverter(final Object defaultValue, final Locale locale, final String pattern, final boolean locPattern) {
+    public BigIntegerLocaleConverter(final Object defaultValue, final Locale locale, final String pattern,
+            final boolean locPattern) {
         super(defaultValue, locale, pattern, locPattern);
     }
 

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/ByteLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/ByteLocaleConverter.java
@@ -188,7 +188,8 @@ public class ByteLocaleConverter extends DecimalLocaleConverter {
      * @param pattern       The conversion pattern
      * @param locPattern    Indicate whether the pattern is localized or not
      */
-    public ByteLocaleConverter(final Object defaultValue, final Locale locale, final String pattern, final boolean locPattern) {
+    public ByteLocaleConverter(final Object defaultValue, final Locale locale, final String pattern,
+            final boolean locPattern) {
 
         super(defaultValue, locale, pattern, locPattern);
     }

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/DateLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/DateLocaleConverter.java
@@ -195,7 +195,8 @@ public class DateLocaleConverter extends BaseLocaleConverter {
      * @param pattern       The conversion pattern
      * @param locPattern    Indicate whether the pattern is localized or not
      */
-    public DateLocaleConverter(final Object defaultValue, final Locale locale, final String pattern, final boolean locPattern) {
+    public DateLocaleConverter(final Object defaultValue, final Locale locale, final String pattern,
+            final boolean locPattern) {
         super(defaultValue, locale, pattern, locPattern);
     }
 

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/DecimalLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/DecimalLocaleConverter.java
@@ -186,7 +186,8 @@ public class DecimalLocaleConverter extends BaseLocaleConverter {
      * @param pattern       The conversion pattern
      * @param locPattern    Indicate whether the pattern is localized or not
      */
-    public DecimalLocaleConverter(final Object defaultValue, final Locale locale, final String pattern, final boolean locPattern) {
+    public DecimalLocaleConverter(final Object defaultValue, final Locale locale, final String pattern,
+            final boolean locPattern) {
         super(defaultValue, locale, pattern, locPattern);
 
     }

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/DoubleLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/DoubleLocaleConverter.java
@@ -175,7 +175,8 @@ public class DoubleLocaleConverter extends DecimalLocaleConverter {
      * @param pattern       The conversion pattern
      * @param locPattern    Indicate whether the pattern is localized or not
      */
-    public DoubleLocaleConverter(final Object defaultValue, final Locale locale, final String pattern, final boolean locPattern) {
+    public DoubleLocaleConverter(final Object defaultValue, final Locale locale, final String pattern,
+            final boolean locPattern) {
         super(defaultValue, locale, pattern, locPattern);
     }
 

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/FloatLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/FloatLocaleConverter.java
@@ -177,7 +177,8 @@ public class FloatLocaleConverter extends DecimalLocaleConverter {
      * @param pattern       The conversion pattern
      * @param locPattern    Indicate whether the pattern is localized or not
      */
-    public FloatLocaleConverter(final Object defaultValue, final Locale locale, final String pattern, final boolean locPattern) {
+    public FloatLocaleConverter(final Object defaultValue, final Locale locale, final String pattern,
+            final boolean locPattern) {
         super(defaultValue, locale, pattern, locPattern);
     }
 

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/IntegerLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/IntegerLocaleConverter.java
@@ -177,7 +177,8 @@ public class IntegerLocaleConverter extends DecimalLocaleConverter {
      * @param pattern       The conversion pattern
      * @param locPattern    Indicate whether the pattern is localized or not
      */
-    public IntegerLocaleConverter(final Object defaultValue, final Locale locale, final String pattern, final boolean locPattern) {
+    public IntegerLocaleConverter(final Object defaultValue, final Locale locale, final String pattern,
+            final boolean locPattern) {
         super(defaultValue, locale, pattern, locPattern);
     }
 

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/LongLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/LongLocaleConverter.java
@@ -176,7 +176,8 @@ public class LongLocaleConverter extends DecimalLocaleConverter {
      * @param pattern       The conversion pattern
      * @param locPattern    Indicate whether the pattern is localized or not
      */
-    public LongLocaleConverter(final Object defaultValue, final Locale locale, final String pattern, final boolean locPattern) {
+    public LongLocaleConverter(final Object defaultValue, final Locale locale, final String pattern,
+            final boolean locPattern) {
         super(defaultValue, locale, pattern, locPattern);
     }
 

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/ShortLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/ShortLocaleConverter.java
@@ -178,7 +178,8 @@ public class ShortLocaleConverter extends DecimalLocaleConverter {
      * @param pattern       The conversion pattern
      * @param locPattern    Indicate whether the pattern is localized or not
      */
-    public ShortLocaleConverter(final Object defaultValue, final Locale locale, final String pattern, final boolean locPattern) {
+    public ShortLocaleConverter(final Object defaultValue, final Locale locale, final String pattern,
+            final boolean locPattern) {
         super(defaultValue, locale, pattern, locPattern);
     }
 

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/SqlDateLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/SqlDateLocaleConverter.java
@@ -177,7 +177,8 @@ public class SqlDateLocaleConverter extends DateLocaleConverter {
      * @param pattern       The conversion pattern
      * @param locPattern    Indicate whether the pattern is localized or not
      */
-    public SqlDateLocaleConverter(final Object defaultValue, final Locale locale, final String pattern, final boolean locPattern) {
+    public SqlDateLocaleConverter(final Object defaultValue, final Locale locale, final String pattern,
+            final boolean locPattern) {
         super(defaultValue, locale, pattern, locPattern);
     }
 

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/SqlTimeLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/SqlTimeLocaleConverter.java
@@ -179,7 +179,8 @@ public class SqlTimeLocaleConverter extends DateLocaleConverter {
      * @param pattern       The conversion pattern
      * @param locPattern    Indicate whether the pattern is localized or not
      */
-    public SqlTimeLocaleConverter(final Object defaultValue, final Locale locale, final String pattern, final boolean locPattern) {
+    public SqlTimeLocaleConverter(final Object defaultValue, final Locale locale, final String pattern,
+            final boolean locPattern) {
         super(defaultValue, locale, pattern, locPattern);
     }
 

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/SqlTimestampLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/SqlTimestampLocaleConverter.java
@@ -178,7 +178,8 @@ public class SqlTimestampLocaleConverter extends DateLocaleConverter {
      * @param pattern       The conversion pattern
      * @param locPattern    Indicate whether the pattern is localized or not
      */
-    public SqlTimestampLocaleConverter(final Object defaultValue, final Locale locale, final String pattern, final boolean locPattern) {
+    public SqlTimestampLocaleConverter(final Object defaultValue, final Locale locale, final String pattern,
+            final boolean locPattern) {
         super(defaultValue, locale, pattern, locPattern);
     }
 

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/StringLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/StringLocaleConverter.java
@@ -190,7 +190,8 @@ public class StringLocaleConverter extends BaseLocaleConverter {
      * @param pattern       The conversion pattern
      * @param locPattern    Indicate whether the pattern is localized or not
      */
-    public StringLocaleConverter(final Object defaultValue, final Locale locale, final String pattern, final boolean locPattern) {
+    public StringLocaleConverter(final Object defaultValue, final Locale locale, final String pattern,
+            final boolean locPattern) {
         super(defaultValue, locale, pattern, locPattern);
     }
 

--- a/src/test/java/org/apache/commons/beanutils2/FluentPropertyBeanIntrospectorTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/FluentPropertyBeanIntrospectorTestCase.java
@@ -95,34 +95,34 @@ public class FluentPropertyBeanIntrospectorTestCase extends TestCase {
     }
 
     public void testIntrospectionCaps() throws Exception {
-	    final PropertyUtilsBean pu = new PropertyUtilsBean();
+        final PropertyUtilsBean pu = new PropertyUtilsBean();
 
         final FluentPropertyBeanIntrospector introspector = new FluentPropertyBeanIntrospector();
 
-	    pu.addBeanIntrospector(introspector);
+        pu.addBeanIntrospector(introspector);
 
-	    final Map<String, PropertyDescriptor> props = createDescriptorMap(
-			pu.getPropertyDescriptors(CapsBean.class));
+        final Map<String, PropertyDescriptor> props = createDescriptorMap(
+            pu.getPropertyDescriptors(CapsBean.class));
 
-	    final PropertyDescriptor aDescriptor = fetchDescriptor(props, "URI");
+        final PropertyDescriptor aDescriptor = fetchDescriptor(props, "URI");
 
-	    assertNotNull("missing property", aDescriptor);
+        assertNotNull("missing property", aDescriptor);
 
-	    assertNotNull("No read method for uri", aDescriptor.getReadMethod());
-	    assertNotNull("No write method for uri", aDescriptor.getWriteMethod());
+        assertNotNull("No read method for uri", aDescriptor.getReadMethod());
+        assertNotNull("No write method for uri", aDescriptor.getWriteMethod());
 
-	    assertNull("Should not find mis-capitalized property", props.get("uRI"));
+        assertNull("Should not find mis-capitalized property", props.get("uRI"));
     }
 
-	public static final class CapsBean {
-		private URI mURI;
+    public static final class CapsBean {
+        private URI mURI;
 
-		public URI getURI() {
-			return mURI;
-		}
+        public URI getURI() {
+            return mURI;
+        }
 
-		public void setURI(final URI theURI) {
-			mURI = theURI;
-		}
-	}
+        public void setURI(final URI theURI) {
+            mURI = theURI;
+        }
+    }
 }

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira157TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira157TestCase.java
@@ -77,8 +77,8 @@ public class Jira157TestCase extends TestCase {
         super.setUp();
 
         final BeanUtilsBean custom = new BeanUtilsBean();
-    	custom.getPropertyUtils().removeBeanIntrospector(SuppressPropertiesBeanIntrospector.SUPPRESS_CLASS);
-    	BeanUtilsBean.setInstance(custom);
+        custom.getPropertyUtils().removeBeanIntrospector(SuppressPropertiesBeanIntrospector.SUPPRESS_CLASS);
+        BeanUtilsBean.setInstance(custom);
     }
 
     /**

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira493TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira493TestCase.java
@@ -30,14 +30,14 @@ import org.junit.Test;
 
 public class Jira493TestCase {
 
-	@Test
-	public void testIndexedProperties() throws Exception {
-		final LazyDynaBean lazyDynaBean = new LazyDynaBean();
-		final BeanUtilsBean beanUtilsBean = BeanUtilsBean.getInstance();
-		beanUtilsBean.setProperty(lazyDynaBean, "x[0]", "x1");
-		beanUtilsBean.setProperty(lazyDynaBean, "x[1]", "x2");
-		final Object x = lazyDynaBean.get("x");
-		assertEquals("[x1, x2]", x.toString());
-	}
+    @Test
+    public void testIndexedProperties() throws Exception {
+        final LazyDynaBean lazyDynaBean = new LazyDynaBean();
+        final BeanUtilsBean beanUtilsBean = BeanUtilsBean.getInstance();
+        beanUtilsBean.setProperty(lazyDynaBean, "x[0]", "x1");
+        beanUtilsBean.setProperty(lazyDynaBean, "x[1]", "x2");
+        final Object x = lazyDynaBean.get("x");
+        assertEquals("[x1, x2]", x.toString());
+    }
 
 }

--- a/src/test/java/org/apache/commons/beanutils2/converters/DateConverterTestBase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/DateConverterTestBase.java
@@ -193,11 +193,11 @@ public abstract class DateConverterTestBase extends TestCase {
 
             long test = now;
             if (date[i] instanceof LocalDate || val instanceof LocalDate) {
-            	test = Instant.ofEpochMilli(now).atZone(ZoneId.systemDefault()).toLocalDate().atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
-			}
+                test = Instant.ofEpochMilli(now).atZone(ZoneId.systemDefault()).toLocalDate().atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
+            }
 
             assertEquals("Convert " + message[i] + " should return a " + date[0],
-            		test, getTimeInMillis(val));
+                    test, getTimeInMillis(val));
         }
     }
 

--- a/src/test/java/org/apache/commons/beanutils2/converters/DurationConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/DurationConverterTestCase.java
@@ -80,15 +80,15 @@ public class DurationConverterTestCase extends TestCase {
         };
 
         final Object[] input = {
-        	"PT20.345S",
-        	"PT15M",
-        	"PT51H4M"
+            "PT20.345S",
+            "PT15M",
+            "PT51H4M"
         };
 
         final Duration[] expected = {
-        		Duration.parse("PT20.345S"),
-        		Duration.parse("PT15M"),
-        		Duration.parse("P2DT3H4M")
+                Duration.parse("PT20.345S"),
+                Duration.parse("PT15M"),
+                Duration.parse("P2DT3H4M")
         };
 
         for(int i=0;i<expected.length;i++) {

--- a/src/test/java/org/apache/commons/beanutils2/converters/EnumConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/EnumConverterTestCase.java
@@ -70,15 +70,15 @@ public class EnumConverterTestCase extends TestCase {
         };
 
         final Object[] input = {
-        	"DELIVERED",
-        	"ORDERED",
-        	"READY"
+            "DELIVERED",
+            "ORDERED",
+            "READY"
         };
 
         final PizzaStatus[] expected = {
-        	PizzaStatus.DELIVERED,
-        	PizzaStatus.ORDERED,
-        	PizzaStatus.READY
+            PizzaStatus.DELIVERED,
+            PizzaStatus.ORDERED,
+            PizzaStatus.READY
         };
 
         for(int i=0;i<expected.length;i++) {

--- a/src/test/java/org/apache/commons/beanutils2/converters/LocalTimeConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/LocalTimeConverterTestCase.java
@@ -80,13 +80,13 @@ public class LocalTimeConverterTestCase extends TestCase {
         };
 
         final Object[] input = {
-        	"10:15",
-        	"08:45:30"
+            "10:15",
+            "08:45:30"
         };
 
         final LocalTime[] expected = {
-        		LocalTime.parse("10:15"),
-        		LocalTime.parse("08:45:30")
+                LocalTime.parse("10:15"),
+                LocalTime.parse("08:45:30")
         };
 
         for(int i=0;i<expected.length;i++) {

--- a/src/test/java/org/apache/commons/beanutils2/converters/MonthDayConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/MonthDayConverterTestCase.java
@@ -80,15 +80,15 @@ public class MonthDayConverterTestCase extends TestCase {
         };
 
         final Object[] input = {
-        	"--12-03",
-        	"--05-30",
-        	"--01-01"
+            "--12-03",
+            "--05-30",
+            "--01-01"
         };
 
         final MonthDay[] expected = {
-        		MonthDay.parse("--12-03"),
-        		MonthDay.parse("--05-30"),
-        		MonthDay.parse("--01-01")
+                MonthDay.parse("--12-03"),
+                MonthDay.parse("--05-30"),
+                MonthDay.parse("--01-01")
         };
 
         for(int i=0;i<expected.length;i++) {

--- a/src/test/java/org/apache/commons/beanutils2/converters/OffsetTimeConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/OffsetTimeConverterTestCase.java
@@ -80,13 +80,13 @@ public class OffsetTimeConverterTestCase extends TestCase {
         };
 
         final Object[] input = {
-        	"10:15+01:00",
-        	"08:45:30+14:00"
+            "10:15+01:00",
+            "08:45:30+14:00"
         };
 
         final OffsetTime[] expected = {
-        		OffsetTime.parse("10:15+01:00"),
-        		OffsetTime.parse("08:45:30+14:00")
+                OffsetTime.parse("10:15+01:00"),
+                OffsetTime.parse("08:45:30+14:00")
         };
 
         for(int i=0;i<expected.length;i++) {

--- a/src/test/java/org/apache/commons/beanutils2/converters/PathConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/PathConverterTestCase.java
@@ -85,8 +85,8 @@ public class PathConverterTestCase extends TestCase {
         final String separator = File.pathSeparator;
 
         final Object[] input = {
-        	separator + "foo"+separator+"bar"+separator+"baz",
-        	separator
+            separator + "foo"+separator+"bar"+separator+"baz",
+            separator
         };
 
         final Path[] expected = {

--- a/src/test/java/org/apache/commons/beanutils2/converters/UUIDConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/UUIDConverterTestCase.java
@@ -80,8 +80,8 @@ public class UUIDConverterTestCase extends TestCase {
         };
 
         final Object[] input = {
-        	"123e4567-e89b-12d3-a456-556642440000",
-        	"7dc53df5-703e-49b3-8670-b1c468f47f1f"
+            "123e4567-e89b-12d3-a456-556642440000",
+            "7dc53df5-703e-49b3-8670-b1c468f47f1f"
         };
 
         final UUID[] expected = {

--- a/src/test/java/org/apache/commons/beanutils2/converters/YearConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/YearConverterTestCase.java
@@ -80,15 +80,15 @@ public class YearConverterTestCase extends TestCase {
         };
 
         final Object[] input = {
-        	"2019",
-        	"1974",
-        	"2112"
+            "2019",
+            "1974",
+            "2112"
         };
 
         final Year[] expected = {
-        		Year.parse("2019"),
-        		Year.parse("1974"),
-        		Year.parse("2112")
+                Year.parse("2019"),
+                Year.parse("1974"),
+                Year.parse("2112")
         };
 
         for(int i=0;i<expected.length;i++) {

--- a/src/test/java/org/apache/commons/beanutils2/converters/YearMonthConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/YearMonthConverterTestCase.java
@@ -80,15 +80,15 @@ public class YearMonthConverterTestCase extends TestCase {
         };
 
         final Object[] input = {
-        	"2007-12",
-        	"1974-05",
-        	"2112-01"
+            "2007-12",
+            "1974-05",
+            "2112-01"
         };
 
         final YearMonth[] expected = {
-        		YearMonth.parse("2007-12"),
-        		YearMonth.parse("1974-05"),
-        		YearMonth.parse("2112-01")
+                YearMonth.parse("2007-12"),
+                YearMonth.parse("1974-05"),
+                YearMonth.parse("2112-01")
         };
 
         for(int i=0;i<expected.length;i++) {

--- a/src/test/java/org/apache/commons/beanutils2/converters/ZoneIdConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ZoneIdConverterTestCase.java
@@ -80,15 +80,15 @@ public class ZoneIdConverterTestCase extends TestCase {
         };
 
         final Object[] input = {
-        	"America/New_York",
-        	"-05:00",
-        	"Australia/Sydney"
+            "America/New_York",
+            "-05:00",
+            "Australia/Sydney"
         };
 
         final ZoneId[] expected = {
-        		ZoneId.of("America/New_York"),
-        		ZoneId.of("-05:00"),
-        		ZoneId.of("Australia/Sydney")
+                ZoneId.of("America/New_York"),
+                ZoneId.of("-05:00"),
+                ZoneId.of("Australia/Sydney")
         };
 
         for(int i=0;i<expected.length;i++) {

--- a/src/test/java/org/apache/commons/beanutils2/converters/ZoneOffsetConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ZoneOffsetConverterTestCase.java
@@ -80,15 +80,15 @@ public class ZoneOffsetConverterTestCase extends TestCase {
         };
 
         final Object[] input = {
-        	"-12:00",
-        	"+14:00",
-        	"+02:00"
+            "-12:00",
+            "+14:00",
+            "+02:00"
         };
 
         final ZoneOffset[] expected = {
-        		ZoneOffset.of("-12:00"),
-        		ZoneOffset.of("+14:00"),
-        		ZoneOffset.of("+02:00")
+                ZoneOffset.of("-12:00"),
+                ZoneOffset.of("+14:00"),
+                ZoneOffset.of("+02:00")
         };
 
         for(int i=0;i<expected.length;i++) {

--- a/src/test/java/org/apache/commons/beanutils2/locale/LocaleConvertUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/locale/LocaleConvertUtilsTestCase.java
@@ -21,7 +21,6 @@ import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.text.NumberFormat;
-import java.util.Locale;
 
 import org.apache.commons.beanutils2.ConversionException;
 


### PR DESCRIPTION
Running `mvn checkstyle:check` produced this report which this PR addresses:

**51 errors:**
```
[ERROR] src\main\java\org\apache\commons\beanutils2\BeanMap.java:[270] (sizes) LineLength: Line is longer than 120 characters (found 136).
[ERROR] src\main\java\org\apache\commons\beanutils2\BeanPropertyValueEqualsPredicate.java:[167] (sizes) LineLength: Line is longer than 120 characters (found 121).
[ERROR] src\main\java\org\apache\commons\beanutils2\BeanUtilsBean.java:[908,13] (whitespace) FileTabCharacter: File contains tab characters (this is the first instance).
[ERROR] src\main\java\org\apache\commons\beanutils2\converters\DateTimeConverter.java:[443,9] (whitespace) FileTabCharacter: File contains tab characters (this is the first instance).
[ERROR] src\main\java\org\apache\commons\beanutils2\converters\DateTimeConverter.java:[461] (sizes) LineLength: Line is longer than 120 characters (found 122).
[ERROR] src\main\java\org\apache\commons\beanutils2\converters\DateTimeConverter.java:[626] (sizes) LineLength: Line is longer than 120 characters (found 127).
[ERROR] src\main\java\org\apache\commons\beanutils2\converters\NumberConverter.java:[546] (sizes) LineLength: Line is longer than 120 characters (found 127).
[ERROR] src\main\java\org\apache\commons\beanutils2\ConvertUtilsBean.java:[517,5] (whitespace) FileTabCharacter: File contains tab characters (this is the first instance).
[ERROR] src\main\java\org\apache\commons\beanutils2\ConvertUtilsBean.java:[526] (sizes) LineLength: Line is longer than 120 characters (found 121).
[ERROR] src\main\java\org\apache\commons\beanutils2\ConvertUtilsBean.java:[531] (sizes) LineLength: Line is longer than 120 characters (found 122).
[ERROR] src\main\java\org\apache\commons\beanutils2\ConvertUtilsBean.java:[533] (sizes) LineLength: Line is longer than 120 characters (found 123).
[ERROR] src\main\java\org\apache\commons\beanutils2\ConvertUtilsBean.java:[535] (sizes) LineLength: Line is longer than 120 characters (found 122).
[ERROR] src\main\java\org\apache\commons\beanutils2\DynaProperty.java:[45,1] (whitespace) FileTabCharacter: File contains tab characters (this is the first instance).
[ERROR] src\main\java\org\apache\commons\beanutils2\locale\BaseLocaleConverter.java:[110] (sizes) LineLength: Line is longer than 120 characters (found 131).
[ERROR] src\main\java\org\apache\commons\beanutils2\locale\converters\BigDecimalLocaleConverter.java:[181] (sizes) LineLength: Line is longer than 120 characters (found 134).
[ERROR] src\main\java\org\apache\commons\beanutils2\locale\converters\BigIntegerLocaleConverter.java:[181] (sizes) LineLength: Line is longer than 120 characters (found 134).
[ERROR] src\main\java\org\apache\commons\beanutils2\locale\converters\ByteLocaleConverter.java:[191] (sizes) LineLength: Line is longer than 120 characters (found 128).
[ERROR] src\main\java\org\apache\commons\beanutils2\locale\converters\DateLocaleConverter.java:[198] (sizes) LineLength: Line is longer than 120 characters (found 128).
[ERROR] src\main\java\org\apache\commons\beanutils2\locale\converters\DecimalLocaleConverter.java:[189] (sizes) LineLength: Line is longer than 120 characters (found 131).
[ERROR] src\main\java\org\apache\commons\beanutils2\locale\converters\DoubleLocaleConverter.java:[178] (sizes) LineLength: Line is longer than 120 characters (found 130).
[ERROR] src\main\java\org\apache\commons\beanutils2\locale\converters\FloatLocaleConverter.java:[180] (sizes) LineLength: Line is longer than 120 characters (found 129).
[ERROR] src\main\java\org\apache\commons\beanutils2\locale\converters\IntegerLocaleConverter.java:[180] (sizes) LineLength: Line is longer than 120 characters (found 131).
[ERROR] src\main\java\org\apache\commons\beanutils2\locale\converters\LongLocaleConverter.java:[179] (sizes) LineLength: Line is longer than 120 characters (found 128).
[ERROR] src\main\java\org\apache\commons\beanutils2\locale\converters\ShortLocaleConverter.java:[181] (sizes) LineLength: Line is longer than 120 characters (found 129).
[ERROR] src\main\java\org\apache\commons\beanutils2\locale\converters\SqlDateLocaleConverter.java:[180] (sizes) LineLength: Line is longer than 120 characters (found 131).
[ERROR] src\main\java\org\apache\commons\beanutils2\locale\converters\SqlTimeLocaleConverter.java:[182] (sizes) LineLength: Line is longer than 120 characters (found 131).
[ERROR] src\main\java\org\apache\commons\beanutils2\locale\converters\SqlTimestampLocaleConverter.java:[181] (sizes) LineLength: Line is longer than 120 characters (found 136).
[ERROR] src\main\java\org\apache\commons\beanutils2\locale\converters\StringLocaleConverter.java:[193] (sizes) LineLength: Line is longer than 120 characters (found 130).
[ERROR] src\main\java\org\apache\commons\beanutils2\locale\LocaleBeanUtils.java:[610] (sizes) LineLength: Line is longer than 120 characters (found 140).
[ERROR] src\main\java\org\apache\commons\beanutils2\locale\LocaleBeanUtilsBean.java:[869] (sizes) LineLength: Line is longer than 120 characters (found 133).
[ERROR] src\main\java\org\apache\commons\beanutils2\locale\LocaleConvertUtils.java:[235] (sizes) LineLength: Line is longer than 120 characters (found 122).
[ERROR] src\main\java\org\apache\commons\beanutils2\MethodUtils.java:[1302] (sizes) LineLength: Line is longer than 120 characters (found 122).
[ERROR] src\main\java\org\apache\commons\beanutils2\RowSetDynaClass.java:[232] (sizes) LineLength: Line is longer than 120 characters (found 125).
[ERROR] src\main\java\org\apache\commons\beanutils2\WeakFastHashMap.java:[63] (javadoc) JavadocType: Type Javadoc comment is missing @param <K> tag.
[ERROR] src\main\java\org\apache\commons\beanutils2\WeakFastHashMap.java:[63] (javadoc) JavadocType: Type Javadoc comment is missing @param <V> tag.
[ERROR] src\test\java\org\apache\commons\beanutils2\bugs\Jira157TestCase.java:[80,5] (whitespace) FileTabCharacter: File contains tab characters (this is the first instance).
[ERROR] src\test\java\org\apache\commons\beanutils2\bugs\Jira493TestCase.java:[33,1] (whitespace) FileTabCharacter: File contains tab characters (this is the first instance).
[ERROR] src\test\java\org\apache\commons\beanutils2\converters\DateConverterTestBase.java:[196,13] (whitespace) FileTabCharacter: File contains tab characters (this is the first instance).
[ERROR] src\test\java\org\apache\commons\beanutils2\converters\DurationConverterTestCase.java:[83,9] (whitespace) FileTabCharacter: File contains tab characters (this is the first instance).
[ERROR] src\test\java\org\apache\commons\beanutils2\converters\EnumConverterTestCase.java:[73,9] (whitespace) FileTabCharacter: File contains tab characters (this is the first instance).
[ERROR] src\test\java\org\apache\commons\beanutils2\converters\LocalTimeConverterTestCase.java:[83,9] (whitespace) FileTabCharacter: File contains tab characters (this is the first instance).
[ERROR] src\test\java\org\apache\commons\beanutils2\converters\MonthDayConverterTestCase.java:[83,9] (whitespace) FileTabCharacter: File contains tab characters (this is the first instance).
[ERROR] src\test\java\org\apache\commons\beanutils2\converters\OffsetTimeConverterTestCase.java:[83,9] (whitespace) FileTabCharacter: File contains tab characters (this is the first instance).
[ERROR] src\test\java\org\apache\commons\beanutils2\converters\PathConverterTestCase.java:[88,9] (whitespace) FileTabCharacter: File contains tab characters (this is the first instance).
[ERROR] src\test\java\org\apache\commons\beanutils2\converters\UUIDConverterTestCase.java:[83,9] (whitespace) FileTabCharacter: File contains tab characters (this is the first instance).
[ERROR] src\test\java\org\apache\commons\beanutils2\converters\YearConverterTestCase.java:[83,9] (whitespace) FileTabCharacter: File contains tab characters (this is the first instance).
[ERROR] src\test\java\org\apache\commons\beanutils2\converters\YearMonthConverterTestCase.java:[83,9] (whitespace) FileTabCharacter: File contains tab characters (this is the first instance).
[ERROR] src\test\java\org\apache\commons\beanutils2\converters\ZoneIdConverterTestCase.java:[83,9] (whitespace) FileTabCharacter: File contains tab characters (this is the first instance).
[ERROR] src\test\java\org\apache\commons\beanutils2\converters\ZoneOffsetConverterTestCase.java:[83,9] (whitespace) FileTabCharacter: File contains tab characters (this is the first instance).
[ERROR] src\test\java\org\apache\commons\beanutils2\FluentPropertyBeanIntrospectorTestCase.java:[98,1] (whitespace) FileTabCharacter: File contains tab characters (this is the first instance).
[ERROR] src\test\java\org\apache\commons\beanutils2\locale\LocaleConvertUtilsTestCase.java:[24,8] (imports) UnusedImports: Unused import - java.util.Locale.
```