### PR TITLE
1.x upgrade commons-collections to 4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,7 +350,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
-      <version>4.1</version>
+      <version>4.4</version>
     </dependency>
     <dependency>
       <groupId>commons-collections</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -348,9 +348,9 @@
       <version>1.2</version>
     </dependency>
     <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-      <version>3.2.2</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+      <version>4.1</version>
     </dependency>
     <dependency>
       <groupId>commons-collections</groupId>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -36,6 +36,12 @@
       <action issue="BEANUTILS-505" dev="ggregory" type="update" due-to="Gary Gregory">
         Add missing serialVersionUID to Serializable classes.
       </action>
+      <action issue="BEANUTILS-517" dev="ggregory" type="update" due-to="Gary Gregory">
+        Update Apache Commons Collections from 4.2 to 4.3
+      </action>      
+      <action issue="BEANUTILS-522" dev="ggregory" type="update" due-to="Gary Gregory">
+        Update Apache Commons Collections from 4.3 to 4.4.
+      </action>      
     </release>
 
     <release version="1.9.4" date="2019-06-12" description="The primary reason for this release is a bugfix for

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -29,6 +29,15 @@
   </properties>
   <body>
 
+    <release version="1.9.5" date="2021-04-01" description="Security Release.">
+      <action issue="BEANUTILS-500" dev="dbrosius" type="update" due-to="Dave Brosius, Gary Gregory">
+        Upgrade from Apache Commons Collections 3 to 4.
+      </action>
+      <action issue="BEANUTILS-505" dev="ggregory" type="update" due-to="Gary Gregory">
+        Add missing serialVersionUID to Serializable classes.
+      </action>
+    </release>
+
     <release version="1.9.4" date="2019-06-12" description="The primary reason for this release is a bugfix for
 CVE-2014-0114. More specifically, our goal with BEANUTILS-520
 is to set the default behaviour of the BeanUtilsBean

--- a/src/main/java/org/apache/commons/beanutils/BasicDynaBean.java
+++ b/src/main/java/org/apache/commons/beanutils/BasicDynaBean.java
@@ -42,9 +42,9 @@ import java.util.Map;
 
 public class BasicDynaBean implements DynaBean, Serializable {
 
+    private static final long serialVersionUID = 1L;
 
     // ---------------------------------------------------------- Constructors
-
 
     /**
      * Construct a new <code>DynaBean</code> associated with the specified

--- a/src/main/java/org/apache/commons/beanutils/BasicDynaClass.java
+++ b/src/main/java/org/apache/commons/beanutils/BasicDynaClass.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 
 public class BasicDynaClass implements DynaClass, Serializable {
 
+    private static final long serialVersionUID = 1L;
 
     // ----------------------------------------------------------- Constructors
 

--- a/src/main/java/org/apache/commons/beanutils/BeanAccessLanguageException.java
+++ b/src/main/java/org/apache/commons/beanutils/BeanAccessLanguageException.java
@@ -28,6 +28,8 @@ package org.apache.commons.beanutils;
 
 public class BeanAccessLanguageException extends IllegalArgumentException {
 
+    private static final long serialVersionUID = 1L;
+
     // --------------------------------------------------------- Constuctors
 
     /**

--- a/src/main/java/org/apache/commons/beanutils/BeanComparator.java
+++ b/src/main/java/org/apache/commons/beanutils/BeanComparator.java
@@ -48,6 +48,7 @@ import org.apache.commons.collections4.comparators.ComparableComparator;
  */
 public class BeanComparator<T> implements Comparator<T>, Serializable {
 
+    private static final long serialVersionUID = 1L;
     private String property;
     private final Comparator<?> comparator;
 

--- a/src/main/java/org/apache/commons/beanutils/BeanComparator.java
+++ b/src/main/java/org/apache/commons/beanutils/BeanComparator.java
@@ -21,7 +21,7 @@ import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Comparator;
 
-import org.apache.commons.collections.comparators.ComparableComparator;
+import org.apache.commons.collections4.comparators.ComparableComparator;
 
 /**
  * <p>
@@ -84,7 +84,7 @@ public class BeanComparator<T> implements Comparator<T>, Serializable {
      * If the property passed in is null then the actual objects will be compared
      */
     public BeanComparator( final String property ) {
-        this( property, ComparableComparator.getInstance() );
+        this( property, ComparableComparator.INSTANCE );
     }
 
     /**
@@ -108,7 +108,7 @@ public class BeanComparator<T> implements Comparator<T>, Serializable {
         if (comparator != null) {
             this.comparator = comparator;
         } else {
-            this.comparator = ComparableComparator.getInstance();
+            this.comparator = ComparableComparator.INSTANCE;
         }
     }
 

--- a/src/main/java/org/apache/commons/beanutils/BeanMap.java
+++ b/src/main/java/org/apache/commons/beanutils/BeanMap.java
@@ -33,8 +33,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.collections.Transformer;
-import org.apache.commons.collections.keyvalue.AbstractMapEntry;
+import org.apache.commons.collections4.Transformer;
+import org.apache.commons.collections4.keyvalue.AbstractMapEntry;
 
 /**
  * An implementation of Map for JavaBeans which uses introspection to

--- a/src/main/java/org/apache/commons/beanutils/BeanMap.java
+++ b/src/main/java/org/apache/commons/beanutils/BeanMap.java
@@ -76,6 +76,9 @@ public class BeanMap extends AbstractMap<Object, Object> implements Cloneable {
      */
     @Deprecated
     public static HashMap defaultTransformers = new HashMap() {
+
+        private static final long serialVersionUID = 1L;
+
         @Override
         public void clear() {
             throw new UnsupportedOperationException();

--- a/src/main/java/org/apache/commons/beanutils/BeanMap.java
+++ b/src/main/java/org/apache/commons/beanutils/BeanMap.java
@@ -69,7 +69,7 @@ public class BeanMap extends AbstractMap<Object, Object> implements Cloneable {
 
     /**
      * This HashMap has been made unmodifiable to prevent issues when
-     * loaded in a shared ClassLoader enviroment.
+     * loaded in a shared ClassLoader environment.
      *
      * @see "http://issues.apache.org/jira/browse/BEANUTILS-112"
      * @deprecated Use {@link BeanMap#getTypeTransformer(Class)} method
@@ -127,9 +127,9 @@ public class BeanMap extends AbstractMap<Object, Object> implements Cloneable {
     };
 
     private static Map<Class<? extends Object>, Transformer> createTypeTransformers() {
-        final Map<Class<? extends Object>, Transformer> defaultTransformers =
+        final Map<Class<? extends Object>, Transformer> defTransformers =
                 new HashMap<Class<? extends Object>, Transformer>();
-        defaultTransformers.put(
+        defTransformers.put(
             Boolean.TYPE,
             new Transformer() {
                 public Object transform( final Object input ) {
@@ -137,7 +137,7 @@ public class BeanMap extends AbstractMap<Object, Object> implements Cloneable {
                 }
             }
         );
-        defaultTransformers.put(
+        defTransformers.put(
             Character.TYPE,
             new Transformer() {
                 public Object transform( final Object input ) {
@@ -145,7 +145,7 @@ public class BeanMap extends AbstractMap<Object, Object> implements Cloneable {
                 }
             }
         );
-        defaultTransformers.put(
+        defTransformers.put(
             Byte.TYPE,
             new Transformer() {
                 public Object transform( final Object input ) {
@@ -153,7 +153,7 @@ public class BeanMap extends AbstractMap<Object, Object> implements Cloneable {
                 }
             }
         );
-        defaultTransformers.put(
+        defTransformers.put(
             Short.TYPE,
             new Transformer() {
                 public Object transform( final Object input ) {
@@ -161,7 +161,7 @@ public class BeanMap extends AbstractMap<Object, Object> implements Cloneable {
                 }
             }
         );
-        defaultTransformers.put(
+        defTransformers.put(
             Integer.TYPE,
             new Transformer() {
                 public Object transform( final Object input ) {
@@ -169,7 +169,7 @@ public class BeanMap extends AbstractMap<Object, Object> implements Cloneable {
                 }
             }
         );
-        defaultTransformers.put(
+        defTransformers.put(
             Long.TYPE,
             new Transformer() {
                 public Object transform( final Object input ) {
@@ -177,7 +177,7 @@ public class BeanMap extends AbstractMap<Object, Object> implements Cloneable {
                 }
             }
         );
-        defaultTransformers.put(
+        defTransformers.put(
             Float.TYPE,
             new Transformer() {
                 public Object transform( final Object input ) {
@@ -185,7 +185,7 @@ public class BeanMap extends AbstractMap<Object, Object> implements Cloneable {
                 }
             }
         );
-        defaultTransformers.put(
+        defTransformers.put(
             Double.TYPE,
             new Transformer() {
                 public Object transform( final Object input ) {
@@ -193,7 +193,7 @@ public class BeanMap extends AbstractMap<Object, Object> implements Cloneable {
                 }
             }
         );
-        return defaultTransformers;
+        return defTransformers;
     }
 
 
@@ -753,7 +753,7 @@ public class BeanMap extends AbstractMap<Object, Object> implements Cloneable {
     /**
      * Map entry used by {@link BeanMap}.
      */
-    protected static class Entry extends AbstractMapEntry {
+    protected static class Entry extends AbstractMapEntry<Object, Object> {
         private final BeanMap owner;
 
         /**
@@ -805,9 +805,9 @@ public class BeanMap extends AbstractMap<Object, Object> implements Cloneable {
         throws IllegalAccessException, ClassCastException {
         try {
             if ( value != null ) {
-                final Class<? extends Object>[] types = method.getParameterTypes();
-                if ( types != null && types.length > 0 ) {
-                    final Class<? extends Object> paramType = types[0];
+                final Class<? extends Object>[] parmTypes = method.getParameterTypes();
+                if ( parmTypes != null && parmTypes.length > 0 ) {
+                    final Class<? extends Object> paramType = parmTypes[0];
                     if ( ! paramType.isAssignableFrom( value.getClass() ) ) {
                         value = convertType( paramType, value );
                     }
@@ -868,9 +868,8 @@ public class BeanMap extends AbstractMap<Object, Object> implements Cloneable {
         throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
 
         // try call constructor
-        final Class<?>[] types = { value.getClass() };
         try {
-            final Constructor<?> constructor = newType.getConstructor( types );
+            final Constructor<?> constructor = newType.getConstructor( value.getClass() );
             final Object[] arguments = { value };
             return constructor.newInstance( arguments );
         }

--- a/src/main/java/org/apache/commons/beanutils/BeanPredicate.java
+++ b/src/main/java/org/apache/commons/beanutils/BeanPredicate.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.beanutils;
 
-import org.apache.commons.collections.Predicate;
+import org.apache.commons.collections4.Predicate;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/src/main/java/org/apache/commons/beanutils/BeanPropertyValueChangeClosure.java
+++ b/src/main/java/org/apache/commons/beanutils/BeanPropertyValueChangeClosure.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.beanutils;
 
-import org.apache.commons.collections.Closure;
+import org.apache.commons.collections4.Closure;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/src/main/java/org/apache/commons/beanutils/BeanPropertyValueChangeClosure.java
+++ b/src/main/java/org/apache/commons/beanutils/BeanPropertyValueChangeClosure.java
@@ -27,7 +27,7 @@ import java.lang.reflect.InvocationTargetException;
 /**
  * <p><code>Closure</code> that sets a property.</p>
  * <p>
- * An implementation of <code>org.apache.commons.collections.Closure</code> that updates
+ * An implementation of <code>org.apache.commons.collections4.Closure</code> that updates
  * a specified property on the object provided with a specified value.
  * The <code>BeanPropertyValueChangeClosure</code> constructor takes two parameters which determine
  * what property will be updated and with what value.
@@ -77,7 +77,7 @@ import java.lang.reflect.InvocationTargetException;
  *
  * @version $Id$
  * @see org.apache.commons.beanutils.PropertyUtils
- * @see org.apache.commons.collections.Closure
+ * @see org.apache.commons.collections4.Closure
  */
 public class BeanPropertyValueChangeClosure implements Closure {
 

--- a/src/main/java/org/apache/commons/beanutils/BeanPropertyValueEqualsPredicate.java
+++ b/src/main/java/org/apache/commons/beanutils/BeanPropertyValueEqualsPredicate.java
@@ -19,7 +19,7 @@ package org.apache.commons.beanutils;
 
 import java.lang.reflect.InvocationTargetException;
 
-import org.apache.commons.collections.Predicate;
+import org.apache.commons.collections4.Predicate;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/src/main/java/org/apache/commons/beanutils/BeanPropertyValueEqualsPredicate.java
+++ b/src/main/java/org/apache/commons/beanutils/BeanPropertyValueEqualsPredicate.java
@@ -27,7 +27,7 @@ import org.apache.commons.logging.LogFactory;
 /**
  * <p><code>Predicate</code> that evaluates a property value against a specified value.</p>
  * <p>
- * An implementation of <code>org.apache.commons.collections.Predicate</code> that evaluates a
+ * An implementation of <code>org.apache.commons.collections4.Predicate</code> that evaluates a
  * property value on the object provided against a specified value and returns <code>true</code>
  * if equal; <code>false</code> otherwise.
  * The <code>BeanPropertyValueEqualsPredicate</code> constructor takes two parameters which
@@ -106,7 +106,7 @@ import org.apache.commons.logging.LogFactory;
  *
  * @version $Id$
  * @see org.apache.commons.beanutils.PropertyUtils
- * @see org.apache.commons.collections.Predicate
+ * @see org.apache.commons.collections4.Predicate
  */
 public class BeanPropertyValueEqualsPredicate implements Predicate {
 

--- a/src/main/java/org/apache/commons/beanutils/BeanToPropertyValueTransformer.java
+++ b/src/main/java/org/apache/commons/beanutils/BeanToPropertyValueTransformer.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.beanutils;
 
-import org.apache.commons.collections.Transformer;
+import org.apache.commons.collections4.Transformer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/src/main/java/org/apache/commons/beanutils/BeanToPropertyValueTransformer.java
+++ b/src/main/java/org/apache/commons/beanutils/BeanToPropertyValueTransformer.java
@@ -27,7 +27,7 @@ import java.lang.reflect.InvocationTargetException;
 /**
  * <p><code>Transformer</code> that outputs a property value.</p>
  *
- * <p>An implementation of <code>org.apache.commons.collections.Transformer</code> that transforms
+ * <p>An implementation of <code>org.apache.commons.collections4.Transformer</code> that transforms
  * the object provided by returning the value of a specified property of the object.  The
  * constructor for <code>BeanToPropertyValueTransformer</code> requires the name of the property
  * that will be used in the transformation.  The property can be a simple, nested, indexed, or
@@ -67,7 +67,7 @@ import java.lang.reflect.InvocationTargetException;
  *
  * @version $Id$
  * @see org.apache.commons.beanutils.PropertyUtils
- * @see org.apache.commons.collections.Transformer
+ * @see org.apache.commons.collections4.Transformer
  */
 public class BeanToPropertyValueTransformer implements Transformer {
 

--- a/src/main/java/org/apache/commons/beanutils/BeanUtils.java
+++ b/src/main/java/org/apache/commons/beanutils/BeanUtils.java
@@ -476,30 +476,4 @@ public class BeanUtils {
     public static <K, V> Map<K, V> createCache() {
         return new WeakFastHashMap<K, V>();
     }
-
-    /**
-     * Return whether a Map is fast
-     * @param map The map
-     * @return Whether it is fast or not.
-     * @since 1.8.0
-     */
-    public static boolean getCacheFast(final Map<?, ?> map) {
-        if (map instanceof WeakFastHashMap) {
-            return ((WeakFastHashMap<?, ?>) map).getFast();
-        } else {
-            return false;
-        }
-    }
-
-    /**
-     * Set whether fast on a Map
-     * @param map The map
-     * @param fast Whether it should be fast or not.
-     * @since 1.8.0
-     */
-    public static void setCacheFast(final Map<?, ?> map, final boolean fast) {
-        if (map instanceof WeakFastHashMap) {
-            ((WeakFastHashMap<?, ?>)map).setFast(fast);
-        }
-    }
 }

--- a/src/main/java/org/apache/commons/beanutils/ConversionException.java
+++ b/src/main/java/org/apache/commons/beanutils/ConversionException.java
@@ -29,9 +29,9 @@ package org.apache.commons.beanutils;
 
 public class ConversionException extends RuntimeException {
 
+    private static final long serialVersionUID = 1L;
 
     // ----------------------------------------------------------- Constructors
-
 
     /**
      * Construct a new exception with the specified message.

--- a/src/main/java/org/apache/commons/beanutils/ConvertingWrapDynaBean.java
+++ b/src/main/java/org/apache/commons/beanutils/ConvertingWrapDynaBean.java
@@ -34,7 +34,7 @@ import java.lang.reflect.InvocationTargetException;
 
 public class ConvertingWrapDynaBean extends WrapDynaBean {
 
-
+    private static final long serialVersionUID = 1L;
 
     /**
      * Construct a new <code>DynaBean</code> associated with the specified

--- a/src/main/java/org/apache/commons/beanutils/JDBCDynaClass.java
+++ b/src/main/java/org/apache/commons/beanutils/JDBCDynaClass.java
@@ -36,6 +36,8 @@ import java.util.Map;
 
 abstract class JDBCDynaClass implements DynaClass, Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     // ----------------------------------------------------- Instance Variables
 
     /**

--- a/src/main/java/org/apache/commons/beanutils/LazyDynaBean.java
+++ b/src/main/java/org/apache/commons/beanutils/LazyDynaBean.java
@@ -113,6 +113,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class LazyDynaBean implements DynaBean, Serializable {
 
+    private static final long serialVersionUID = 1L;
 
    /**
     * Commons Logging

--- a/src/main/java/org/apache/commons/beanutils/LazyDynaClass.java
+++ b/src/main/java/org/apache/commons/beanutils/LazyDynaClass.java
@@ -44,6 +44,8 @@ package org.apache.commons.beanutils;
  */
 public class LazyDynaClass extends BasicDynaClass implements MutableDynaClass  {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * Controls whether changes to this DynaClass's properties are allowed.
      */

--- a/src/main/java/org/apache/commons/beanutils/LazyDynaList.java
+++ b/src/main/java/org/apache/commons/beanutils/LazyDynaList.java
@@ -160,6 +160,8 @@ import java.util.Map;
  */
 public class LazyDynaList extends ArrayList<Object> {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * The DynaClass of the List's elements.
      */

--- a/src/main/java/org/apache/commons/beanutils/LazyDynaMap.java
+++ b/src/main/java/org/apache/commons/beanutils/LazyDynaMap.java
@@ -272,7 +272,6 @@ public class LazyDynaMap extends LazyDynaBean implements MutableDynaClass {
         // Create a new instance of the Map
         Map<String, Object> newMap = null;
         try {
-            @SuppressWarnings("unchecked")
             final
             // The new map is used as properties map
             Map<String, Object> temp = getMap().getClass().newInstance();

--- a/src/main/java/org/apache/commons/beanutils/LazyDynaMap.java
+++ b/src/main/java/org/apache/commons/beanutils/LazyDynaMap.java
@@ -47,6 +47,8 @@ import java.util.Map;
  */
 public class LazyDynaMap extends LazyDynaBean implements MutableDynaClass {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * The name of this DynaClass (analogous to the
      * <code>getName()</code> method of <code>java.lang.Class</code>).

--- a/src/main/java/org/apache/commons/beanutils/MethodUtils.java
+++ b/src/main/java/org/apache/commons/beanutils/MethodUtils.java
@@ -787,11 +787,11 @@ public class MethodUtils {
         if (clazz == null) {
             clazz = method.getDeclaringClass();
         } else {
-            sameClass = clazz.equals(method.getDeclaringClass());
             if (!method.getDeclaringClass().isAssignableFrom(clazz)) {
                 throw new IllegalArgumentException(clazz.getName() +
                         " is not assignable from " + method.getDeclaringClass().getName());
             }
+            sameClass = clazz.equals(method.getDeclaringClass());
         }
 
         // If the class is public, we are done

--- a/src/main/java/org/apache/commons/beanutils/NestedNullException.java
+++ b/src/main/java/org/apache/commons/beanutils/NestedNullException.java
@@ -27,6 +27,8 @@ package org.apache.commons.beanutils;
 
 public class NestedNullException extends BeanAccessLanguageException {
 
+    private static final long serialVersionUID = 1L;
+
     // --------------------------------------------------------- Constuctors
 
     /**

--- a/src/main/java/org/apache/commons/beanutils/PropertyUtils.java
+++ b/src/main/java/org/apache/commons/beanutils/PropertyUtils.java
@@ -22,8 +22,7 @@ import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Map;
-
-import org.apache.commons.collections.FastHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 
 /**
@@ -376,10 +375,8 @@ public class PropertyUtils {
      * @param beanClass Bean class to be introspected
      * @return the mapped property descriptors
      * @see PropertyUtilsBean#getMappedPropertyDescriptors(Class)
-     * @deprecated This method should not be exposed
      */
-    @Deprecated
-    public static FastHashMap getMappedPropertyDescriptors(final Class<?> beanClass) {
+    public static Map<Class<?>, Map> getMappedPropertyDescriptors(final Class<?> beanClass) {
 
         return PropertyUtilsBean.getInstance().getMappedPropertyDescriptors(beanClass);
 
@@ -397,7 +394,7 @@ public class PropertyUtils {
      * @deprecated This method should not be exposed
      */
     @Deprecated
-    public static FastHashMap getMappedPropertyDescriptors(final Object bean) {
+    public static Map<Class<?>, Map> getMappedPropertyDescriptors(final Object bean) {
 
         return PropertyUtilsBean.getInstance().getMappedPropertyDescriptors(bean);
 

--- a/src/main/java/org/apache/commons/beanutils/PropertyUtilsBean.java
+++ b/src/main/java/org/apache/commons/beanutils/PropertyUtilsBean.java
@@ -30,11 +30,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.apache.commons.beanutils.expression.DefaultResolver;
 import org.apache.commons.beanutils.expression.Resolver;
-import org.apache.commons.collections.FastHashMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -114,7 +114,7 @@ public class PropertyUtilsBean {
      * introspected, keyed by the java.lang.Class of this object.
      */
     private WeakFastHashMap<Class<?>, BeanIntrospectionData> descriptorsCache = null;
-    private WeakFastHashMap<Class<?>, FastHashMap> mappedDescriptorsCache = null;
+    private WeakFastHashMap<Class<?>, Map> mappedDescriptorsCache = null;
 
     /** An empty object array */
     private static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
@@ -131,7 +131,7 @@ public class PropertyUtilsBean {
     public PropertyUtilsBean() {
         descriptorsCache = new WeakFastHashMap<Class<?>, BeanIntrospectionData>();
         descriptorsCache.setFast(true);
-        mappedDescriptorsCache = new WeakFastHashMap<Class<?>, FastHashMap>();
+        mappedDescriptorsCache = new WeakFastHashMap<Class<?>, Map>();
         mappedDescriptorsCache.setFast(true);
         introspectors = new CopyOnWriteArrayList<BeanIntrospector>();
         resetBeanIntrospectors();
@@ -711,10 +711,8 @@ public class PropertyUtilsBean {
      *
      * @param beanClass Bean class to be introspected
      * @return the mapped property descriptors
-     * @deprecated This method should not be exposed
      */
-    @Deprecated
-    public FastHashMap getMappedPropertyDescriptors(final Class<?> beanClass) {
+    Map<Class<?>, Map> getMappedPropertyDescriptors(final Class<?> beanClass) {
 
         if (beanClass == null) {
             return null;
@@ -733,10 +731,8 @@ public class PropertyUtilsBean {
      *
      * @param bean Bean to be introspected
      * @return the mapped property descriptors
-     * @deprecated This method should not be exposed
      */
-    @Deprecated
-    public FastHashMap getMappedPropertyDescriptors(final Object bean) {
+    Map getMappedPropertyDescriptors(final Object bean) {
 
         if (bean == null) {
             return null;
@@ -958,11 +954,10 @@ public class PropertyUtilsBean {
             return result;
         }
 
-        FastHashMap mappedDescriptors =
+        Map mappedDescriptors =
                 getMappedPropertyDescriptors(bean);
         if (mappedDescriptors == null) {
-            mappedDescriptors = new FastHashMap();
-            mappedDescriptors.setFast(true);
+            mappedDescriptors = new ConcurrentHashMap<Class<?>, Map>();
             mappedDescriptorsCache.put(bean.getClass(), mappedDescriptors);
         }
         result = (PropertyDescriptor) mappedDescriptors.get(name);

--- a/src/main/java/org/apache/commons/beanutils/ResultSetDynaClass.java
+++ b/src/main/java/org/apache/commons/beanutils/ResultSetDynaClass.java
@@ -82,9 +82,9 @@ import java.util.Iterator;
 
 public class ResultSetDynaClass extends JDBCDynaClass {
 
+    private static final long serialVersionUID = 1L;
 
     // ----------------------------------------------------------- Constructors
-
 
     /**
      * <p>Construct a new ResultSetDynaClass for the specified

--- a/src/main/java/org/apache/commons/beanutils/ResultSetDynaClass.java
+++ b/src/main/java/org/apache/commons/beanutils/ResultSetDynaClass.java
@@ -80,7 +80,7 @@ import java.util.Iterator;
  * @version $Id$
  */
 
-public class ResultSetDynaClass extends JDBCDynaClass implements DynaClass {
+public class ResultSetDynaClass extends JDBCDynaClass {
 
 
     // ----------------------------------------------------------- Constructors

--- a/src/main/java/org/apache/commons/beanutils/RowSetDynaClass.java
+++ b/src/main/java/org/apache/commons/beanutils/RowSetDynaClass.java
@@ -66,6 +66,7 @@ import java.util.List;
 
 public class RowSetDynaClass extends JDBCDynaClass {
 
+    private static final long serialVersionUID = 1L;
 
     // ----------------------------------------------------- Instance variables
 

--- a/src/main/java/org/apache/commons/beanutils/RowSetDynaClass.java
+++ b/src/main/java/org/apache/commons/beanutils/RowSetDynaClass.java
@@ -19,7 +19,6 @@
 package org.apache.commons.beanutils;
 
 
-import java.io.Serializable;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;

--- a/src/main/java/org/apache/commons/beanutils/RowSetDynaClass.java
+++ b/src/main/java/org/apache/commons/beanutils/RowSetDynaClass.java
@@ -65,7 +65,7 @@ import java.util.List;
  * @version $Id$
  */
 
-public class RowSetDynaClass extends JDBCDynaClass implements DynaClass, Serializable {
+public class RowSetDynaClass extends JDBCDynaClass {
 
 
     // ----------------------------------------------------- Instance variables

--- a/src/main/java/org/apache/commons/beanutils/WeakFastHashMap.java
+++ b/src/main/java/org/apache/commons/beanutils/WeakFastHashMap.java
@@ -61,7 +61,7 @@ import java.util.WeakHashMap;
  * @since Commons Collections 1.0
  * @version $Id$
  */
-class WeakFastHashMap<K, V> extends HashMap<K, V> {
+public class WeakFastHashMap<K, V> extends HashMap<K, V> {
 
     /**
      * The underlying map we are managing.

--- a/src/main/java/org/apache/commons/beanutils/WeakFastHashMap.java
+++ b/src/main/java/org/apache/commons/beanutils/WeakFastHashMap.java
@@ -63,6 +63,8 @@ import java.util.WeakHashMap;
  */
 public class WeakFastHashMap<K, V> extends HashMap<K, V> {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * The underlying map we are managing.
      */

--- a/src/main/java/org/apache/commons/beanutils/WrapDynaBean.java
+++ b/src/main/java/org/apache/commons/beanutils/WrapDynaBean.java
@@ -46,9 +46,9 @@ import java.lang.reflect.InvocationTargetException;
 
 public class WrapDynaBean implements DynaBean, Serializable {
 
+    private static final long serialVersionUID = 1L;
 
     // ---------------------------------------------------------- Constructors
-
 
     /**
      * Construct a new <code>DynaBean</code> associated with the specified

--- a/src/main/java/org/apache/commons/beanutils/WrapDynaClass.java
+++ b/src/main/java/org/apache/commons/beanutils/WrapDynaClass.java
@@ -458,7 +458,6 @@ public class WrapDynaClass implements DynaClass {
         if (regulars == null) {
             regulars = new PropertyDescriptor[0];
         }
-        @SuppressWarnings("deprecation")
         Map<?, ?> mappeds =
                 PropertyUtils.getMappedPropertyDescriptors(beanClass);
         if (mappeds == null) {

--- a/src/main/java/org/apache/commons/beanutils/WrapDynaClass.java
+++ b/src/main/java/org/apache/commons/beanutils/WrapDynaClass.java
@@ -196,6 +196,9 @@ public class WrapDynaClass implements DynaClass {
      */
     @Deprecated
     protected static HashMap<Object, Object> dynaClasses = new HashMap<Object, Object>() {
+
+        private static final long serialVersionUID = 1L;
+
         @Override
         public void clear() {
             getDynaClassesMap().clear();

--- a/src/main/java/org/apache/commons/beanutils/locale/LocaleConvertUtils.java
+++ b/src/main/java/org/apache/commons/beanutils/locale/LocaleConvertUtils.java
@@ -18,8 +18,9 @@
 package org.apache.commons.beanutils.locale;
 
 import java.util.Locale;
+import java.util.Map;
 
-import org.apache.commons.collections.FastHashMap;
+import org.apache.commons.beanutils.locale.LocaleConverter;
 
 /**
  * <p>Utility methods for converting locale-sensitive String scalar values to objects of the
@@ -316,18 +317,18 @@ public class LocaleConvertUtils {
     }
 
     /**
-     * <p>Look up and return any registered FastHashMap instance for the specified locale.</p>
+     * <p>Look up and return any registered map instance for the specified locale.</p>
      *
      * <p>For more details see <code>LocaleConvertUtilsBean</code></p>
      *
      * @param locale The Locale
-     * @return The FastHashMap instance contains the all {@link LocaleConverter} types for
+     * @return The map instance contains the all {@link LocaleConverter} types for
      *  the specified locale.
      * @see LocaleConvertUtilsBean#lookup(Locale)
      * @deprecated This method will be modified to return a Map in the next release.
      */
     @Deprecated
-    protected static FastHashMap lookup(final Locale locale) {
+    protected static Map<Class<?>, LocaleConverter> lookup(final Locale locale) {
         return LocaleConvertUtilsBean.getInstance().lookup(locale);
     }
 
@@ -343,7 +344,7 @@ public class LocaleConvertUtils {
      * @deprecated This method will be modified to return a Map in the next release.
      */
     @Deprecated
-    protected static FastHashMap create(final Locale locale) {
+    protected static Map<Class<?>, LocaleConverter> create(final Locale locale) {
 
         return LocaleConvertUtilsBean.getInstance().create(locale);
     }

--- a/src/main/java/org/apache/commons/beanutils/locale/LocaleConvertUtilsBean.java
+++ b/src/main/java/org/apache/commons/beanutils/locale/LocaleConvertUtilsBean.java
@@ -558,7 +558,6 @@ public class LocaleConvertUtilsBean {
         public Object put(final Object key, final Object value) {
             return map.put(key, value);
         }
-        @SuppressWarnings({ "rawtypes", "unchecked" })
         // we operate on very generic types (<Object, Object>), so there is
         // no need for doing type checks
         @Override

--- a/src/main/java/org/apache/commons/beanutils/locale/converters/DecimalLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils/locale/converters/DecimalLocaleConverter.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.Locale;
 
@@ -236,7 +237,7 @@ public class DecimalLocaleConverter extends BaseLocaleConverter {
         // fact that objects returned from this method have the same toString
         // representation, each call to getInstance actually returns a new
         // object.
-        final DecimalFormat formatter = (DecimalFormat) DecimalFormat.getInstance(locale);
+        final DecimalFormat formatter = (DecimalFormat) NumberFormat.getInstance(locale);
 
         // if some constructors default pattern to null, it makes only sense
         // to handle null pattern gracefully

--- a/src/main/java/org/apache/commons/beanutils/package-info.java
+++ b/src/main/java/org/apache/commons/beanutils/package-info.java
@@ -1021,7 +1021,7 @@
  * <p>
  * BeanComparator relies on an internal Comparator to perform the actual
  * comparisions. By default,
- * <code>org.apache.commons.collections.comparators.ComparableComparator</code>
+ * <code>org.apache.commons.collections4.comparators.ComparableComparator</code>
  * is used which imposes a natural order. If you want to change the order,
  * then a custom Comparator should be created and passed into the
  * appropriate constructor.
@@ -1030,8 +1030,8 @@
  * For example:
  * </p>
  * <code><pre>
- *     import org.apache.commons.collections.comparators.ComparableComparator;
- *     import org.apache.commons.collections.comparators.ReverseComparator;
+ *     import org.apache.commons.collections4.comparators.ComparableComparator;
+ *     import org.apache.commons.collections4.comparators.ReverseComparator;
  *     import org.apache.commons.beanutils.BeanComparator;
  *     ...
  *     BeanComparator reversedNaturalOrderBeanComparator

--- a/src/test/java/org/apache/commons/beanutils/BeanMapTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils/BeanMapTestCase.java
@@ -27,7 +27,7 @@ import junit.textui.TestRunner;
 
 import org.apache.commons.beanutils.bugs.other.Jira87BeanFactory;
 import org.apache.commons.collections.BulkTest;
-import org.apache.commons.collections.Transformer;
+import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections.map.AbstractTestMap;
 
 /**

--- a/src/test/java/org/apache/commons/beanutils/BeanPredicateTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils/BeanPredicateTestCase.java
@@ -19,10 +19,10 @@ package org.apache.commons.beanutils;
 
 import junit.framework.TestCase;
 
-import org.apache.commons.collections.functors.EqualPredicate;
-import org.apache.commons.collections.functors.InstanceofPredicate;
-import org.apache.commons.collections.functors.NotPredicate;
-import org.apache.commons.collections.functors.NullPredicate;
+import org.apache.commons.collections4.functors.EqualPredicate;
+import org.apache.commons.collections4.functors.InstanceofPredicate;
+import org.apache.commons.collections4.functors.NotPredicate;
+import org.apache.commons.collections4.functors.NullPredicate;
 
 /**
  * @version $Id$

--- a/src/test/java/org/apache/commons/beanutils/converters/BooleanArrayConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils/converters/BooleanArrayConverterTestCase.java
@@ -156,7 +156,7 @@ public class BooleanArrayConverterTestCase extends TestCase {
         final BooleanConverter bc = new BooleanConverter(
             trueStrings, falseStrings, BooleanConverter.NO_DEFAULT);
         final BooleanArrayConverter converter = new BooleanArrayConverter(
-            bc, BooleanArrayConverter.NO_DEFAULT);
+            bc, AbstractArrayConverter.NO_DEFAULT);
 
         final boolean[] results = (boolean[]) converter.convert(null, "NOPE, sure, sure");
         assertNotNull(results);
@@ -261,7 +261,7 @@ public class BooleanArrayConverterTestCase extends TestCase {
             trueStrings, falseStrings, BooleanConverter.NO_DEFAULT);
 
         final BooleanArrayConverter converter = new BooleanArrayConverter(
-            bc, BooleanArrayConverter.NO_DEFAULT);
+            bc, AbstractArrayConverter.NO_DEFAULT);
 
         ConvertUtils.register(converter, BooleanArrayConverter.MODEL);
         final boolean[] sample = new boolean[0];

--- a/src/test/java/org/apache/commons/beanutils/locale/LocaleBeanificationTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils/locale/LocaleBeanificationTestCase.java
@@ -27,6 +27,7 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
+import org.apache.commons.beanutils.BeanUtilsBean;
 import org.apache.commons.beanutils.BeanUtilsTestCase;
 import org.apache.commons.beanutils.ContextClassLoaderLocal;
 import org.apache.commons.beanutils.ConversionException;
@@ -297,7 +298,7 @@ public class LocaleBeanificationTestCase extends TestCase {
         assertEquals("Signal not set by test thread", 2, signal.getSignal());
         assertTrue(
                     "Different LocaleBeanUtilsBean instances per context classloader",
-                    LocaleBeanUtilsBean.getInstance() != signal.getBean());
+                    BeanUtilsBean.getInstance() != signal.getBean());
         assertTrue(
                     "Different LocaleConvertUtilsBean instances per context classloader",
                     LocaleConvertUtilsBean.getInstance() != signal.getConvertUtils());

--- a/src/test/java/org/apache/commons/beanutils/locale/LocaleConvertUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils/locale/LocaleConvertUtilsTestCase.java
@@ -71,7 +71,7 @@ public class LocaleConvertUtilsTestCase extends TestCase {
 
         LocaleConvertUtils.deregister();
 
-        final NumberFormat nf = DecimalFormat.getNumberInstance();
+        final NumberFormat nf = NumberFormat.getNumberInstance();
         final String result = nf.format(1.1);
 
         // could be commas instead of stops in Europe.


### PR DESCRIPTION
I merged the changes in master since beanutils 1.9.4, through commons-collections 4.4.

I stopped there because it looked like removing commons-collections 4 (BEANUTILS-527) also required java 8 language features.

I was also unclear about whether to merge Jira509TestCase (BEANUTILS-509).

'mvn test' passes with java 8.

Feedback appreciated.