### PR TITLE
[BEANUTILS-545] - Redundant check MappedPropertyDescriptor creations

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/MappedPropertyDescriptor.java
+++ b/src/main/java/org/apache/commons/beanutils2/MappedPropertyDescriptor.java
@@ -87,11 +87,6 @@ public class MappedPropertyDescriptor extends PropertyDescriptor {
 
         super(propertyName, null, null);
 
-        if (propertyName == null || propertyName.isEmpty()) {
-            throw new IntrospectionException("bad property name: " +
-                    propertyName + " on class: " + beanClass.getClass().getName());
-        }
-
         setName(propertyName);
         final String base = capitalizePropertyName(propertyName);
 
@@ -153,11 +148,6 @@ public class MappedPropertyDescriptor extends PropertyDescriptor {
             throws IntrospectionException {
 
         super(propertyName, null, null);
-
-        if (propertyName == null || propertyName.isEmpty()) {
-            throw new IntrospectionException("bad property name: " +
-                    propertyName);
-        }
         setName(propertyName);
 
         // search the mapped get and set methods
@@ -199,12 +189,6 @@ public class MappedPropertyDescriptor extends PropertyDescriptor {
             throws IntrospectionException {
 
         super(propertyName, mappedGetter, mappedSetter);
-
-        if (propertyName == null || propertyName.isEmpty()) {
-            throw new IntrospectionException("bad property name: " +
-                    propertyName);
-        }
-
         setName(propertyName);
         mappedReadMethodRef  = new MappedMethodReference(mappedGetter);
         mappedWriteMethodRef = new MappedMethodReference(mappedSetter);

--- a/src/test/java/org/apache/commons/beanutils2/MappedPropertyTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/MappedPropertyTestCase.java
@@ -20,6 +20,8 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
+import java.beans.IntrospectionException;
+
 /**
  * <p>Test Case for the {@code MappedPropertyDescriptor}.</p>
  *
@@ -82,6 +84,36 @@ public class MappedPropertyTestCase extends TestCase {
             assertNotNull("Setter is missing", desc.getMappedWriteMethod());
         } catch (final Exception ex) {
             fail("Property '" + property + "' Not Found in " + clazz.getName() + ": " + ex);
+        }
+    }
+
+    /**
+     * Test valid property Name
+     */
+    public void testIntrospectionException(){
+        final Class<?> clazz = MappedPropertyTestBean.class;
+        try {
+            new MappedPropertyDescriptor(null, clazz);
+            fail("Must have failed");
+        } catch (final IntrospectionException ex) {
+            // expected result
+            assertEquals("bad property name", ex.getMessage());
+        }
+
+        try {
+            new MappedPropertyDescriptor(null, null, null );
+            fail("Must have failed");
+        } catch (final IntrospectionException ex) {
+            // expected result
+            assertEquals("bad property name", ex.getMessage());
+        }
+
+        try {
+            new MappedPropertyDescriptor(null, clazz, null, null );
+                fail("Must have failed");
+        } catch (final IntrospectionException ex) {
+            // expected result
+            assertEquals("bad property name", ex.getMessage());
         }
     }
 


### PR DESCRIPTION
 
Currently when we try to create a new  MappedPropertyDescriptor object the constructor check if the propertyName is null. This is redundant because the same check it's execute in the super constructor.