### PR TITLE
New Date/Time API continued replace Old

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/ConvertUtilsBean.java
+++ b/src/main/java/org/apache/commons/beanutils2/ConvertUtilsBean.java
@@ -26,6 +26,7 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.sql.Timestamp;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -53,10 +54,11 @@ import org.apache.commons.beanutils2.converters.ClassConverter;
 import org.apache.commons.beanutils2.converters.ConverterFacade;
 import org.apache.commons.beanutils2.converters.DateConverter;
 import org.apache.commons.beanutils2.converters.DoubleConverter;
-import org.apache.commons.beanutils2.converters.EnumConverter;
 import org.apache.commons.beanutils2.converters.DurationConverter;
+import org.apache.commons.beanutils2.converters.EnumConverter;
 import org.apache.commons.beanutils2.converters.FileConverter;
 import org.apache.commons.beanutils2.converters.FloatConverter;
+import org.apache.commons.beanutils2.converters.InstantConverter;
 import org.apache.commons.beanutils2.converters.IntegerConverter;
 import org.apache.commons.beanutils2.converters.LocalDateConverter;
 import org.apache.commons.beanutils2.converters.LocalDateTimeConverter;
@@ -112,6 +114,7 @@ import org.apache.commons.logging.LogFactory;
  * <li>java.sql.Date (no default value)</li>
  * <li>java.sql.Time (no default value)</li>
  * <li>java.sql.Timestamp (no default value)</li>
+ * <li>java.time.Instant (no default value)</li>
  * <li>java.time.LocalDate (no default value)</li>
  * <li>java.time.LocalDateTime (no default value)</li>
  * <li>java.time.LocalTime (no default value)</li>
@@ -484,6 +487,7 @@ public class ConvertUtilsBean {
      *     <li>{@code URL.class} - {@link URLConverter}</li>
      *     <li>{@code URI.class} - {@link URIConverter}</li>
      *     <li>{@code UUID.class} - {@link UUIDConverter}</li>
+     *     <li>{@code Instant.class} - {@link InstantConverter}</li>
      *     <li>{@code LocalDate.class} - {@link LocalDateConverter}</li>
      *     <li>{@code LocalDateTime.class} - {@link LocalDateTimeConverter}</li>
      *     <li>{@code LocalTime.class} - {@link LocalTimeConverter}</li>
@@ -516,6 +520,7 @@ public class ConvertUtilsBean {
         register(URL.class,            throwException ? new URLConverter()            : new URLConverter(null));
         register(URI.class,            throwException ? new URIConverter()            : new URIConverter(null));
         register(UUID.class,           throwException ? new UUIDConverter()           : new UUIDConverter(null));
+        register(Instant.class,        throwException ? new InstantConverter()        : new InstantConverter(null));
         register(LocalDate.class,      throwException ? new LocalDateConverter()      : new LocalDateConverter(null));
         register(LocalDateTime.class,  throwException ? new LocalDateTimeConverter()  : new LocalDateTimeConverter(null));
         register(LocalTime.class,      throwException ? new LocalTimeConverter()      : new LocalTimeConverter(null));
@@ -582,6 +587,7 @@ public class ConvertUtilsBean {
         registerArrayConverter(URL.class,            new URLConverter(),           throwException, defaultArraySize);
         registerArrayConverter(URI.class,            new URIConverter(),           throwException, defaultArraySize);
         registerArrayConverter(UUID.class,           new UUIDConverter(),          throwException, defaultArraySize);
+        registerArrayConverter(Instant.class,        new InstantConverter(),       throwException, defaultArraySize);
         registerArrayConverter(LocalDate.class,      new LocalDateConverter(),     throwException, defaultArraySize);
         registerArrayConverter(LocalDateTime.class,  new LocalDateTimeConverter(), throwException, defaultArraySize);
         registerArrayConverter(LocalTime.class,      new LocalTimeConverter(),     throwException, defaultArraySize);

--- a/src/main/java/org/apache/commons/beanutils2/converters/DateTimeConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/converters/DateTimeConverter.java
@@ -42,6 +42,7 @@ import org.apache.commons.beanutils2.ConversionException;
  * <ul>
  *     <li>{@code java.util.Date}</li>
  *     <li>{@code java.util.Calendar}</li>
+ *     <li>{@code java.time.Instant}</li>
  *     <li>{@code java.time.LocalDate}</li>
  *     <li>{@code java.time.LocalDateTime}</li>
  *     <li>{@code java.time.OffsetDateTime}</li>
@@ -227,7 +228,7 @@ public abstract class DateTimeConverter<D> extends AbstractConverter<D> {
         } else if (value instanceof Calendar) {
             date = ((Calendar) value).getTime();
         } else if (value instanceof Long) {
-            date = new Date(((Long) value).longValue());
+            date = new Date(((Long) value).longValue());  
         } else if (value instanceof LocalDateTime) {
             date = java.sql.Timestamp.valueOf(((LocalDateTime) value));
         } else if (value instanceof LocalDate) {
@@ -276,6 +277,7 @@ public abstract class DateTimeConverter<D> extends AbstractConverter<D> {
      *     <li>{@code java.time.LocalDateTime}</li>
      *     <li>{@code java.time.OffsetDateTime}</li>
      *     <li>{@code java.time.ZonedDateTime}</li>
+     *     <li>{@code java.time.Instant}</li>
      *     <li>{@code java.sql.Date}</li>
      *     <li>{@code java.sql.Time}</li>
      *     <li>{@code java.sql.Timestamp}</li>
@@ -358,6 +360,12 @@ public abstract class DateTimeConverter<D> extends AbstractConverter<D> {
             final Instant temp = date.toInstant();
             return toDate(targetType, temp.getEpochSecond(), temp.getNano());
         }
+        
+        //Handle Instant and other TemporalAccessor implementations.
+        if (value instanceof TemporalAccessor) {
+            final Instant temp = Instant.from(((TemporalAccessor) value));
+            return toDate(targetType, temp.getEpochSecond(), temp.getNano());
+        }
 
         // Convert all other types to String & handle
         final String stringValue = toTrim(value);
@@ -396,6 +404,7 @@ public abstract class DateTimeConverter<D> extends AbstractConverter<D> {
      *     <li>{@code java.time.LocalDate}</li>
      *     <li>{@code java.time.LocalDateTime}</li>
      *     <li>{@code java.time.ZonedDateTime}</li>
+     *     <li>{@code java.time.Instant}</li>
      *     <li>{@code java.sql.Date}</li>
      *     <li>{@code java.sql.Time}</li>
      *     <li>{@code java.sql.Timestamp}</li>
@@ -423,6 +432,7 @@ public abstract class DateTimeConverter<D> extends AbstractConverter<D> {
      *     <li>{@code java.time.LocalDate}</li>
      *     <li>{@code java.time.LocalDateTime}</li>
      *     <li>{@code java.time.ZonedDateTime}</li>
+     *     <li>{@code java.time.Instant}</li>
      *     <li>{@code java.sql.Date}</li>
      *     <li>{@code java.sql.Time}</li>
      *     <li>{@code java.sql.Timestamp}</li>
@@ -495,6 +505,12 @@ public abstract class DateTimeConverter<D> extends AbstractConverter<D> {
             final OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(
                     Instant.ofEpochSecond(seconds, nanos), getZoneId());
             return type.cast(offsetDateTime);
+        }
+        
+        // java.time.Instant
+        if (type.equals(Instant.class)) {
+            final Instant instant = Instant.ofEpochSecond(seconds, nanos);
+            return type.cast(instant);
         }
 
         // java.util.Calendar

--- a/src/main/java/org/apache/commons/beanutils2/converters/InstantConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/converters/InstantConverter.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.beanutils2.converters;
+
+import java.time.Instant;
+
+/**
+ * {@link DateTimeConverter} implementation that handles conversion to
+ * and from <b>java.time.Instant</b> objects.
+ * <p>
+ * This implementation can be configured to handle conversion either
+ * by using a Locale's default format or by specifying a set of format
+ * patterns (note, there is no default String conversion for Calendar).
+ * See the {@link DateTimeConverter} documentation for further details.
+ * </p>
+ * <p>
+ * Can be configured to either return a <i>default value</i> or throw a
+ * {@code ConversionException} if a conversion error occurs.
+ * </p>
+ *
+ * @since 2.0
+ * @see java.time.Instant
+ */
+public final class InstantConverter extends DateTimeConverter<Instant> {
+
+    /**
+     * Constructs a <b>java.time.Instant</b> <i>Converter</i> that throws
+     * a {@code ConversionException} if an error occurs.
+     */
+    public InstantConverter() {
+    }
+
+    /**
+     * Constructs a <b>java.time.Instant</b> <i>Converter</i> that returns
+     * a default value if an error occurs.
+     *
+     * @param defaultValue The default value to be returned
+     * if the value to be converted is missing or an error
+     * occurs converting the value.
+     */
+    public InstantConverter(final Instant defaultValue) {
+        super(defaultValue);
+    }
+
+    /**
+     * Gets the default type this {@code Converter} handles.
+     *
+     * @return The default type this {@code Converter} handles.
+     */
+    @Override
+    protected Class<Instant> getDefaultType() {
+        return Instant.class;
+    }
+
+}

--- a/src/main/java/org/apache/commons/beanutils2/converters/SqlTimeConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/converters/SqlTimeConverter.java
@@ -17,9 +17,9 @@
 package org.apache.commons.beanutils2.converters;
 
 import java.sql.Time;
-import java.text.DateFormat;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Locale;
-import java.util.TimeZone;
 
 /**
  * {@link DateTimeConverter} implementation that handles conversion to
@@ -68,25 +68,17 @@ public final class SqlTimeConverter extends DateTimeConverter<Time> {
     }
 
     /**
-     * Gets a {@code DateFormat} for the Locale.
+     * Gets a {@code DateTimeFormatter} for the Locale.
      * @param locale TODO
-     * @param timeZone TODO
+     * @param zoneId TODO
+     * @param value TODO
      *
-     * @return The DateFormat.
+     * @return The DateTimeFormatter.
      * @since 1.8.0
      */
     @Override
-    protected DateFormat getFormat(final Locale locale, final TimeZone timeZone) {
-        DateFormat format = null;
-        if (locale == null) {
-            format = DateFormat.getTimeInstance(DateFormat.SHORT);
-        } else {
-            format = DateFormat.getTimeInstance(DateFormat.SHORT, locale);
-        }
-        if (timeZone != null) {
-            format.setTimeZone(timeZone);
-        }
-        return format;
+    protected DateTimeFormatter getFormat(final Locale locale, final ZoneId zoneId,String value) {
+        return super.getFormat(locale, zoneId, 2);
     }
-
+    
 }

--- a/src/main/java/org/apache/commons/beanutils2/converters/SqlTimestampConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/converters/SqlTimestampConverter.java
@@ -17,9 +17,6 @@
 package org.apache.commons.beanutils2.converters;
 
 import java.sql.Timestamp;
-import java.text.DateFormat;
-import java.util.Locale;
-import java.util.TimeZone;
 
 /**
  * {@link DateTimeConverter} implementation that handles conversion to
@@ -66,26 +63,5 @@ public final class SqlTimestampConverter extends DateTimeConverter<Timestamp> {
     protected Class<Timestamp> getDefaultType() {
         return Timestamp.class;
     }
-
-    /**
-     * Gets a {@code DateFormat} for the Locale.
-     * @param locale TODO
-     * @param timeZone TODO
-     *
-     * @return The DateFormat.
-     * @since 1.8.0
-     */
-    @Override
-    protected DateFormat getFormat(final Locale locale, final TimeZone timeZone) {
-        DateFormat format = null;
-        if (locale == null) {
-            format = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT);
-        } else {
-            format = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT, locale);
-        }
-        if (timeZone != null) {
-            format.setTimeZone(timeZone);
-        }
-        return format;
-    }
+    
 }

--- a/src/test/java/org/apache/commons/beanutils2/ConvertUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/ConvertUtilsTestCase.java
@@ -621,7 +621,7 @@ public class ConvertUtilsTestCase extends TestCase {
 
         // Convert using registered DateConverter
         final java.util.Date today = new java.util.Date();
-        final DateFormat fmt = new SimpleDateFormat("M/d/yy"); /* US Short Format */
+        final DateFormat fmt = new SimpleDateFormat("M/d/yy, h:mm a",Locale.US); /* US Short Format */
         final String expected = fmt.format(today);
         assertEquals("DateConverter M/d/yy", expected, utils.convert(today, String.class));
 

--- a/src/test/java/org/apache/commons/beanutils2/converters/DateConverterTestBase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/DateConverterTestBase.java
@@ -25,6 +25,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAccessor;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -85,6 +86,12 @@ public abstract class DateConverterTestBase<T> extends TestCase {
 
         if (date instanceof OffsetDateTime) {
             return ((OffsetDateTime) date).toInstant().toEpochMilli();
+        }
+        
+        //Instant and other TemporalAccessor 
+        if (date instanceof TemporalAccessor) {
+          final Instant temp = Instant.from(((TemporalAccessor) date));
+          return temp.toEpochMilli();
         }
 
         if (date instanceof Calendar) {

--- a/src/test/java/org/apache/commons/beanutils2/converters/InstantConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/InstantConverterTestCase.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.beanutils2.converters;
+
+import java.time.Instant;
+import java.util.Calendar;
+
+import junit.framework.TestSuite;
+
+/**
+ * Test Case for the InstantConverterTestCase class.
+ */
+public class InstantConverterTestCase extends DateConverterTestBase<Instant> {
+
+    /**
+     * Create Test Suite
+     * @return test suite
+     */
+    public static TestSuite suite() {
+        return new TestSuite(InstantConverterTestCase.class);
+    }
+
+    /**
+     * Constructs a new Date test case.
+     * @param name Test Name
+     */
+    public InstantConverterTestCase(final String name) {
+        super(name);
+    }
+
+    /**
+     * Gets the expected type
+     * @return The expected type
+     */
+    @Override
+    protected Class<Instant> getExpectedType() {
+        return Instant.class;
+    }
+
+    /**
+     * Create the Converter with no default value.
+     * @return A new Converter
+     */
+    @Override
+    protected InstantConverter makeConverter() {
+        return new InstantConverter();
+    }
+
+    /**
+     * Create the Converter with a default value.
+     * @param defaultValue The default value
+     * @return A new Converter
+     */
+    @Override
+    protected InstantConverter makeConverter(final Instant defaultValue) {
+        return new InstantConverter(defaultValue);
+    }
+
+    /**
+     * Convert from a Calendar to the appropriate Date type
+     *
+     * @param value The Calendar value to convert
+     * @return The converted value
+     */
+    @Override
+    protected Instant toType(final Calendar value) {
+        return Instant.ofEpochMilli(value.getTimeInMillis());
+    }
+}

--- a/src/test/java/org/apache/commons/beanutils2/converters/SqlTimeConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/SqlTimeConverterTestCase.java
@@ -105,8 +105,9 @@ public class SqlTimeConverterTestCase extends DateConverterTestBase<Time> {
         final SqlTimeConverter converter = makeConverter();
         converter.setUseLocaleFormat(true);
 
+        //Locale.US require  UpperCase , AM PM replace am pm 
         // Valid String --> Type Conversion
-        final String testString = "3:06 pm";
+        final String testString = "3:06 PM";
         final Object expected = toType(testString, pattern, null);
         validConversion(converter, expected, testString);
 
@@ -114,8 +115,8 @@ public class SqlTimeConverterTestCase extends DateConverterTestBase<Time> {
         invalidConversion(converter, null);
         invalidConversion(converter, "");
         invalidConversion(converter, "13:05");
-        invalidConversion(converter, "11:05 p");
-        invalidConversion(converter, "11.05 pm");
+        invalidConversion(converter, "11:05 P");
+        invalidConversion(converter, "11.05 PM");
         invalidConversion(converter, new Integer(2));
 
         // Test specified Locale


### PR DESCRIPTION
1、Lifting accuracy from milliseconds to nanoseconds.
2、add InstantConvert support java.time.Instant.
3、DateTimeFormatter replace SimpleDateFormat，thread safe  and provide richer pattern .
4、java.time.ZoneId repalce TimeZone ，future oriented.