### PR TITLE
Refactor logger usage

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/BeanPredicate.java
+++ b/src/main/java/org/apache/commons/beanutils2/BeanPredicate.java
@@ -69,7 +69,7 @@ public class BeanPredicate<T> implements Predicate<T> {
             evaluation = predicate.test(propValue);
         } catch (final IllegalArgumentException e) {
             final String errorMsg = "Problem during evaluation.";
-            log.error("ERROR: " + errorMsg, e);
+            log.error(errorMsg, e);
             throw e;
         } catch (final IllegalAccessException e) {
             final String errorMsg = "Unable to access the property provided.";

--- a/src/main/java/org/apache/commons/beanutils2/BeanPropertyValueChangeConsumer.java
+++ b/src/main/java/org/apache/commons/beanutils2/BeanPropertyValueChangeConsumer.java
@@ -167,7 +167,7 @@ public class BeanPropertyValueChangeConsumer<T, V> implements Consumer<T> {
             final String errorMsg = "Unable to execute Closure. Null value encountered in property path...";
 
             if (ignoreNull) {
-                log.warn("WARNING: " + errorMsg + e);
+                log.warn(errorMsg, e);
             } else {
                 final IllegalArgumentException iae = new IllegalArgumentException(errorMsg);
                 if (!BeanUtils.initCause(iae, e)) {

--- a/src/main/java/org/apache/commons/beanutils2/BeanPropertyValueEqualsPredicate.java
+++ b/src/main/java/org/apache/commons/beanutils2/BeanPropertyValueEqualsPredicate.java
@@ -205,7 +205,7 @@ public class BeanPropertyValueEqualsPredicate<T, V> implements Predicate<T> {
             final String errorMsg = "Problem during evaluation. Null value encountered in property path...";
 
             if (ignoreNull) {
-                log.warn("WARNING: " + errorMsg + e);
+                log.warn(errorMsg, e);
             } else {
                 final IllegalArgumentException iae = new IllegalArgumentException(errorMsg);
                 if (!BeanUtils.initCause(iae, e)) {

--- a/src/main/java/org/apache/commons/beanutils2/BeanToPropertyValueTransformer.java
+++ b/src/main/java/org/apache/commons/beanutils2/BeanToPropertyValueTransformer.java
@@ -156,7 +156,7 @@ public class BeanToPropertyValueTransformer<T, R> implements Function<T, R> {
             final String errorMsg = "Problem during transformation. Null value encountered in property path...";
 
             if (ignoreNull) {
-                log.warn("WARNING: " + errorMsg + e);
+                log.warn(errorMsg, e);
             } else {
                 final IllegalArgumentException iae = new IllegalArgumentException(errorMsg);
                 if (!BeanUtils.initCause(iae, e)) {

--- a/src/main/java/org/apache/commons/beanutils2/BeanUtilsBean.java
+++ b/src/main/java/org/apache/commons/beanutils2/BeanUtilsBean.java
@@ -1058,7 +1058,9 @@ public class BeanUtilsBean {
     protected Object convert(final Object value, final Class<?> type) {
         final Converter converter = getConvertUtils().lookup(type);
         if (converter != null) {
-            log.trace("        USING CONVERTER " + converter);
+            if (log.isTraceEnabled()) {
+                log.trace("        USING CONVERTER " + converter);
+            }
             return converter.convert(type, value);
         }
         return value;

--- a/src/main/java/org/apache/commons/beanutils2/FluentPropertyBeanIntrospector.java
+++ b/src/main/java/org/apache/commons/beanutils2/FluentPropertyBeanIntrospector.java
@@ -144,9 +144,10 @@ public class FluentPropertyBeanIntrospector implements BeanIntrospector {
                         pd.setWriteMethod(m);
                     }
                 } catch (final IntrospectionException e) {
-                    log.debug("Error when creating PropertyDescriptor for " + m
-                            + "! Ignoring this property.");
-                    log.debug("Exception is:", e);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Error when creating PropertyDescriptor for " + m
+                            + "! Ignoring this property.", e);
+                    }
                 }
             }
         }

--- a/src/main/java/org/apache/commons/beanutils2/LazyDynaBean.java
+++ b/src/main/java/org/apache/commons/beanutils2/LazyDynaBean.java
@@ -784,7 +784,7 @@ public class LazyDynaBean implements DynaBean, Serializable {
         catch (final Exception ex) {
             if (logger().isWarnEnabled()) {
                 logger().warn("Error instantiating DynaBean property of type '" +
-                        type.getName() + "' for '" + name + "' " + ex);
+                        type.getName() + "' for '" + name + "' ", ex);
             }
             return null;
         }
@@ -855,7 +855,7 @@ public class LazyDynaBean implements DynaBean, Serializable {
         }
         catch (final Exception ex) {
             if (logger().isWarnEnabled()) {
-                logger().warn("Error instantiating property of type '" + type.getName() + "' for '" + name + "' " + ex);
+                logger().warn("Error instantiating property of type '" + type.getName() + "' for '" + name + "' ", ex);
             }
             return null;
         }

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/DateLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/DateLocaleConverter.java
@@ -304,7 +304,9 @@ public class DateLocaleConverter extends BaseLocaleConverter {
                                                 localChars,
                                                 DEFAULT_PATTERN_CHARS);
          } catch (final Exception ex) {
-             log.debug("Converting pattern '" + localizedPattern + "' for " + locale, ex);
+             if (log.isDebugEnabled()) {
+                 log.debug("Converting pattern '" + localizedPattern + "' for " + locale, ex);
+             }
          }
          return convertedPattern;
     }


### PR DESCRIPTION
1. Skip message concatenation if logging level is not enabled
2. Remove logging level prefix from messages because it's printed by
logger formatter itself
3. Remove exception from message, pass it as a last parameter of slf4j
logger call