### PR TITLE
Updated URLConverter

### DIFF
--- a/src/test/java/org/apache/commons/beanutils2/converters/ConverterTestSuite.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ConverterTestSuite.java
@@ -53,7 +53,6 @@ public class ConverterTestSuite {
         testSuite.addTestSuite(SqlDateConverterTestCase.class);
         testSuite.addTestSuite(SqlTimeConverterTestCase.class);
         testSuite.addTestSuite(SqlTimestampConverterTestCase.class);
-        testSuite.addTestSuite(URLConverterTestCase.class);
         return testSuite;
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/converters/URLConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/URLConverterTestCase.java
@@ -17,57 +17,28 @@
 
 package org.apache.commons.beanutils2.converters;
 
+import org.apache.commons.beanutils2.ConversionException;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.net.URL;
 
-import org.apache.commons.beanutils2.ConversionException;
-import org.apache.commons.beanutils2.Converter;
-
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * Test Case for the URLConverter class.
- *
  */
+public class URLConverterTestCase {
 
-public class URLConverterTestCase extends TestCase {
+    private URLConverter converter;
 
-    public static TestSuite suite() {
-        return new TestSuite(URLConverterTestCase.class);
+    @Before
+    public void before() {
+        converter = new URLConverter();
     }
 
-
-
-    private Converter converter = null;
-
-
-
-    public URLConverterTestCase(final String name) {
-        super(name);
-    }
-
-    protected Class<?> getExpectedType() {
-        return URL.class;
-    }
-
-    protected Converter makeConverter() {
-        return new URLConverter();
-    }
-
-
-
-    @Override
-    public void setUp() throws Exception {
-        converter = makeConverter();
-    }
-
-    @Override
-    public void tearDown() throws Exception {
-        converter = null;
-    }
-
-
-
+    @Test
     public void testSimpleConversion() throws Exception {
         final String[] message= {
             "from String",
@@ -91,23 +62,23 @@ public class URLConverterTestCase extends TestCase {
             "http://notreal.apache.org",
         };
 
-        final URL[] expected = {
-            new URL("http://www.apache.org"),
-            new URL("http://www.apache.org/"),
-            new URL("ftp://cvs.apache.org"),
-            new URL("file://project.xml"),
-            new URL("http://208.185.179.12"),
-            new URL("http://www.apache.org:9999/test/thing"),
-            new URL("http://user:admin@www.apache.org:50/one/two.three"),
-            new URL("http://notreal.apache.org")
+        final String[] expected = {
+            "http://www.apache.org",
+            "http://www.apache.org/",
+            "ftp://cvs.apache.org",
+            "file://project.xml",
+            "http://208.185.179.12",
+            "http://www.apache.org:9999/test/thing",
+            "http://user:admin@www.apache.org:50/one/two.three",
+            "http://notreal.apache.org"
         };
 
-        for(int i=0;i<expected.length;i++) {
-            assertEquals(message[i] + " to URL",expected[i],converter.convert(URL.class,input[i]));
-            assertEquals(message[i] + " to null type",expected[i],converter.convert(null,input[i]));
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals(message[i] + " to URL", expected[i], converter.convert(URL.class, input[i]).toString());
+            assertEquals(message[i] + " to null type", expected[i], converter.convert(null, input[i]).toString());
         }
 
-        for(int i=0;i<expected.length;i++) {
+        for (int i = 0; i < expected.length; i++) {
             assertEquals(input[i] + " to String", input[i], converter.convert(String.class, expected[i]));
         }
     }
@@ -115,6 +86,7 @@ public class URLConverterTestCase extends TestCase {
     /**
      * Tests a conversion to an unsupported type.
      */
+    @Test
     public void testUnsupportedType() {
         try {
             converter.convert(Integer.class, "http://www.apache.org");
@@ -124,4 +96,3 @@ public class URLConverterTestCase extends TestCase {
         }
     }
 }
-

--- a/src/test/java/org/apache/commons/beanutils2/converters/URLConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/URLConverterTestCase.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import java.net.URL;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 /**
  * Test Case for the URLConverter class.
@@ -40,18 +39,7 @@ public class URLConverterTestCase {
 
     @Test
     public void testSimpleConversion() throws Exception {
-        final String[] message= {
-            "from String",
-            "from String",
-            "from String",
-            "from String",
-            "from String",
-            "from String",
-            "from String",
-            "from String",
-        };
-
-        final Object[] input = {
+        final String[] input = {
             "http://www.apache.org",
             "http://www.apache.org/",
             "ftp://cvs.apache.org",
@@ -60,39 +48,24 @@ public class URLConverterTestCase {
             "http://www.apache.org:9999/test/thing",
             "http://user:admin@www.apache.org:50/one/two.three",
             "http://notreal.apache.org",
+            "http://notreal.apache.org/test/file.xml#计算机图形学",
+            "http://notreal.apache.org/test/file.xml#%E8%AE%A1%E7%AE%97%E6%9C%BA%E5%9B%BE%E5%BD%A2%E5%AD%A6"
         };
 
-        final String[] expected = {
-            "http://www.apache.org",
-            "http://www.apache.org/",
-            "ftp://cvs.apache.org",
-            "file://project.xml",
-            "http://208.185.179.12",
-            "http://www.apache.org:9999/test/thing",
-            "http://user:admin@www.apache.org:50/one/two.three",
-            "http://notreal.apache.org"
-        };
+        for (String urlString : input) {
+            assertEquals("from String to URL", urlString, converter.convert(URL.class, urlString).toString());
+            assertEquals("from String to null type", urlString, converter.convert(null, urlString).toString());
 
-        for (int i = 0; i < expected.length; i++) {
-            assertEquals(message[i] + " to URL", expected[i], converter.convert(URL.class, input[i]).toString());
-            assertEquals(message[i] + " to null type", expected[i], converter.convert(null, input[i]).toString());
-        }
-
-        for (int i = 0; i < expected.length; i++) {
-            assertEquals(input[i] + " to String", input[i], converter.convert(String.class, expected[i]));
+            URL url = new URL(urlString);
+            assertEquals(urlString + " to String", urlString, converter.convert(String.class, url));
         }
     }
 
     /**
      * Tests a conversion to an unsupported type.
      */
-    @Test
+    @Test(expected = ConversionException.class)
     public void testUnsupportedType() {
-        try {
-            converter.convert(Integer.class, "http://www.apache.org");
-            fail("Unsupported type could be converted!");
-        } catch (final ConversionException cex) {
-            // expected result
-        }
+        converter.convert(Integer.class, "http://www.apache.org");
     }
 }


### PR DESCRIPTION
While working on another PR, I noticed some unit tests started locking up when I lost my internet connection temporarily.
When looking into why, I learned something interesting about the `URL#equals` method.

```java
/**
 * ...
 * Two URL objects are equal if they have the same protocol, reference
 * equivalent hosts, have the same port number on the host, and the same
 * file and fragment of the file.<p>
 *
 * Two hosts are considered equivalent if both host names can be resolved
 * into the same IP addresses; else if either host name can't be
 * resolved, the host names must be equal without regard to case; or both
 * host names equal to null.<p>
 *
 * Since hosts comparison requires name resolution, this operation is a
 * blocking operation. <p>
 * ...
 */
```

In other words, the tests for the URLConverter connect to the internet and will stall the tests if it's unable to do so as it's a blocking operation.

I'm not sure what the guidelines for the repository is, but I've always been pretty firm on, configuration/environment should not affect automated tests, so I think this should be changed to no longer block when there's no internet.

To do an offline comparison, one should use `URI#equals` or `String#equals`.
I'm not sure if the fix is perfect from a QA standpoint, but it avoids this by comparing `String`s instead of `URL`s.

---

While I was at it, I also updated the URLConverter to use JUnit 4.