### PR TITLE
[BEANUTILS-420] - Expose filed throug accessor methods

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/JDBCDynaClass.java
+++ b/src/main/java/org/apache/commons/beanutils2/JDBCDynaClass.java
@@ -262,6 +262,16 @@ abstract class JDBCDynaClass implements DynaClass, Serializable {
     }
 
     /**
+     * Indicate whether the column names or labels should be used.
+     *
+     * @return {@code true} if the column names or labels should be used,
+     * otherwise {@code false}.
+     */
+    protected boolean isUseColumnLabel() {
+        return useColumnLabel;
+    }
+
+    /**
      * Get a column value from a {@link ResultSet} for the specified name.
      *
      * @param resultSet The result set
@@ -309,5 +319,12 @@ abstract class JDBCDynaClass implements DynaClass, Serializable {
         }
         return name;
     }
-
+    /**
+     * Get the Cross Reference <code>map</code> for column name.
+     *
+     * @return  The Cross Reference for column name <code>map</code>
+     */
+    protected Map<String, String> getColumnNameXref() {
+        return columnNameXref;
+    }
 }

--- a/src/test/java/org/apache/commons/beanutils2/DynaRowSetTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/DynaRowSetTestCase.java
@@ -131,6 +131,9 @@ public class DynaRowSetTestCase extends TestCase {
         assertEquals("string property class", String.class,
                      dynaProp.getType());
 
+        assertFalse(dynaClass.isUseColumnLabel());
+        assertNotNull("Get the Cross Reference Property exists", dynaClass.getColumnNameXref());
+
     }
 
     public void testGetDynaProperties() {


### PR DESCRIPTION
JDBCDynaClass.useColumnLabel and columnNameXref are private. All other variables are protected. I am working on a custom dynaclass where I need to know their values.