### PR TITLE
Change visibility of PropertyUtilsBean.getReadMethod(Class, PropertyDescriptor)

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java
+++ b/src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java
@@ -1119,6 +1119,7 @@ public class PropertyUtilsBean {
      * @param clazz The class of the read method will be invoked on
      * @param descriptor Property descriptor to return a getter for
      * @return The read method
+     * @since 2.0.0
      */
     public Method getReadMethod(final Class<?> clazz, final PropertyDescriptor descriptor) {
         return MethodUtils.getAccessibleMethod(clazz, descriptor.getReadMethod());

--- a/src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java
+++ b/src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java
@@ -1120,7 +1120,7 @@ public class PropertyUtilsBean {
      * @param descriptor Property descriptor to return a getter for
      * @return The read method
      */
-    Method getReadMethod(final Class<?> clazz, final PropertyDescriptor descriptor) {
+    public Method getReadMethod(final Class<?> clazz, final PropertyDescriptor descriptor) {
         return MethodUtils.getAccessibleMethod(clazz, descriptor.getReadMethod());
     }
 

--- a/src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java
+++ b/src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java
@@ -1111,10 +1111,15 @@ public class PropertyUtilsBean {
     }
 
     /**
-     * <p>Return an accessible property getter method for this property,
-     * if there is one; otherwise return {@code null}.</p>
+     * <p>Return the property getter method for this property if accessible from given
+     * {@code clazz} (and if there is one at all); otherwise return {@code null}.</p>
      *
      * <p><strong>FIXME</strong> - Does not work with DynaBeans.</p>
+     *
+     * <p>This fairly low-level method shouldn't be needed for most usecases. However, if
+     * you do have to implement something extra, you can improve consistency with the
+     * standard code (e.g. that of {@link #getProperty getProperty()}) by calling this
+     * method instead of using {@code descriptor.getReadMethod()} directly.
      *
      * @param clazz The class of the read method will be invoked on
      * @param descriptor Property descriptor to return a getter for
@@ -1232,10 +1237,15 @@ public class PropertyUtilsBean {
     }
 
     /**
-     * <p>Return an accessible property setter method for this property,
-     * if there is one; otherwise return {@code null}.</p>
+     * <p>Return the property setter method for this property if accessible from given
+     * {@code clazz} (and if there is one at all); otherwise return {@code null}.</p>
      *
      * <p><strong>FIXME</strong> - Does not work with DynaBeans.</p>
+     *
+     * <p>This fairly low-level method shouldn't be needed for most usecases. However, if
+     * you do have to implement something extra, you can improve consistency with the
+     * standard code (e.g. that of {@link #setProperty setProperty()}) by calling this
+     * method instead of using {@code descriptor.getWriteMethod()} directly.
      *
      * @param clazz The class of the read method will be invoked on
      * @param descriptor Property descriptor to return a setter for


### PR DESCRIPTION
Having this method package-private (as now) hinders subclassing. This cannot be considered a security issue, because nothing precludes subclasses from overriding every public method where the method in question is used in anyway.

This change is also consistent with visibility of other similar methods. For comparison:

* `getReadMethod(Class)` — public;
* `getReadMethod(Class, PropertyDescription)` — currently package-private, changing to public;
* `getWriteMethod(Class)` — public;
* `getWriteMethod(Class, PropertyDescription)` — public (added only in 1.9.1).
