### PR TITLE
BEANUTILS-550: correction of returning default value by StringConverter

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/converters/AbstractConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/converters/AbstractConverter.java
@@ -295,9 +295,6 @@ public abstract class AbstractConverter implements Converter {
      * @return The default value for the specified type.
      */
     protected Object getDefault(final Class<?> type) {
-        if (type.equals(String.class)) {
-            return null;
-        }
         return defaultValue;
     }
 

--- a/src/test/java/org/apache/commons/beanutils2/BeanUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/BeanUtilsTestCase.java
@@ -27,6 +27,7 @@ import java.util.StringTokenizer;
 
 import org.apache.commons.beanutils2.converters.ArrayConverter;
 import org.apache.commons.beanutils2.converters.DateConverter;
+import org.apache.commons.beanutils2.converters.StringConverter;
 
 import junit.framework.Test;
 import junit.framework.TestCase;
@@ -146,6 +147,12 @@ public class BeanUtilsTestCase extends TestCase {
         testCalendar.set(Calendar.MILLISECOND, 0);
         testUtilDate = testCalendar.getTime();
         testStringDate = "28.12.1992";
+
+        /**
+         * Replacing default StringConverter (having default value) with StringConverter without default value
+         * to allow testing of nullProperty.
+         */
+        ConvertUtils.register(new StringConverter(), String.class);
     }
 
     /**

--- a/src/test/java/org/apache/commons/beanutils2/DynaBeanUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/DynaBeanUtilsTestCase.java
@@ -24,6 +24,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.beanutils2.converters.StringConverter;
+
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
@@ -96,6 +98,11 @@ public class DynaBeanUtilsTestCase extends TestCase {
     public void setUp() throws Exception {
 
         ConvertUtils.deregister();
+        /**
+         * Replacing default StringConverter (having default value) with StringConverter without default value
+         * to allow testing of nullProperty.
+         */
+        ConvertUtils.register(new StringConverter(), String.class);
 
         // Instantiate a new DynaBean instance
         final DynaClass dynaClass = createDynaClass();
@@ -811,6 +818,7 @@ public class DynaBeanUtilsTestCase extends TestCase {
      * Test populate() method on scalar properties.
      */
     public void testPopulateScalar() {
+
 
         try {
 

--- a/src/test/java/org/apache/commons/beanutils2/converters/StringConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/StringConverterTestCase.java
@@ -25,6 +25,9 @@ import junit.framework.TestCase;
  *
  */
 public class StringConverterTestCase extends TestCase {
+
+    private static final String DEFAULT_VALUE = "default";
+
     /** The converter to be tested. */
     private StringConverter converter;
 
@@ -60,5 +63,13 @@ public class StringConverterTestCase extends TestCase {
      */
     public void testDefaultType() {
         assertEquals("Wrong default type", String.class, converter.getDefaultType());
+    }
+
+    /**
+     * Tests whether the correct default value is returned.
+     */
+    public void testDefaultValue() {
+        converter.setDefaultValue(DEFAULT_VALUE);
+        assertEquals("Wrong default value", DEFAULT_VALUE, converter.convert(String.class, null));
     }
 }


### PR DESCRIPTION
PR for Jira issue: BEANUTILS-550.

Assignment of default value in StringConverter didn’t work as method getDefault(final Class<?> type), only for String.class, returned null instead of default value. I’ve changed this method to return default value also for String.class.
 
Could you please review and let me know if this modification is OK? 
I would appreciate any feedback.
Justyna
