### PR TITLE
Fix #552 - Allow stopClass for PropertyUtilsBean

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/DefaultBeanIntrospector.java
+++ b/src/main/java/org/apache/commons/beanutils2/DefaultBeanIntrospector.java
@@ -74,7 +74,7 @@ public class DefaultBeanIntrospector implements BeanIntrospector {
     public void introspect(final IntrospectionContext icontext) {
         BeanInfo beanInfo = null;
         try {
-            beanInfo = Introspector.getBeanInfo(icontext.getTargetClass());
+            beanInfo = Introspector.getBeanInfo(icontext.getTargetClass(), icontext.getStopClass());
         } catch (final IntrospectionException e) {
             // no descriptors are added to the context
             log.error(

--- a/src/main/java/org/apache/commons/beanutils2/DefaultIntrospectionContext.java
+++ b/src/main/java/org/apache/commons/beanutils2/DefaultIntrospectionContext.java
@@ -37,6 +37,8 @@ import java.util.Set;
 class DefaultIntrospectionContext implements IntrospectionContext {
     /** The current class for introspection. */
     private final Class<?> currentClass;
+    /** The stop class for introspection. */
+    private final Class<?> stopClass;
 
     /** A map for storing the already added property descriptors. */
     private final Map<String, PropertyDescriptor> descriptors;
@@ -49,13 +51,31 @@ class DefaultIntrospectionContext implements IntrospectionContext {
      * @param cls the current class
      */
     public DefaultIntrospectionContext(final Class<?> cls) {
+        this(cls, Object.class);
+    }
+
+    /**
+     *
+     * Creates a new instance of {@code DefaultIntrospectionContext} and sets
+     * the current class for introspection.
+     *
+     * @param cls the current class
+     * @param stopCls the stop class
+     */
+    public DefaultIntrospectionContext(final Class<?> cls, final Class<?> stopCls) {
         currentClass = cls;
+        stopClass = stopCls;
         descriptors = new HashMap<>();
     }
 
     @Override
     public Class<?> getTargetClass() {
         return currentClass;
+    }
+
+    @Override
+    public Class<?> getStopClass() {
+        return stopClass;
     }
 
     @Override

--- a/src/main/java/org/apache/commons/beanutils2/DefaultIntrospectionContext.java
+++ b/src/main/java/org/apache/commons/beanutils2/DefaultIntrospectionContext.java
@@ -51,7 +51,7 @@ class DefaultIntrospectionContext implements IntrospectionContext {
      * @param cls the current class
      */
     public DefaultIntrospectionContext(final Class<?> cls) {
-        this(cls, Object.class);
+        this(cls, null);
     }
 
     /**

--- a/src/main/java/org/apache/commons/beanutils2/IntrospectionContext.java
+++ b/src/main/java/org/apache/commons/beanutils2/IntrospectionContext.java
@@ -49,9 +49,7 @@ public interface IntrospectionContext {
      *
      * @return the stop class
      */
-    default Class<?> getStopClass() {
-        return Object.class;
-    }
+    Class<?> getStopClass();
 
     /**
      * Adds the given property descriptor to this context. This method is called

--- a/src/main/java/org/apache/commons/beanutils2/IntrospectionContext.java
+++ b/src/main/java/org/apache/commons/beanutils2/IntrospectionContext.java
@@ -44,6 +44,16 @@ public interface IntrospectionContext {
     Class<?> getTargetClass();
 
     /**
+     * The baseclass at which to stop the analysis.
+     * Any methods/properties/events in the stopClass or in its baseclasses will be ignored in the analysis.
+     *
+     * @return the stop class
+     */
+    default Class<?> getStopClass() {
+        return Object.class;
+    }
+
+    /**
      * Adds the given property descriptor to this context. This method is called
      * by a {@code BeanIntrospector} during introspection for each detected
      * property. If this context already contains a descriptor for the affected

--- a/src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java
+++ b/src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java
@@ -178,6 +178,7 @@ public class PropertyUtilsBean {
     public final void resetBeanIntrospectors() {
         introspectors.clear();
         introspectors.add(DefaultBeanIntrospector.INSTANCE);
+        introspectors.add(SuppressPropertiesBeanIntrospector.SUPPRESS_CLASS);
     }
 
     /**
@@ -2126,7 +2127,7 @@ public class PropertyUtilsBean {
      * @throws IllegalArgumentException if the bean class is <b>null</b>
      */
     private BeanIntrospectionData getIntrospectionData(final Class<?> beanClass) {
-        return getIntrospectionData(beanClass, Object.class);
+        return getIntrospectionData(beanClass, null);
     }
 
     /**
@@ -2141,10 +2142,6 @@ public class PropertyUtilsBean {
     private BeanIntrospectionData getIntrospectionData(final Class<?> beanClass, final Class<?> stopClass) {
         if (beanClass == null) {
             throw new IllegalArgumentException("No bean class specified");
-        }
-
-        if (stopClass == null) {
-            throw new IllegalArgumentException("No stop class specified");
         }
 
         // Look up any cached information for this bean class

--- a/src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java
+++ b/src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java
@@ -119,15 +119,17 @@ public class PropertyUtilsBean {
 
     /** Base constructor */
     public PropertyUtilsBean() {
+        this(new CopyOnWriteArrayList<>());
+        resetBeanIntrospectors();
+    }
+
+    public PropertyUtilsBean(List<BeanIntrospector> introspectors) {
         descriptorsCache = new WeakFastHashMap<>();
         descriptorsCache.setFast(true);
         mappedDescriptorsCache = new WeakFastHashMap<>();
         mappedDescriptorsCache.setFast(true);
-        introspectors = new CopyOnWriteArrayList<>();
-        resetBeanIntrospectors();
+        this.introspectors = new CopyOnWriteArrayList<>(introspectors);
     }
-
-
 
     /**
      * Gets the configured {@link Resolver} implementation used by BeanUtils.
@@ -176,7 +178,6 @@ public class PropertyUtilsBean {
     public final void resetBeanIntrospectors() {
         introspectors.clear();
         introspectors.add(DefaultBeanIntrospector.INSTANCE);
-        introspectors.add(SuppressPropertiesBeanIntrospector.SUPPRESS_CLASS);
     }
 
     /**

--- a/src/test/java/org/apache/commons/beanutils2/BeanIntrospectionDataTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/BeanIntrospectionDataTestCase.java
@@ -111,7 +111,7 @@ public class BeanIntrospectionDataTestCase extends TestCase {
      */
     public void testGetWriteMethodUnknown() {
         final BeanIntrospectionData data = setUpData();
-        final PropertyDescriptor pd = data.getDescriptor("child");
+        final PropertyDescriptor pd = data.getDescriptor("class");
         assertNull("Got a write method", data.getWriteMethod(BEAN_CLASS, pd));
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/BeanIntrospectionDataTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/BeanIntrospectionDataTestCase.java
@@ -111,7 +111,7 @@ public class BeanIntrospectionDataTestCase extends TestCase {
      */
     public void testGetWriteMethodUnknown() {
         final BeanIntrospectionData data = setUpData();
-        final PropertyDescriptor pd = data.getDescriptor("class");
+        final PropertyDescriptor pd = data.getDescriptor("child");
         assertNull("Got a write method", data.getWriteMethod(BEAN_CLASS, pd));
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/SuppressPropertiesBeanIntrospectorTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/SuppressPropertiesBeanIntrospectorTestCase.java
@@ -117,6 +117,11 @@ public class SuppressPropertiesBeanIntrospectorTestCase extends TestCase {
         }
 
         @Override
+        public Class<?> getStopClass() {
+            throw new UnsupportedOperationException("Unexpected method call!");
+        }
+
+        @Override
         public void addPropertyDescriptor(final PropertyDescriptor desc) {
             throw new UnsupportedOperationException("Unexpected method call!");
         }


### PR DESCRIPTION
Fix https://issues.apache.org/jira/projects/BEANUTILS/issues/BEANUTILS-552
- Add new method PropertyUtilsBean#getPropertyDescriptors(beanClass, stopClass)
- Add ctor for PropertyUtilsBean