### PR TITLE
Migrate to JUnit 5

### DIFF
--- a/src/test/java/org/apache/commons/beanutils2/BasicDynaBeanTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/BasicDynaBeanTestCase.java
@@ -17,7 +17,14 @@
 
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -29,7 +36,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>
@@ -37,7 +46,7 @@ import junit.framework.TestCase;
  * provide similar levels of functionality.
  * </p>
  */
-public class BasicDynaBeanTestCase extends TestCase {
+public class BasicDynaBeanTestCase {
 
     /**
      * The set of property names we expect to have returned when calling {@code getDynaProperties()}. You should update this list when new properties are added
@@ -51,15 +60,6 @@ public class BasicDynaBeanTestCase extends TestCase {
      * The basic test bean for each test.
      */
     protected DynaBean bean;
-
-    /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public BasicDynaBeanTestCase(final String name) {
-        super(name);
-    }
 
     /**
      * Create and return a {@code DynaClass} instance for our test {@code DynaBean}.
@@ -80,7 +80,7 @@ public class BasicDynaBeanTestCase extends TestCase {
     /**
      * Sets up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         // Instantiate a new DynaBean instance
         final DynaClass dynaClass = createDynaClass();
@@ -123,7 +123,7 @@ public class BasicDynaBeanTestCase extends TestCase {
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     public void tearDown() {
 
         bean = null;
@@ -133,6 +133,7 @@ public class BasicDynaBeanTestCase extends TestCase {
     /**
      * Corner cases on getDynaProperty invalid arguments.
      */
+    @Test
     public void testGetDescriptorArguments() {
         assertNull(bean.getDynaClass().getDynaProperty("unknown"));
         assertThrows(NullPointerException.class, () -> bean.getDynaClass().getDynaProperty(null));
@@ -146,13 +147,14 @@ public class BasicDynaBeanTestCase extends TestCase {
      */
     protected void testGetDescriptorBase(final String name, final Class<?> type) {
         final DynaProperty descriptor = bean.getDynaClass().getDynaProperty(name);
-        assertNotNull("Got descriptor", descriptor);
-        assertEquals("Got correct type", type, descriptor.getType());
+        assertNotNull(descriptor, "Got descriptor");
+        assertEquals(type, descriptor.getType(), "Got correct type");
     }
 
     /**
      * Positive getDynaProperty on property {@code booleanProperty}.
      */
+    @Test
     public void testGetDescriptorBoolean() {
         testGetDescriptorBase("booleanProperty", Boolean.TYPE);
     }
@@ -160,6 +162,7 @@ public class BasicDynaBeanTestCase extends TestCase {
     /**
      * Positive getDynaProperty on property {@code doubleProperty}.
      */
+    @Test
     public void testGetDescriptorDouble() {
         testGetDescriptorBase("doubleProperty", Double.TYPE);
     }
@@ -167,6 +170,7 @@ public class BasicDynaBeanTestCase extends TestCase {
     /**
      * Positive getDynaProperty on property {@code floatProperty}.
      */
+    @Test
     public void testGetDescriptorFloat() {
         testGetDescriptorBase("floatProperty", Float.TYPE);
     }
@@ -174,6 +178,7 @@ public class BasicDynaBeanTestCase extends TestCase {
     /**
      * Positive getDynaProperty on property {@code intProperty}.
      */
+    @Test
     public void testGetDescriptorInt() {
         testGetDescriptorBase("intProperty", Integer.TYPE);
     }
@@ -181,6 +186,7 @@ public class BasicDynaBeanTestCase extends TestCase {
     /**
      * Positive getDynaProperty on property {@code longProperty}.
      */
+    @Test
     public void testGetDescriptorLong() {
         testGetDescriptorBase("longProperty", Long.TYPE);
     }
@@ -188,9 +194,10 @@ public class BasicDynaBeanTestCase extends TestCase {
     /**
      * Positive test for getDynaProperties(). Each property name listed in {@code properties} should be returned exactly once.
      */
+    @Test
     public void testGetDescriptors() {
         final DynaProperty[] pd = bean.getDynaClass().getDynaProperties();
-        assertNotNull("Got descriptors", pd);
+        assertNotNull(pd, "Got descriptors");
         final int[] count = new int[properties.length];
         for (final DynaProperty element : pd) {
             final String name = element.getName();
@@ -212,6 +219,7 @@ public class BasicDynaBeanTestCase extends TestCase {
     /**
      * Positive getDynaProperty on property {@code booleanSecond} that uses an "is" method as the getter.
      */
+    @Test
     public void testGetDescriptorSecond() {
         testGetDescriptorBase("booleanSecond", Boolean.TYPE);
     }
@@ -219,6 +227,7 @@ public class BasicDynaBeanTestCase extends TestCase {
     /**
      * Positive getDynaProperty on property {@code shortProperty}.
      */
+    @Test
     public void testGetDescriptorShort() {
         testGetDescriptorBase("shortProperty", Short.TYPE);
     }
@@ -226,6 +235,7 @@ public class BasicDynaBeanTestCase extends TestCase {
     /**
      * Positive getDynaProperty on property {@code stringProperty}.
      */
+    @Test
     public void testGetDescriptorString() {
         testGetDescriptorBase("stringProperty", String.class);
     }
@@ -233,6 +243,7 @@ public class BasicDynaBeanTestCase extends TestCase {
     /**
      * Corner cases on getIndexedProperty invalid arguments.
      */
+    @Test
     public void testGetIndexedArguments() {
         assertThrows(IndexOutOfBoundsException.class, () -> bean.get("intArray", -1));
     }
@@ -240,56 +251,60 @@ public class BasicDynaBeanTestCase extends TestCase {
     /**
      * Positive and negative tests on getIndexedProperty valid arguments.
      */
+    @Test
     public void testGetIndexedValues() {
         Object value = null;
         for (int i = 0; i < 5; i++) {
             value = bean.get("intArray", i);
-            assertNotNull("intArray returned value " + i, value);
-            assertTrue("intArray returned Integer " + i, value instanceof Integer);
-            assertEquals("intArray returned correct " + i, i * 10, ((Integer) value).intValue());
+            assertNotNull(value, "intArray returned value " + i);
+            assertInstanceOf(Integer.class, value, "intArray returned Integer " + i);
+            assertEquals(i * 10, ((Integer) value).intValue(), "intArray returned correct " + i);
             value = bean.get("intIndexed", i);
-            assertNotNull("intIndexed returned value " + i, value);
-            assertTrue("intIndexed returned Integer " + i, value instanceof Integer);
-            assertEquals("intIndexed returned correct " + i, i * 10, ((Integer) value).intValue());
+            assertNotNull(value, "intIndexed returned value " + i);
+            assertInstanceOf(Integer.class, value, "intIndexed returned Integer " + i);
+            assertEquals(i * 10, ((Integer) value).intValue(), "intIndexed returned correct " + i);
             value = bean.get("listIndexed", i);
-            assertNotNull("listIndexed returned value " + i, value);
-            assertTrue("list returned String " + i, value instanceof String);
-            assertEquals("listIndexed returned correct " + i, "String " + i, (String) value);
+            assertNotNull(value, "listIndexed returned value " + i);
+            assertInstanceOf(String.class, value, "list returned String " + i);
+            assertEquals("String " + i, (String) value, "listIndexed returned correct " + i);
             value = bean.get("stringArray", i);
-            assertNotNull("stringArray returned value " + i, value);
-            assertTrue("stringArray returned String " + i, value instanceof String);
-            assertEquals("stringArray returned correct " + i, "String " + i, (String) value);
+            assertNotNull(value, "stringArray returned value " + i);
+            assertInstanceOf(String.class, value, "stringArray returned String " + i);
+            assertEquals("String " + i, (String) value, "stringArray returned correct " + i);
             value = bean.get("stringIndexed", i);
-            assertNotNull("stringIndexed returned value " + i, value);
-            assertTrue("stringIndexed returned String " + i, value instanceof String);
-            assertEquals("stringIndexed returned correct " + i, "String " + i, (String) value);
+            assertNotNull(value, "stringIndexed returned value " + i);
+            assertInstanceOf(String.class, value, "stringIndexed returned String " + i);
+            assertEquals("String " + i, (String) value, "stringIndexed returned correct " + i);
         }
     }
 
     /**
      * Corner cases on getMappedProperty invalid arguments.
      */
+    @Test
     public void testGetMappedArguments() {
         final Object value = bean.get("mappedProperty", "unknown");
-        assertNull("Should not return a value", value);
+        assertNull(value, "Should not return a value");
     }
 
     /**
      * Positive and negative tests on getMappedProperty valid arguments.
      */
+    @Test
     public void testGetMappedValues() {
         Object value = null;
         value = bean.get("mappedProperty", "First Key");
-        assertEquals("Can find first value", "First Value", value);
+        assertEquals("First Value", value, "Can find first value");
         value = bean.get("mappedProperty", "Second Key");
-        assertEquals("Can find second value", "Second Value", value);
+        assertEquals("Second Value", value, "Can find second value");
         value = bean.get("mappedProperty", "Third Key");
-        assertNull("Can not find third value", value);
+        assertNull(value, "Can not find third value");
     }
 
     /**
      * Corner cases on getSimpleProperty invalid arguments.
      */
+    @Test
     public void testGetSimpleArguments() {
         assertThrows(NullPointerException.class, () -> bean.get(null));
     }
@@ -297,91 +312,100 @@ public class BasicDynaBeanTestCase extends TestCase {
     /**
      * Test getSimpleProperty on a boolean property.
      */
+    @Test
     public void testGetSimpleBoolean() {
         final Object value = bean.get("booleanProperty");
-        assertNotNull("Got a value", value);
-        assertTrue("Got correct type", value instanceof Boolean);
-        assertTrue("Got correct value", (Boolean) value);
+        assertNotNull(value, "Got a value");
+        assertInstanceOf(Boolean.class, value, "Got correct type");
+        assertTrue((Boolean) value, "Got correct value");
     }
 
     /**
      * Test getSimpleProperty on a double property.
      */
+    @Test
     public void testGetSimpleDouble() {
         final Object value = bean.get("doubleProperty");
-        assertNotNull("Got a value", value);
-        assertTrue("Got correct type", value instanceof Double);
-        assertEquals("Got correct value", ((Double) value).doubleValue(), 321.0, 0.005);
+        assertNotNull(value, "Got a value");
+        assertInstanceOf(Double.class, value, "Got correct type");
+        assertEquals(((Double) value).doubleValue(), 321.0, 0.005, "Got correct value");
     }
 
     /**
      * Test getSimpleProperty on a float property.
      */
+    @Test
     public void testGetSimpleFloat() {
         final Object value = bean.get("floatProperty");
-        assertNotNull("Got a value", value);
-        assertTrue("Got correct type", value instanceof Float);
-        assertEquals("Got correct value", ((Float) value).floatValue(), (float) 123.0, (float) 0.005);
+        assertNotNull(value, "Got a value");
+        assertInstanceOf(Float.class, value, "Got correct type");
+        assertEquals(((Float) value).floatValue(), (float) 123.0, (float) 0.005, "Got correct value");
     }
 
     /**
      * Test getSimpleProperty on a int property.
      */
+    @Test
     public void testGetSimpleInt() {
         final Object value = bean.get("intProperty");
-        assertNotNull("Got a value", value);
-        assertTrue("Got correct type", value instanceof Integer);
-        assertEquals("Got correct value", ((Integer) value).intValue(), 123);
+        assertNotNull(value, "Got a value");
+        assertInstanceOf(Integer.class, value, "Got correct type");
+        assertEquals(((Integer) value).intValue(), 123, "Got correct value");
     }
 
     /**
      * Test getSimpleProperty on a long property.
      */
+    @Test
     public void testGetSimpleLong() {
         final Object value = bean.get("longProperty");
-        assertNotNull("Got a value", value);
-        assertTrue("Got correct type", value instanceof Long);
-        assertEquals("Got correct value", ((Long) value).longValue(), 321);
+        assertNotNull(value, "Got a value");
+        assertInstanceOf(Long.class, value, "Got correct type");
+        assertEquals(((Long) value).longValue(), 321, "Got correct value");
     }
 
     /**
      * Test getSimpleProperty on a short property.
      */
+    @Test
     public void testGetSimpleShort() {
         final Object value = bean.get("shortProperty");
-        assertNotNull("Got a value", value);
-        assertTrue("Got correct type", value instanceof Short);
-        assertEquals("Got correct value", ((Short) value).shortValue(), (short) 987);
+        assertNotNull(value, "Got a value");
+        assertInstanceOf(Short.class, value, "Got correct type");
+        assertEquals(((Short) value).shortValue(), (short) 987, "Got correct value");
     }
 
     /**
      * Test getSimpleProperty on a String property.
      */
+    @Test
     public void testGetSimpleString() {
         final Object value = bean.get("stringProperty");
-        assertNotNull("Got a value", value);
-        assertTrue("Got correct type", value instanceof String);
-        assertEquals("Got correct value", (String) value, "This is a string");
+        assertNotNull(value, "Got a value");
+        assertInstanceOf(String.class, value, "Got correct type");
+        assertEquals((String) value, "This is a string", "Got correct value");
     }
 
     /**
      * Test {@code contains()} method for mapped properties.
      */
+    @Test
     public void testMappedContains() {
-        assertTrue("Can see first key", bean.contains("mappedProperty", "First Key"));
-        assertTrue("Can not see unknown key", !bean.contains("mappedProperty", "Unknown Key"));
+        assertTrue(bean.contains("mappedProperty", "First Key"), "Can see first key");
+        assertFalse(bean.contains("mappedProperty", "Unknown Key"), "Can not see unknown key");
     }
 
     /**
      * Test {@code remove()} method for mapped properties.
      */
+    @Test
     public void testMappedRemove() {
-        assertTrue("Can see first key", bean.contains("mappedProperty", "First Key"));
+        assertTrue(bean.contains("mappedProperty", "First Key"), "Can see first key");
         bean.remove("mappedProperty", "First Key");
-        assertTrue("Can not see first key", !bean.contains("mappedProperty", "First Key"));
-        assertTrue("Can not see unknown key", !bean.contains("mappedProperty", "Unknown Key"));
+        assertFalse(bean.contains("mappedProperty", "First Key"), "Can not see first key");
+        assertFalse(bean.contains("mappedProperty", "Unknown Key"), "Can not see unknown key");
         bean.remove("mappedProperty", "Unknown Key");
-        assertTrue("Can not see unknown key", !bean.contains("mappedProperty", "Unknown Key"));
+        assertFalse(bean.contains("mappedProperty", "Unknown Key"), "Can not see unknown key");
     }
 
     /**
@@ -391,6 +415,7 @@ public class BasicDynaBeanTestCase extends TestCase {
      * @throws IllegalAccessException
      * @throws IOException
      */
+    @Test
     public void testSerialization() throws Exception {
         // Serialize the test bean
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -447,6 +472,7 @@ public class BasicDynaBeanTestCase extends TestCase {
     /**
      * Corner cases on setIndexedProperty invalid arguments.
      */
+    @Test
     public void testSetIndexedArguments() {
         assertThrows(IndexOutOfBoundsException.class, () -> bean.set("intArray", -1, Integer.valueOf(0)));
     }
@@ -454,113 +480,125 @@ public class BasicDynaBeanTestCase extends TestCase {
     /**
      * Positive and negative tests on setIndexedProperty valid arguments.
      */
+    @Test
     public void testSetIndexedValues() {
         Object value = null;
         bean.set("intArray", 0, Integer.valueOf(1));
         value = bean.get("intArray", 0);
-        assertNotNull("Returned new value 0", value);
-        assertTrue("Returned Integer new value 0", value instanceof Integer);
-        assertEquals("Returned correct new value 0", 1, ((Integer) value).intValue());
+        assertNotNull(value, "Returned new value 0");
+        assertInstanceOf(Integer.class, value, "Returned Integer new value 0");
+        assertEquals(1, ((Integer) value).intValue(), "Returned correct new value 0");
         bean.set("intIndexed", 1, Integer.valueOf(11));
         value = bean.get("intIndexed", 1);
-        assertNotNull("Returned new value 1", value);
-        assertTrue("Returned Integer new value 1", value instanceof Integer);
-        assertEquals("Returned correct new value 1", 11, ((Integer) value).intValue());
+        assertNotNull(value, "Returned new value 1");
+        assertInstanceOf(Integer.class, value, "Returned Integer new value 1");
+        assertEquals(11, ((Integer) value).intValue(), "Returned correct new value 1");
         bean.set("listIndexed", 2, "New Value 2");
         value = bean.get("listIndexed", 2);
-        assertNotNull("Returned new value 2", value);
-        assertTrue("Returned String new value 2", value instanceof String);
-        assertEquals("Returned correct new value 2", "New Value 2", (String) value);
+        assertNotNull(value, "Returned new value 2");
+        assertInstanceOf(String.class, value, "Returned String new value 2");
+        assertEquals("New Value 2", (String) value, "Returned correct new value 2");
         bean.set("stringArray", 3, "New Value 3");
         value = bean.get("stringArray", 3);
-        assertNotNull("Returned new value 3", value);
-        assertTrue("Returned String new value 3", value instanceof String);
-        assertEquals("Returned correct new value 3", "New Value 3", (String) value);
+        assertNotNull(value, "Returned new value 3");
+        assertInstanceOf(String.class, value, "Returned String new value 3");
+        assertEquals("New Value 3", (String) value, "Returned correct new value 3");
         bean.set("stringIndexed", 4, "New Value 4");
         value = bean.get("stringIndexed", 4);
-        assertNotNull("Returned new value 4", value);
-        assertTrue("Returned String new value 4", value instanceof String);
-        assertEquals("Returned correct new value 4", "New Value 4", (String) value);
+        assertNotNull(value, "Returned new value 4");
+        assertInstanceOf(String.class, value, "Returned String new value 4");
+        assertEquals("New Value 4", (String) value, "Returned correct new value 4");
     }
 
     /**
      * Positive and negative tests on setMappedProperty valid arguments.
      */
+    @Test
     public void testSetMappedValues() {
         bean.set("mappedProperty", "First Key", "New First Value");
-        assertEquals("Can replace old value", "New First Value", (String) bean.get("mappedProperty", "First Key"));
+        assertEquals("New First Value", (String) bean.get("mappedProperty", "First Key"),
+                                "Can replace old value");
         bean.set("mappedProperty", "Fourth Key", "Fourth Value");
-        assertEquals("Can set new value", "Fourth Value", (String) bean.get("mappedProperty", "Fourth Key"));
+        assertEquals("Fourth Value", (String) bean.get("mappedProperty", "Fourth Key"), "Can set new value");
     }
 
     /**
      * Test setSimpleProperty on a boolean property.
      */
+    @Test
     public void testSetSimpleBoolean() {
         final boolean oldValue = ((Boolean) bean.get("booleanProperty")).booleanValue();
         final boolean newValue = !oldValue;
         bean.set("booleanProperty", Boolean.valueOf(newValue));
-        assertEquals("Matched new value", newValue, ((Boolean) bean.get("booleanProperty")).booleanValue());
+        assertEquals(newValue, ((Boolean) bean.get("booleanProperty")).booleanValue(), "Matched new value");
     }
 
     /**
      * Test setSimpleProperty on a double property.
      */
+    @Test
     public void testSetSimpleDouble() {
         final double oldValue = ((Double) bean.get("doubleProperty")).doubleValue();
         final double newValue = oldValue + 1.0;
         bean.set("doubleProperty", Double.valueOf(newValue));
-        assertEquals("Matched new value", newValue, ((Double) bean.get("doubleProperty")).doubleValue(), 0.005);
+        assertEquals(newValue, ((Double) bean.get("doubleProperty")).doubleValue(), 0.005,
+                                "Matched new value");
     }
 
     /**
      * Test setSimpleProperty on a float property.
      */
+    @Test
     public void testSetSimpleFloat() {
         final float oldValue = ((Float) bean.get("floatProperty")).floatValue();
         final float newValue = oldValue + (float) 1.0;
         bean.set("floatProperty", Float.valueOf(newValue));
-        assertEquals("Matched new value", newValue, ((Float) bean.get("floatProperty")).floatValue(), (float) 0.005);
+        assertEquals(newValue, ((Float) bean.get("floatProperty")).floatValue(), (float) 0.005,
+                                "Matched new value");
     }
 
     /**
      * Test setSimpleProperty on a int property.
      */
+    @Test
     public void testSetSimpleInt() {
         final int oldValue = ((Integer) bean.get("intProperty")).intValue();
         final int newValue = oldValue + 1;
         bean.set("intProperty", Integer.valueOf(newValue));
-        assertEquals("Matched new value", newValue, ((Integer) bean.get("intProperty")).intValue());
+        assertEquals(newValue, ((Integer) bean.get("intProperty")).intValue(), "Matched new value");
     }
 
     /**
      * Test setSimpleProperty on a long property.
      */
+    @Test
     public void testSetSimpleLong() {
         final long oldValue = ((Long) bean.get("longProperty")).longValue();
         final long newValue = oldValue + 1;
         bean.set("longProperty", Long.valueOf(newValue));
-        assertEquals("Matched new value", newValue, ((Long) bean.get("longProperty")).longValue());
+        assertEquals(newValue, ((Long) bean.get("longProperty")).longValue(), "Matched new value");
     }
 
     /**
      * Test setSimpleProperty on a short property.
      */
+    @Test
     public void testSetSimpleShort() {
         final short oldValue = ((Short) bean.get("shortProperty")).shortValue();
         final short newValue = (short) (oldValue + 1);
         bean.set("shortProperty", Short.valueOf(newValue));
-        assertEquals("Matched new value", newValue, ((Short) bean.get("shortProperty")).shortValue());
+        assertEquals(newValue, ((Short) bean.get("shortProperty")).shortValue(), "Matched new value");
     }
 
     /**
      * Test setSimpleProperty on a String property.
      */
+    @Test
     public void testSetSimpleString() {
         final String oldValue = (String) bean.get("stringProperty");
         final String newValue = oldValue + " Extra Value";
         bean.set("stringProperty", newValue);
-        assertEquals("Matched new value", newValue, (String) bean.get("stringProperty"));
+        assertEquals(newValue, (String) bean.get("stringProperty"), "Matched new value");
     }
 
 }

--- a/src/test/java/org/apache/commons/beanutils2/BeanComparatorTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/BeanComparatorTestCase.java
@@ -17,12 +17,18 @@
 
 package org.apache.commons.beanutils2;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Case for the BeanComparator class.
  */
-public class BeanComparatorTestCase extends TestCase {
+public class BeanComparatorTestCase {
 
     /**
      * The test beans for each test.
@@ -33,18 +39,9 @@ public class BeanComparatorTestCase extends TestCase {
     protected AlphaBean alphaBean2;
 
     /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public BeanComparatorTestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Sets up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     public void setUp() {
         bean = new TestBean();
         alphaBean1 = new AlphaBean("alphaBean1");
@@ -54,7 +51,7 @@ public class BeanComparatorTestCase extends TestCase {
     /**
      * Tears down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     public void tearDown() {
         bean = null;
         alphaBean1 = null;
@@ -64,26 +61,29 @@ public class BeanComparatorTestCase extends TestCase {
     /**
      * Tests comparing one bean against itself.
      */
+    @Test
     public void testCompareBeanAgainstSelf() {
         final BeanComparator<AlphaBean, String> beanComparator = new BeanComparator<>("name");
         final int result = beanComparator.compare(alphaBean1, alphaBean1);
-        assertEquals("Comparator did not sort properly.  Result:" + result, 0, result);
+        assertEquals(0, result, () -> "Comparator did not sort properly.  Result:" + result);
     }
 
     /**
      * Tests comparing two beans via their name using the default Comparator where they have the same value.
      */
+    @Test
     public void testCompareIdentical() {
         alphaBean1 = new AlphaBean("alphabean");
         alphaBean2 = new AlphaBean("alphabean");
         final BeanComparator<AlphaBean, String> beanComparator = new BeanComparator<>("name");
         final int result = beanComparator.compare(alphaBean1, alphaBean2);
-        assertEquals("Comparator did not sort properly.  Result:" + result, 0, result);
+        assertEquals(0, result, () -> "Comparator did not sort properly.  Result:" + result);
     }
 
     /**
      * Tests comparing two beans on a boolean property, which is not possible.
      */
+    @Test
     public void testCompareOnBooleanProperty() {
         try {
             final TestBean testBeanA = new TestBean();
@@ -107,6 +107,7 @@ public class BeanComparatorTestCase extends TestCase {
     /**
      * Tests comparing two beans who don't have a property
      */
+    @Test
     public void testCompareOnMissingProperty() {
         try {
             final BeanComparator<AlphaBean, String> beanComparator = new BeanComparator<>("bogusName");
@@ -114,13 +115,14 @@ public class BeanComparatorTestCase extends TestCase {
             fail("should not be able to compare");
 
         } catch (final Exception e) {
-            assertTrue("Wrong exception was thrown: " + e, e.toString().contains("Unknown property"));
+            assertTrue(e.toString().contains("Unknown property"), () -> "Wrong exception was thrown: " + e);
         }
     }
 
     /**
      * Tests comparing two beans via their name using the default Comparator, but with one of the beans being null.
      */
+    @Test
     public void testCompareWithNulls() {
         try {
             final BeanComparator<AlphaBean, String> beanComparator = new BeanComparator<>("name");
@@ -135,6 +137,7 @@ public class BeanComparatorTestCase extends TestCase {
     /**
      * Tests comparing two beans on a boolean property, then changing the property and testing/
      */
+    @Test
     public void testSetProperty() {
         final TestBean testBeanA = new TestBean();
         final TestBean testBeanB = new TestBean();
@@ -143,35 +146,37 @@ public class BeanComparatorTestCase extends TestCase {
         testBeanB.setDoubleProperty(1.0);
 
         final BeanComparator<TestBean, String> beanComparator = new BeanComparator<>("doubleProperty");
-        int result = beanComparator.compare(testBeanA, testBeanB);
+        final int result1 = beanComparator.compare(testBeanA, testBeanB);
 
-        assertEquals("Comparator did not sort properly.  Result:" + result, 1, result);
+        assertEquals(1, result1, () -> "Comparator did not sort properly.  Result:" + result1);
 
         testBeanA.setStringProperty("string 1");
         testBeanB.setStringProperty("string 2");
 
         beanComparator.setProperty("stringProperty");
 
-        result = beanComparator.compare(testBeanA, testBeanB);
+        final int result2 = beanComparator.compare(testBeanA, testBeanB);
 
-        assertEquals("Comparator did not sort properly.  Result:" + result, -1, result);
+        assertEquals(-1, result2, () -> "Comparator did not sort properly.  Result:" + result2);
     }
 
     /**
      * Tests comparing two beans via their name using the default Comparator
      */
+    @Test
     public void testSimpleCompare() {
         final BeanComparator<AlphaBean, String> beanComparator = new BeanComparator<>("name");
         final int result = beanComparator.compare(alphaBean1, alphaBean2);
-        assertEquals("Comparator did not sort properly.  Result:" + result, -1, result);
+        assertEquals(-1, result, () -> "Comparator did not sort properly.  Result:" + result);
     }
 
     /**
      * Tests comparing two beans via their name using the default Comparator, but the inverse
      */
+    @Test
     public void testSimpleCompareInverse() {
         final BeanComparator<AlphaBean, String> beanComparator = new BeanComparator<>("name");
         final int result = beanComparator.compare(alphaBean2, alphaBean1);
-        assertEquals("Comparator did not sort properly.  Result:" + result, 1, result);
+        assertEquals(1, result, () -> "Comparator did not sort properly.  Result:" + result);
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/BeanIntrospectionDataTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/BeanIntrospectionDataTestCase.java
@@ -16,17 +16,21 @@
  */
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for {@code BeanIntrospectionData}.
  */
-public class BeanIntrospectionDataTestCase extends TestCase {
+public class BeanIntrospectionDataTestCase {
     /** Constant for the test bean class. */
     private static final Class<?> BEAN_CLASS = FluentIntrospectionTestBean.class;
 
@@ -67,16 +71,18 @@ public class BeanIntrospectionDataTestCase extends TestCase {
     /**
      * Tests whether a write method can be queried if it is defined in the descriptor.
      */
+    @Test
     public void testGetWriteMethodDefined() {
         final BeanIntrospectionData data = setUpData();
         final PropertyDescriptor pd = fetchTestDescriptor(data);
-        assertNotNull("No write method", pd.getWriteMethod());
-        assertEquals("Wrong write method", pd.getWriteMethod(), data.getWriteMethod(BEAN_CLASS, pd));
+        assertNotNull(pd.getWriteMethod(), "No write method");
+        assertEquals(pd.getWriteMethod(), data.getWriteMethod(BEAN_CLASS, pd), "Wrong write method");
     }
 
     /**
      * Tests getWriteMethod() if the method cannot be resolved. (This is a corner case which should normally not happen in practice.)
      */
+    @Test
     public void testGetWriteMethodNonExisting() throws Exception {
         final PropertyDescriptor pd = new PropertyDescriptor(TEST_PROP, BEAN_CLASS.getMethod("getFluentGetProperty"),
                 BEAN_CLASS.getMethod("setFluentGetProperty", String.class));
@@ -84,27 +90,29 @@ public class BeanIntrospectionDataTestCase extends TestCase {
         methods.put(TEST_PROP, "hashCode");
         final BeanIntrospectionData data = new BeanIntrospectionData(new PropertyDescriptor[] { pd }, methods);
         pd.setWriteMethod(null);
-        assertNull("Got a write method", data.getWriteMethod(BEAN_CLASS, pd));
+        assertNull(data.getWriteMethod(BEAN_CLASS, pd), "Got a write method");
     }
 
     /**
      * Tests whether a write method can be queried that is currently not available in the property descriptor.
      */
+    @Test
     public void testGetWriteMethodUndefined() throws Exception {
         final BeanIntrospectionData data = setUpData();
         final PropertyDescriptor pd = fetchTestDescriptor(data);
         final Method writeMethod = pd.getWriteMethod();
         pd.setWriteMethod(null);
-        assertEquals("Wrong write method", writeMethod, data.getWriteMethod(BEAN_CLASS, pd));
-        assertEquals("Method not set in descriptor", writeMethod, pd.getWriteMethod());
+        assertEquals(writeMethod, data.getWriteMethod(BEAN_CLASS, pd), "Wrong write method");
+        assertEquals(writeMethod, pd.getWriteMethod(), "Method not set in descriptor");
     }
 
     /**
      * Tests getWriteMethod() for a property for which no write method is known.
      */
+    @Test
     public void testGetWriteMethodUnknown() {
         final BeanIntrospectionData data = setUpData();
         final PropertyDescriptor pd = data.getDescriptor("class");
-        assertNull("Got a write method", data.getWriteMethod(BEAN_CLASS, pd));
+        assertNull(data.getWriteMethod(BEAN_CLASS, pd), "Got a write method");
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/BeanPredicateTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/BeanPredicateTestCase.java
@@ -17,26 +17,27 @@
 
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.function.Predicate;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit test for {@link BeanPredicate}
  */
-public class BeanPredicateTestCase extends TestCase {
+public class BeanPredicateTestCase {
 
-    public BeanPredicateTestCase(final String name) {
-        super(name);
-    }
-
+    @Test
     public void testEqual() {
         final Predicate<String> p = s -> s.equals("foo");
         final BeanPredicate<String> predicate = new BeanPredicate<>("stringProperty", p);
         assertTrue(predicate.test(new TestBean("foo")));
-        assertTrue(!predicate.test(new TestBean("bar")));
+        assertFalse(predicate.test(new TestBean("bar")));
     }
 
+    @Test
     public void testInstanceOf() {
         final Predicate<String> p = String.class::isInstance;
         final BeanPredicate<String> predicate = new BeanPredicate<>("stringProperty", p);
@@ -44,19 +45,21 @@ public class BeanPredicateTestCase extends TestCase {
         assertTrue(predicate.test(new TestBean("bar")));
     }
 
+    @Test
     public void testNotEqual() {
         final Predicate<String> p = s -> !s.equals("foo");
         final BeanPredicate<String> predicate = new BeanPredicate<>("stringProperty", p);
-        assertTrue(!predicate.test(new TestBean("foo")));
+        assertFalse(predicate.test(new TestBean("foo")));
         assertTrue(predicate.test(new TestBean("bar")));
     }
 
+    @Test
     public void testNull() {
         final Predicate<String> p = s -> s == null;
         final BeanPredicate<String> predicate = new BeanPredicate<>("stringProperty", p);
         final String nullString = null;
         assertTrue(predicate.test(new TestBean(nullString)));
-        assertTrue(!predicate.test(new TestBean("bar")));
+        assertFalse(predicate.test(new TestBean("bar")));
     }
 
 }

--- a/src/test/java/org/apache/commons/beanutils2/BeanPropertyValueChangeConsumerTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/BeanPropertyValueChangeConsumerTestCase.java
@@ -17,14 +17,17 @@
 
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for {@code BeanPropertyValueChangeClosure}.
  */
-public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
+public class BeanPropertyValueChangeConsumerTestCase {
 
     private static final Integer expectedIntegerValue = Integer.valueOf(123);
     private static final Float expectedFloatValue = Float.valueOf(123.123f);
@@ -33,17 +36,9 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     private static final Byte expectedByteValue = Byte.valueOf("12");
 
     /**
-     * Constructor for BeanPropertyValueChangeClosureTest.
-     *
-     * @param name Name of this test case.
-     */
-    public BeanPropertyValueChangeConsumerTestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Test execute with indexed property.
      */
+    @Test
     public void testExecuteWithIndexedProperty() {
         final TestBean testBean = new TestBean();
         new BeanPropertyValueChangeConsumer<>("intIndexed[0]", expectedIntegerValue).accept(testBean);
@@ -53,6 +48,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with an invalid property name.
      */
+    @Test
     public void testExecuteWithInvalidPropertyName() {
         try {
             new BeanPropertyValueChangeConsumer<>("bogusProperty", "foo").accept(new TestBean());
@@ -65,6 +61,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with mapped property.
      */
+    @Test
     public void testExecuteWithMappedProperty() {
         final TestBean testBean = new TestBean();
         new BeanPropertyValueChangeConsumer<>("mappedProperty(fred)", "barney").accept(testBean);
@@ -74,6 +71,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with a nested property.
      */
+    @Test
     public void testExecuteWithNestedProperty() {
         final TestBean testBean = new TestBean();
         new BeanPropertyValueChangeConsumer<>("nested.stringProperty", "bar").accept(testBean);
@@ -83,6 +81,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with a nested property and null in the property path.
      */
+    @Test
     public void testExecuteWithNullInPropertyPath() {
         try {
             new BeanPropertyValueChangeConsumer<>("anotherNested.stringProperty", "foo").accept(new TestBean());
@@ -95,6 +94,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with a nested property and null in the property path and ignoreNull = true.
      */
+    @Test
     public void testExecuteWithNullInPropertyPathAngIgnoreTrue() {
         final TestBean testBean = new TestBean();
 
@@ -112,6 +112,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with read only property.
      */
+    @Test
     public void testExecuteWithReadOnlyProperty() {
         try {
             new BeanPropertyValueChangeConsumer<>("readOnlyProperty", "foo").accept(new TestBean());
@@ -124,6 +125,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with simple boolean property and Boolean value.
      */
+    @Test
     public void testExecuteWithSimpleBooleanPropertyAndBooleanValue() {
         final TestBean testBean = new TestBean();
         new BeanPropertyValueChangeConsumer<>("booleanProperty", expectedBooleanValue).accept(testBean);
@@ -133,6 +135,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with simple boolean property and String value.
      */
+    @Test
     public void testExecuteWithSimpleBooleanPropertyAndStringValue() {
         try {
             new BeanPropertyValueChangeConsumer<>("booleanProperty", "true").accept(new TestBean());
@@ -145,6 +148,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with simple byte property and Byte value.
      */
+    @Test
     public void testExecuteWithSimpleBytePropertyAndByteValue() {
         final TestBean testBean = new TestBean();
         new BeanPropertyValueChangeConsumer<>("byteProperty", expectedByteValue).accept(testBean);
@@ -154,6 +158,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with simple boolean property and String value.
      */
+    @Test
     public void testExecuteWithSimpleBytePropertyAndStringValue() {
         assertThrows(IllegalArgumentException.class, () -> new BeanPropertyValueChangeConsumer<>("byteProperty", "foo").accept(new TestBean()));
     }
@@ -161,6 +166,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with simple double property and Double value.
      */
+    @Test
     public void testExecuteWithSimpleDoublePropertyAndDoubleValue() {
         final TestBean testBean = new TestBean();
         new BeanPropertyValueChangeConsumer<>("doubleProperty", expectedDoubleValue).accept(testBean);
@@ -170,6 +176,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with simple double property and Float value.
      */
+    @Test
     public void testExecuteWithSimpleDoublePropertyAndFloatValue() {
         final TestBean testBean = new TestBean();
         new BeanPropertyValueChangeConsumer<>("doubleProperty", expectedFloatValue).accept(testBean);
@@ -179,6 +186,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with simple double property and Integer value.
      */
+    @Test
     public void testExecuteWithSimpleDoublePropertyAndIntegerValue() {
         final TestBean testBean = new TestBean();
         new BeanPropertyValueChangeConsumer<>("doubleProperty", expectedIntegerValue).accept(testBean);
@@ -188,6 +196,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with simple double property and String value.
      */
+    @Test
     public void testExecuteWithSimpleDoublePropertyAndStringValue() {
         try {
             new BeanPropertyValueChangeConsumer<>("doubleProperty", "123").accept(new TestBean());
@@ -200,6 +209,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with simple float property and Double value.
      */
+    @Test
     public void testExecuteWithSimpleFloatPropertyAndDoubleValue() {
         try {
             new BeanPropertyValueChangeConsumer<>("floatProperty", expectedDoubleValue).accept(new TestBean());
@@ -212,6 +222,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with simple float property and Float value.
      */
+    @Test
     public void testExecuteWithSimpleFloatPropertyAndFloatValue() {
         final TestBean testBean = new TestBean();
         new BeanPropertyValueChangeConsumer<>("floatProperty", expectedFloatValue).accept(testBean);
@@ -221,6 +232,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with simple float property and Integer value.
      */
+    @Test
     public void testExecuteWithSimpleFloatPropertyAndIntegerValue() {
         final TestBean testBean = new TestBean();
         new BeanPropertyValueChangeConsumer<>("floatProperty", expectedIntegerValue).accept(testBean);
@@ -230,6 +242,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with simple float property and String value.
      */
+    @Test
     public void testExecuteWithSimpleFloatPropertyAndStringValue() {
         try {
             new BeanPropertyValueChangeConsumer<>("floatProperty", "123").accept(new TestBean());
@@ -242,6 +255,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with simple int property and Double value.
      */
+    @Test
     public void testExecuteWithSimpleIntPropertyAndDoubleValue() {
         try {
             new BeanPropertyValueChangeConsumer<>("intProperty", expectedDoubleValue).accept(new TestBean());
@@ -254,6 +268,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with simple int property and Float value.
      */
+    @Test
     public void testExecuteWithSimpleIntPropertyAndFloatValue() {
         try {
             new BeanPropertyValueChangeConsumer<>("intProperty", expectedFloatValue).accept(new TestBean());
@@ -266,6 +281,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with simple int property and Integer value.
      */
+    @Test
     public void testExecuteWithSimpleIntPropertyAndIntegerValue() {
         final TestBean testBean = new TestBean();
         new BeanPropertyValueChangeConsumer<>("intProperty", expectedIntegerValue).accept(testBean);
@@ -275,6 +291,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with simple int property and String value.
      */
+    @Test
     public void testExecuteWithSimpleIntPropertyAndStringValue() {
         try {
             new BeanPropertyValueChangeConsumer<>("intProperty", "123").accept(new TestBean());
@@ -287,6 +304,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with simple primitive property and null value.
      */
+    @Test
     public void testExecuteWithSimplePrimitivePropertyAndNullValue() {
         try {
             new BeanPropertyValueChangeConsumer<>("intProperty", null).accept(new TestBean());
@@ -299,6 +317,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with a simple String property.
      */
+    @Test
     public void testExecuteWithSimpleStringProperty() {
         final TestBean testBean = new TestBean();
         new BeanPropertyValueChangeConsumer<>("stringProperty", "barney").accept(testBean);
@@ -308,6 +327,7 @@ public class BeanPropertyValueChangeConsumerTestCase extends TestCase {
     /**
      * Test execute with write only property.
      */
+    @Test
     public void testExecuteWithWriteOnlyProperty() {
         final TestBean testBean = new TestBean();
         new BeanPropertyValueChangeConsumer<>("writeOnlyProperty", "foo").accept(testBean);

--- a/src/test/java/org/apache/commons/beanutils2/BeanPropertyValueEqualsPredicateTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/BeanPropertyValueEqualsPredicateTestCase.java
@@ -17,12 +17,16 @@
 
 package org.apache.commons.beanutils2;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for {@code BeanPropertyValueEqualsPredicateTest}.
  */
-public class BeanPropertyValueEqualsPredicateTestCase extends TestCase {
+public class BeanPropertyValueEqualsPredicateTestCase {
 
     private static final Integer expectedIntegerValue = Integer.valueOf(123);
     private static final Float expectedFloatValue = Float.valueOf(123.123f);
@@ -31,56 +35,52 @@ public class BeanPropertyValueEqualsPredicateTestCase extends TestCase {
     private static final Byte expectedByteValue = Byte.valueOf("12");
 
     /**
-     * Constructor for BeanPropertyValueEqualsPredicateTest.
-     *
-     * @param name Name of this test case.
-     */
-    public BeanPropertyValueEqualsPredicateTestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Test evaluate with boolean property.
      */
+    @Test
     public void testEvaluateWithBooleanProperty() {
         final BeanPropertyValueEqualsPredicate<TestBean, Boolean> predicate = new BeanPropertyValueEqualsPredicate<>("booleanProperty", expectedBooleanValue);
         assertTrue(predicate.test(new TestBean(expectedBooleanValue.booleanValue())));
-        assertTrue(!predicate.test(new TestBean(!expectedBooleanValue.booleanValue())));
+        assertFalse(predicate.test(new TestBean(!expectedBooleanValue.booleanValue())));
     }
 
     /**
      * Test evaluate with byte property.
      */
+    @Test
     public void testEvaluateWithByteProperty() {
         final BeanPropertyValueEqualsPredicate<TestBean, Byte> predicate = new BeanPropertyValueEqualsPredicate<>("byteProperty", expectedByteValue);
         final TestBean testBean = new TestBean();
         testBean.setByteProperty(expectedByteValue.byteValue());
         assertTrue(predicate.test(testBean));
         testBean.setByteProperty((byte) (expectedByteValue.byteValue() - 1));
-        assertTrue(!predicate.test(testBean));
+        assertFalse(predicate.test(testBean));
     }
 
     /**
      * Test evaluate with double property.
      */
+    @Test
     public void testEvaluateWithDoubleProperty() {
         final BeanPropertyValueEqualsPredicate<TestBean, Double> predicate = new BeanPropertyValueEqualsPredicate<>("doubleProperty", expectedDoubleValue);
         assertTrue(predicate.test(new TestBean(expectedDoubleValue.doubleValue())));
-        assertTrue(!predicate.test(new TestBean(expectedDoubleValue.doubleValue() - 1)));
+        assertFalse(predicate.test(new TestBean(expectedDoubleValue.doubleValue() - 1)));
     }
 
     /**
      * Test evaluate with float property.
      */
+    @Test
     public void testEvaluateWithFloatProperty() {
         final BeanPropertyValueEqualsPredicate<TestBean, Float> predicate = new BeanPropertyValueEqualsPredicate<>("floatProperty", expectedFloatValue);
         assertTrue(predicate.test(new TestBean(expectedFloatValue.floatValue())));
-        assertTrue(!predicate.test(new TestBean(expectedFloatValue.floatValue() - 1)));
+        assertFalse(predicate.test(new TestBean(expectedFloatValue.floatValue() - 1)));
     }
 
     /**
      * Test evaluate with indexed property.
      */
+    @Test
     public void testEvaluateWithIndexedProperty() {
         // try a valid index
         BeanPropertyValueEqualsPredicate<TestBean, Object> predicate = new BeanPropertyValueEqualsPredicate<>("intIndexed[0]", expectedIntegerValue);
@@ -88,13 +88,13 @@ public class BeanPropertyValueEqualsPredicateTestCase extends TestCase {
         testBean.setIntIndexed(0, expectedIntegerValue.intValue());
         assertTrue(predicate.test(testBean));
         testBean.setIntIndexed(0, expectedIntegerValue.intValue() - 1);
-        assertTrue(!predicate.test(testBean));
+        assertFalse(predicate.test(testBean));
 
         // try an invalid index
         predicate = new BeanPropertyValueEqualsPredicate<>("intIndexed[999]", "exception-ahead");
 
         try {
-            assertTrue(!predicate.test(testBean));
+            assertFalse(predicate.test(testBean));
         } catch (final ArrayIndexOutOfBoundsException e) {
             /* this is what should happen */
         }
@@ -103,15 +103,17 @@ public class BeanPropertyValueEqualsPredicateTestCase extends TestCase {
     /**
      * Test evaluate with int property.
      */
+    @Test
     public void testEvaluateWithIntProperty() {
         final BeanPropertyValueEqualsPredicate<TestBean, Integer> predicate = new BeanPropertyValueEqualsPredicate<>("intProperty", expectedIntegerValue);
         assertTrue(predicate.test(new TestBean(expectedIntegerValue.intValue())));
-        assertTrue(!predicate.test(new TestBean(expectedIntegerValue.intValue() - 1)));
+        assertFalse(predicate.test(new TestBean(expectedIntegerValue.intValue() - 1)));
     }
 
     /**
      * Test evaluate with an invalid property name.
      */
+    @Test
     public void testEvaluateWithInvalidPropertyName() {
         try {
             new BeanPropertyValueEqualsPredicate<TestBean, Object>("bogusProperty", null).test(new TestBean());
@@ -123,6 +125,7 @@ public class BeanPropertyValueEqualsPredicateTestCase extends TestCase {
     /**
      * Test evaluate with mapped property.
      */
+    @Test
     public void testEvaluateWithMappedProperty() {
         // try a key that is in the map
         BeanPropertyValueEqualsPredicate<TestBean, String> predicate = new BeanPropertyValueEqualsPredicate<>("mappedProperty(test-key)", "match");
@@ -130,16 +133,17 @@ public class BeanPropertyValueEqualsPredicateTestCase extends TestCase {
         testBean.setMappedProperty("test-key", "match");
         assertTrue(predicate.test(testBean));
         testBean.setMappedProperty("test-key", "no-match");
-        assertTrue(!predicate.test(testBean));
+        assertFalse(predicate.test(testBean));
 
         // try a key that isn't in the map
         predicate = new BeanPropertyValueEqualsPredicate<>("mappedProperty(invalid-key)", "match");
-        assertTrue(!predicate.test(testBean));
+        assertFalse(predicate.test(testBean));
     }
 
     /**
      * Test evaluate with nested mapped property.
      */
+    @Test
     public void testEvaluateWithNestedMappedProperty() {
         final BeanPropertyValueEqualsPredicate<TestBean, String> predicate = new BeanPropertyValueEqualsPredicate<>("anotherNested.mappedProperty(test-key)",
                 "match");
@@ -149,12 +153,13 @@ public class BeanPropertyValueEqualsPredicateTestCase extends TestCase {
         testBean.setAnotherNested(nestedBean);
         assertTrue(predicate.test(testBean));
         nestedBean.setMappedProperty("test-key", "no-match");
-        assertTrue(!predicate.test(testBean));
+        assertFalse(predicate.test(testBean));
     }
 
     /**
      * Test evaluate with nested property.
      */
+    @Test
     public void testEvaluateWithNestedProperty() {
         final BeanPropertyValueEqualsPredicate<TestBean, String> predicate = new BeanPropertyValueEqualsPredicate<>("anotherNested.stringProperty", "match");
         final TestBean testBean = new TestBean();
@@ -162,12 +167,13 @@ public class BeanPropertyValueEqualsPredicateTestCase extends TestCase {
         testBean.setAnotherNested(nestedBean);
         assertTrue(predicate.test(testBean));
         testBean.setAnotherNested(new TestBean("no-match"));
-        assertTrue(!predicate.test(testBean));
+        assertFalse(predicate.test(testBean));
     }
 
     /**
      * Test evaluate with null in property path and ignore=false.
      */
+    @Test
     public void testEvaluateWithNullInPath() {
         final BeanPropertyValueEqualsPredicate<TestBean, String> predicate = new BeanPropertyValueEqualsPredicate<>("anotherNested.stringProperty", "foo");
         try {
@@ -182,11 +188,12 @@ public class BeanPropertyValueEqualsPredicateTestCase extends TestCase {
     /**
      * Test evaluate with null in property path and ignore=true.
      */
+    @Test
     public void testEvaluateWithNullInPathAndIgnoreTrue() {
         final BeanPropertyValueEqualsPredicate<TestBean, String> predicate = new BeanPropertyValueEqualsPredicate<>("anotherNested.stringProperty", "foo",
                 true);
         try {
-            assertTrue(!predicate.test(new TestBean()));
+            assertFalse(predicate.test(new TestBean()));
         } catch (final IllegalArgumentException e) {
             fail("Should not have throw IllegalArgumentException");
         }
@@ -195,20 +202,22 @@ public class BeanPropertyValueEqualsPredicateTestCase extends TestCase {
     /**
      * Test evaluate with primitive property and null value.
      */
+    @Test
     public void testEvaluateWithPrimitiveAndNull() {
         BeanPropertyValueEqualsPredicate<TestBean, Object> predicate = new BeanPropertyValueEqualsPredicate<>("intProperty", null);
-        assertTrue(!predicate.test(new TestBean(0)));
+        assertFalse(predicate.test(new TestBean(0)));
 
         predicate = new BeanPropertyValueEqualsPredicate<>("booleanProperty", null);
-        assertTrue(!predicate.test(new TestBean(true)));
+        assertFalse(predicate.test(new TestBean(true)));
 
         predicate = new BeanPropertyValueEqualsPredicate<>("floatProperty", null);
-        assertTrue(!predicate.test(new TestBean(expectedFloatValue.floatValue())));
+        assertFalse(predicate.test(new TestBean(expectedFloatValue.floatValue())));
     }
 
     /**
      * Test evaluate with read only property.
      */
+    @Test
     public void testEvaluateWithReadOnlyProperty() {
         final TestBean testBean = new TestBean();
         final BeanPropertyValueEqualsPredicate<TestBean, String> predicate = new BeanPropertyValueEqualsPredicate<>("readOnlyProperty",
@@ -219,24 +228,27 @@ public class BeanPropertyValueEqualsPredicateTestCase extends TestCase {
     /**
      * Test evaluate with simple String property.
      */
+    @Test
     public void testEvaluateWithSimpleStringProperty() {
         final BeanPropertyValueEqualsPredicate<TestBean, String> predicate = new BeanPropertyValueEqualsPredicate<>("stringProperty", "foo");
         assertTrue(predicate.test(new TestBean("foo")));
-        assertTrue(!predicate.test(new TestBean("bar")));
+        assertFalse(predicate.test(new TestBean("bar")));
     }
 
     /**
      * Test evaluate with simple String property and null values.
      */
+    @Test
     public void testEvaluateWithSimpleStringPropertyWithNullValues() {
         final BeanPropertyValueEqualsPredicate<TestBean, String> predicate = new BeanPropertyValueEqualsPredicate<>("stringProperty", null);
         assertTrue(predicate.test(new TestBean((String) null)));
-        assertTrue(!predicate.test(new TestBean("bar")));
+        assertFalse(predicate.test(new TestBean("bar")));
     }
 
     /**
      * Test evaluate with write only property.
      */
+    @Test
     public void testEvaluateWithWriteOnlyProperty() {
         try {
             new BeanPropertyValueEqualsPredicate<TestBean, String>("writeOnlyProperty", null).test(new TestBean());

--- a/src/test/java/org/apache/commons/beanutils2/BeanToPropertyValueTransformerTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/BeanToPropertyValueTransformerTestCase.java
@@ -17,12 +17,16 @@
 
 package org.apache.commons.beanutils2;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for {@code BeanToPropertyValueTransformer}.
  */
-public class BeanToPropertyValueTransformerTestCase extends TestCase {
+public class BeanToPropertyValueTransformerTestCase {
 
     private static final Integer expectedIntegerValue = Integer.valueOf(123);
     private static final Long expectedLongValue = Long.valueOf(123);
@@ -32,17 +36,9 @@ public class BeanToPropertyValueTransformerTestCase extends TestCase {
     private static final Byte expectedByteValue = Byte.valueOf("12");
 
     /**
-     * Constructor for BeanToPropertyValueTransformerTestCase.
-     *
-     * @param name Name of this test case.
-     */
-    public BeanToPropertyValueTransformerTestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Test transform with indexed property.
      */
+    @Test
     public void testTransformWithIndexedProperty() {
         BeanToPropertyValueTransformer<TestBean, Integer> transformer = new BeanToPropertyValueTransformer<>("intIndexed[0]");
         final TestBean testBean = new TestBean();
@@ -63,6 +59,7 @@ public class BeanToPropertyValueTransformerTestCase extends TestCase {
     /**
      * Test transform with invalid property.
      */
+    @Test
     public void testTransformWithInvalidProperty() {
         try {
             new BeanToPropertyValueTransformer<>("bogusProperty").apply(new TestBean());
@@ -74,6 +71,7 @@ public class BeanToPropertyValueTransformerTestCase extends TestCase {
     /**
      * Test transform with mapped property.
      */
+    @Test
     public void testTransformWithMappedProperty() {
         BeanToPropertyValueTransformer<TestBean, String> transformer = new BeanToPropertyValueTransformer<>("mappedProperty(test-key)");
         final TestBean testBean = new TestBean();
@@ -90,6 +88,7 @@ public class BeanToPropertyValueTransformerTestCase extends TestCase {
     /**
      * Test transform with nested indexed property.
      */
+    @Test
     public void testTransformWithNestedIndexedProperty() {
         final BeanToPropertyValueTransformer<TestBean, Integer> transformer = new BeanToPropertyValueTransformer<>("anotherNested.intIndexed[0]");
         final TestBean testBean = new TestBean();
@@ -102,6 +101,7 @@ public class BeanToPropertyValueTransformerTestCase extends TestCase {
     /**
      * Test transform with nested property.
      */
+    @Test
     public void testTransformWithNestedProperty() {
         final BeanToPropertyValueTransformer<TestBean, String> transformer = new BeanToPropertyValueTransformer<>("anotherNested.stringProperty");
         final TestBean testBean = new TestBean();
@@ -113,6 +113,7 @@ public class BeanToPropertyValueTransformerTestCase extends TestCase {
     /**
      * Test transform with null in property path.
      */
+    @Test
     public void testTransformWithNullInPath() {
         final BeanToPropertyValueTransformer<TestBean, String> transformer = new BeanToPropertyValueTransformer<>("anotherNested.stringProperty");
 
@@ -127,6 +128,7 @@ public class BeanToPropertyValueTransformerTestCase extends TestCase {
     /**
      * Test transform with null in property path and ignore = true.
      */
+    @Test
     public void testTransformWithNullInPathAndIgnoreTrue() {
         final BeanToPropertyValueTransformer<TestBean, String> transformer = new BeanToPropertyValueTransformer<>("anotherNested.stringProperty", true);
         assertNull(transformer.apply(new TestBean()));
@@ -135,6 +137,7 @@ public class BeanToPropertyValueTransformerTestCase extends TestCase {
     /**
      * Test transform with read only property.
      */
+    @Test
     public void testTransformWithReadOnlyProperty() {
         final BeanToPropertyValueTransformer<TestBean, String> transformer = new BeanToPropertyValueTransformer<>("readOnlyProperty");
         final TestBean testBean = new TestBean();
@@ -144,6 +147,7 @@ public class BeanToPropertyValueTransformerTestCase extends TestCase {
     /**
      * Test transform with simple boolean property.
      */
+    @Test
     public void testTransformWithSimpleBooleanProperty() {
         final BeanToPropertyValueTransformer<TestBean, Boolean> transformer = new BeanToPropertyValueTransformer<>("booleanProperty");
         final TestBean testBean = new TestBean(expectedBooleanValue.booleanValue());
@@ -153,6 +157,7 @@ public class BeanToPropertyValueTransformerTestCase extends TestCase {
     /**
      * Test transform with simple byte property.
      */
+    @Test
     public void testTransformWithSimpleByteProperty() {
         final BeanToPropertyValueTransformer<TestBean, Byte> transformer = new BeanToPropertyValueTransformer<>("byteProperty");
         final TestBean testBean = new TestBean();
@@ -163,6 +168,7 @@ public class BeanToPropertyValueTransformerTestCase extends TestCase {
     /**
      * Test transform with simple double property.
      */
+    @Test
     public void testTransformWithSimpleDoubleProperty() {
         final BeanToPropertyValueTransformer<TestBean, Double> transformer = new BeanToPropertyValueTransformer<>("doubleProperty");
         final TestBean testBean = new TestBean(expectedDoubleValue.doubleValue());
@@ -172,6 +178,7 @@ public class BeanToPropertyValueTransformerTestCase extends TestCase {
     /**
      * Test transform with simple float property.
      */
+    @Test
     public void testTransformWithSimpleFloatProperty() {
         final BeanToPropertyValueTransformer<TestBean, Float> transformer = new BeanToPropertyValueTransformer<>("floatProperty");
         final TestBean testBean = new TestBean(expectedFloatValue.floatValue());
@@ -181,6 +188,7 @@ public class BeanToPropertyValueTransformerTestCase extends TestCase {
     /**
      * Test transform with simple int property.
      */
+    @Test
     public void testTransformWithSimpleIntProperty() {
         final BeanToPropertyValueTransformer<TestBean, Integer> transformer = new BeanToPropertyValueTransformer<>("intProperty");
         final TestBean testBean = new TestBean(expectedIntegerValue.intValue());
@@ -190,6 +198,7 @@ public class BeanToPropertyValueTransformerTestCase extends TestCase {
     /**
      * Test transform with simple long property.
      */
+    @Test
     public void testTransformWithSimpleLongProperty() {
         final BeanToPropertyValueTransformer<TestBean, Long> transformer = new BeanToPropertyValueTransformer<>("longProperty");
         final TestBean testBean = new TestBean();
@@ -200,6 +209,7 @@ public class BeanToPropertyValueTransformerTestCase extends TestCase {
     /**
      * Test transform with simple String property.
      */
+    @Test
     public void testTransformWithSimpleStringProperty() {
         final BeanToPropertyValueTransformer<TestBean, String> transformer = new BeanToPropertyValueTransformer<>("stringProperty");
         final TestBean testBean = new TestBean("foo");
@@ -209,6 +219,7 @@ public class BeanToPropertyValueTransformerTestCase extends TestCase {
     /**
      * Test transform with simple String property and null value.
      */
+    @Test
     public void testTransformWithSimpleStringPropertyAndNullValue() {
         final BeanToPropertyValueTransformer<TestBean, String> transformer = new BeanToPropertyValueTransformer<>("stringProperty");
         final TestBean testBean = new TestBean((String) null);
@@ -218,6 +229,7 @@ public class BeanToPropertyValueTransformerTestCase extends TestCase {
     /**
      * Test transform with write only property.
      */
+    @Test
     public void testTransformWithWriteOnlyProperty() {
         try {
             new BeanToPropertyValueTransformer<>("writeOnlyProperty").apply(new TestBean());

--- a/src/test/java/org/apache/commons/beanutils2/BeanUtilsBean2TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/BeanUtilsBean2TestCase.java
@@ -16,24 +16,23 @@
  */
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 /**
  * Test Case for the {@link BeanUtilsBean2}.
  */
 public class BeanUtilsBean2TestCase extends BeanUtilsBeanTestCase {
 
     /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public BeanUtilsBean2TestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Sets up instance variables required by this test case.
      */
     @Override
+    @BeforeEach
     public void setUp() {
         ConvertUtils.deregister();
         BeanUtilsBean.setInstance(new BeanUtilsBean2());
@@ -44,6 +43,7 @@ public class BeanUtilsBean2TestCase extends BeanUtilsBeanTestCase {
      * Tear down instance variables required by this test case.
      */
     @Override
+    @AfterEach
     public void tearDown() {
         bean = null;
     }
@@ -52,19 +52,21 @@ public class BeanUtilsBean2TestCase extends BeanUtilsBeanTestCase {
      * Test {@code copyProperty()} converting to a String.
      */
     @Override
+    @Test
     public void testCopyPropertyConvertToString() {
         try {
             BeanUtils.copyProperty(bean, "stringProperty", testUtilDate);
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("java.util.Date --> String", testStringDate, bean.getStringProperty());
+        assertEquals(testStringDate, bean.getStringProperty(), "java.util.Date --> String");
     }
 
     /**
      * Test {@code copyProperty()} converting to a String.
      */
     @Override
+    @Test
     public void testCopyPropertyConvertToStringArray() {
         try {
             bean.setStringArray(null);
@@ -72,14 +74,15 @@ public class BeanUtilsBean2TestCase extends BeanUtilsBeanTestCase {
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("java.util.Date[] --> String[] length", 1, bean.getStringArray().length);
-        assertEquals("java.util.Date[] --> String[] value ", testStringDate, bean.getStringArray()[0]);
+        assertEquals(1, bean.getStringArray().length, "java.util.Date[] --> String[] length");
+        assertEquals(testStringDate, bean.getStringArray()[0], "java.util.Date[] --> String[] value ");
     }
 
     /**
      * Test {@code copyProperty()} converting to a String on indexed property
      */
     @Override
+    @Test
     public void testCopyPropertyConvertToStringIndexed() {
         try {
             bean.setStringArray(new String[1]);
@@ -87,14 +90,15 @@ public class BeanUtilsBean2TestCase extends BeanUtilsBeanTestCase {
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("java.util.Date[] --> String[] length", 1, bean.getStringArray().length);
-        assertEquals("java.util.Date[] --> String[] value ", testStringDate, bean.getStringArray()[0]);
+        assertEquals(1, bean.getStringArray().length, "java.util.Date[] --> String[] length");
+        assertEquals(testStringDate, bean.getStringArray()[0], "java.util.Date[] --> String[] value ");
     }
 
     /**
      * Test {@code getArrayProperty()} converting to a String.
      */
     @Override
+    @Test
     public void testGetArrayPropertyDate() {
         String[] value = null;
         try {
@@ -103,14 +107,15 @@ public class BeanUtilsBean2TestCase extends BeanUtilsBeanTestCase {
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("java.util.Date[] --> String[] length", 1, value.length);
-        assertEquals("java.util.Date[] --> String[] value ", testStringDate, value[0]);
+        assertEquals(1, value.length, "java.util.Date[] --> String[] length");
+        assertEquals(testStringDate, value[0], "java.util.Date[] --> String[] value ");
     }
 
     /**
      * Test {@code getArrayProperty()} converting to a String.
      */
     @Override
+    @Test
     public void testGetIndexedPropertyDate() {
         String value = null;
         try {
@@ -119,13 +124,14 @@ public class BeanUtilsBean2TestCase extends BeanUtilsBeanTestCase {
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("java.util.Date[0] --> String", testStringDate, value);
+        assertEquals(testStringDate, value, "java.util.Date[0] --> String");
     }
 
     /**
      * Test {@code getSimpleProperty()} converting to a String.
      */
     @Override
+    @Test
     public void testGetSimplePropertyDate() {
         String value = null;
         try {
@@ -134,26 +140,28 @@ public class BeanUtilsBean2TestCase extends BeanUtilsBeanTestCase {
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("java.util.Date --> String", testStringDate, value);
+        assertEquals(testStringDate, value, "java.util.Date --> String");
     }
 
     /**
      * Test {@code setProperty()} converting to a String.
      */
     @Override
+    @Test
     public void testSetPropertyConvertToString() {
         try {
             BeanUtils.setProperty(bean, "stringProperty", testUtilDate);
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("java.util.Date --> String", testStringDate, bean.getStringProperty());
+        assertEquals(testStringDate, bean.getStringProperty(), "java.util.Date --> String");
     }
 
     /**
      * Test {@code setProperty()} converting to a String array.
      */
     @Override
+    @Test
     public void testSetPropertyConvertToStringArray() {
         try {
             bean.setStringArray(null);
@@ -161,14 +169,15 @@ public class BeanUtilsBean2TestCase extends BeanUtilsBeanTestCase {
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("java.util.Date[] --> String[] length", 1, bean.getStringArray().length);
-        assertEquals("java.util.Date[] --> String[] value ", testStringDate, bean.getStringArray()[0]);
+        assertEquals(1, bean.getStringArray().length, "java.util.Date[] --> String[] length");
+        assertEquals(testStringDate, bean.getStringArray()[0], "java.util.Date[] --> String[] value ");
     }
 
     /**
      * Test {@code setProperty()} converting to a String on indexed property
      */
     @Override
+    @Test
     public void testSetPropertyConvertToStringIndexed() {
         try {
             bean.setStringArray(new String[1]);
@@ -176,7 +185,7 @@ public class BeanUtilsBean2TestCase extends BeanUtilsBeanTestCase {
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("java.util.Date --> String[]", testStringDate, bean.getStringArray()[0]);
+        assertEquals(testStringDate, bean.getStringArray()[0], "java.util.Date --> String[]");
     }
 
 }

--- a/src/test/java/org/apache/commons/beanutils2/BeanUtilsBeanTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/BeanUtilsBeanTestCase.java
@@ -17,7 +17,12 @@
 
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Calendar;
@@ -25,10 +30,11 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.beanutils2.converters.ArrayConverter;
 import org.apache.commons.beanutils2.converters.DateConverter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>
@@ -52,7 +58,7 @@ import org.apache.commons.beanutils2.converters.DateConverter;
  * <li>getArrayProperty(Object bean, String name)</li>
  * </ul>
  */
-public class BeanUtilsBeanTestCase extends TestCase {
+public class BeanUtilsBeanTestCase {
 
     /**
      * Test for JDK 1.4
@@ -87,30 +93,21 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /** Test String Date value */
     protected String testStringDate;
 
-    /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public BeanUtilsBeanTestCase(final String name) {
-        super(name);
-    }
-
     // Ensure that the actual int[] matches the expected int[]
     protected void checkIntArray(final int[] actual, final int[] expected) {
-        assertNotNull("actual array not null", actual);
-        assertEquals("actual array length", expected.length, actual.length);
+        assertNotNull(actual, "actual array not null");
+        assertEquals(expected.length, actual.length, "actual array length");
         for (int i = 0; i < actual.length; i++) {
-            assertEquals("actual array value[" + i + "]", expected[i], actual[i]);
+            assertEquals(expected[i], actual[i], "actual array value[" + i + "]");
         }
     }
 
     // Ensure that the actual Map matches the expected Map
     protected void checkMap(final Map<?, ?> actual, final Map<?, ?> expected) {
-        assertNotNull("actual map not null", actual);
-        assertEquals("actual map size", expected.size(), actual.size());
+        assertNotNull(actual, "actual map not null");
+        assertEquals(expected.size(), actual.size(), "actual map size");
         for (final Object key : expected.keySet()) {
-            assertEquals("actual map value(" + key + ")", expected.get(key), actual.get(key));
+            assertEquals(expected.get(key), actual.get(key), "actual map value(" + key + ")");
         }
     }
 
@@ -135,7 +132,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Sets up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     public void setUp() {
         ConvertUtils.deregister();
         BeanUtilsBean.setInstance(new BeanUtilsBean());
@@ -166,11 +163,12 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     public void tearDown() {
         bean = null;
     }
 
+    @Test
     public void testArrayPropertyConversion() throws Exception {
         final BeanUtilsBean beanUtils = new BeanUtilsBean(new ConvertUtilsBean(), new PropertyUtilsBean());
 
@@ -178,15 +176,17 @@ public class BeanUtilsBeanTestCase extends TestCase {
         final String[] results = beanUtils.getArrayProperty(bean, "intArray");
 
         final int[] values = bean.getIntArray();
-        assertEquals("Converted array size not equal to property array size.", results.length, values.length);
+        assertEquals(results.length, values.length,
+                                "Converted array size not equal to property array size.");
         for (int i = 0, size = values.length; i < size; i++) {
-            assertEquals("Value " + i + " incorrectly converted ", values[i] + "", results[i]);
+            assertEquals(values[i] + "", results[i], "Value " + i + " incorrectly converted ");
         }
     }
 
     /**
      * Test the copyProperties() method from a DynaBean.
      */
+    @Test
     public void testCopyPropertiesDynaBean() {
 
         // Set up an origin bean with customized properties
@@ -216,38 +216,39 @@ public class BeanUtilsBeanTestCase extends TestCase {
         }
 
         // Validate the results for scalar properties
-        assertEquals("Copied boolean property", false, bean.getBooleanProperty());
-        assertEquals("Copied byte property", (byte) 111, bean.getByteProperty());
-        assertEquals("Copied double property", 333.33, bean.getDoubleProperty(), 0.005);
-        assertEquals("Copied int property", 333, bean.getIntProperty());
-        assertEquals("Copied long property", 3333, bean.getLongProperty());
-        assertEquals("Copied short property", (short) 33, bean.getShortProperty());
-        assertEquals("Copied string property", "Custom string", bean.getStringProperty());
+        assertEquals(false, bean.getBooleanProperty(), "Copied boolean property");
+        assertEquals((byte) 111, bean.getByteProperty(), "Copied byte property");
+        assertEquals(333.33, bean.getDoubleProperty(), 0.005, "Copied double property");
+        assertEquals(333, bean.getIntProperty(), "Copied int property");
+        assertEquals(3333, bean.getLongProperty(), "Copied long property");
+        assertEquals((short) 33, bean.getShortProperty(), "Copied short property");
+        assertEquals("Custom string", bean.getStringProperty(), "Copied string property");
 
         // Validate the results for array properties
         final String[] dupProperty = bean.getDupProperty();
-        assertNotNull("dupProperty present", dupProperty);
-        assertEquals("dupProperty length", 3, dupProperty.length);
-        assertEquals("dupProperty[0]", "New 0", dupProperty[0]);
-        assertEquals("dupProperty[1]", "New 1", dupProperty[1]);
-        assertEquals("dupProperty[2]", "New 2", dupProperty[2]);
+        assertNotNull(dupProperty, "dupProperty present");
+        assertEquals(3, dupProperty.length, "dupProperty length");
+        assertEquals("New 0", dupProperty[0], "dupProperty[0]");
+        assertEquals("New 1", dupProperty[1], "dupProperty[1]");
+        assertEquals("New 2", dupProperty[2], "dupProperty[2]");
         final int[] intArray = bean.getIntArray();
-        assertNotNull("intArray present", intArray);
-        assertEquals("intArray length", 3, intArray.length);
-        assertEquals("intArray[0]", 100, intArray[0]);
-        assertEquals("intArray[1]", 200, intArray[1]);
-        assertEquals("intArray[2]", 300, intArray[2]);
+        assertNotNull(intArray, "intArray present");
+        assertEquals(3, intArray.length, "intArray length");
+        assertEquals(100, intArray[0], "intArray[0]");
+        assertEquals(200, intArray[1], "intArray[1]");
+        assertEquals(300, intArray[2], "intArray[2]");
         final String[] stringArray = bean.getStringArray();
-        assertNotNull("stringArray present", stringArray);
-        assertEquals("stringArray length", 2, stringArray.length);
-        assertEquals("stringArray[0]", "New 0", stringArray[0]);
-        assertEquals("stringArray[1]", "New 1", stringArray[1]);
+        assertNotNull(stringArray, "stringArray present");
+        assertEquals(2, stringArray.length, "stringArray length");
+        assertEquals("New 0", stringArray[0], "stringArray[0]");
+        assertEquals("New 1", stringArray[1], "stringArray[1]");
 
     }
 
     /**
      * Test copyProperties() when the origin is a {@code Map}.
      */
+    @Test
     public void testCopyPropertiesMap() {
 
         final Map<String, Object> map = new HashMap<>();
@@ -269,34 +270,35 @@ public class BeanUtilsBeanTestCase extends TestCase {
         }
 
         // Scalar properties
-        assertEquals("booleanProperty", false, bean.getBooleanProperty());
-        assertEquals("byteProperty", (byte) 111, bean.getByteProperty());
-        assertEquals("doubleProperty", 333.0, bean.getDoubleProperty(), 0.005);
-        assertEquals("floatProperty", (float) 222.0, bean.getFloatProperty(), (float) 0.005);
-        assertEquals("longProperty", 111, bean.getIntProperty());
-        assertEquals("longProperty", 444, bean.getLongProperty());
-        assertEquals("shortProperty", (short) 555, bean.getShortProperty());
-        assertEquals("stringProperty", "New String Property", bean.getStringProperty());
+        assertEquals(false, bean.getBooleanProperty(), "booleanProperty");
+        assertEquals((byte) 111, bean.getByteProperty(), "byteProperty");
+        assertEquals(333.0, bean.getDoubleProperty(), 0.005, "doubleProperty");
+        assertEquals((float) 222.0, bean.getFloatProperty(), (float) 0.005, "floatProperty");
+        assertEquals(111, bean.getIntProperty(), "longProperty");
+        assertEquals(444, bean.getLongProperty(), "longProperty");
+        assertEquals((short) 555, bean.getShortProperty(), "shortProperty");
+        assertEquals("New String Property", bean.getStringProperty(), "stringProperty");
 
         // Indexed Properties
         final String[] dupProperty = bean.getDupProperty();
-        assertNotNull("dupProperty present", dupProperty);
-        assertEquals("dupProperty length", 3, dupProperty.length);
-        assertEquals("dupProperty[0]", "New 0", dupProperty[0]);
-        assertEquals("dupProperty[1]", "New 1", dupProperty[1]);
-        assertEquals("dupProperty[2]", "New 2", dupProperty[2]);
+        assertNotNull(dupProperty, "dupProperty present");
+        assertEquals(3, dupProperty.length, "dupProperty length");
+        assertEquals("New 0", dupProperty[0], "dupProperty[0]");
+        assertEquals("New 1", dupProperty[1], "dupProperty[1]");
+        assertEquals("New 2", dupProperty[2], "dupProperty[2]");
         final int[] intArray = bean.getIntArray();
-        assertNotNull("intArray present", intArray);
-        assertEquals("intArray length", 3, intArray.length);
-        assertEquals("intArray[0]", 0, intArray[0]);
-        assertEquals("intArray[1]", 100, intArray[1]);
-        assertEquals("intArray[2]", 200, intArray[2]);
+        assertNotNull(intArray, "intArray present");
+        assertEquals(3, intArray.length, "intArray length");
+        assertEquals(0, intArray[0], "intArray[0]");
+        assertEquals(100, intArray[1], "intArray[1]");
+        assertEquals(200, intArray[2], "intArray[2]");
 
     }
 
     /**
      * Test the copyProperties() method from a standard JavaBean.
      */
+    @Test
     public void testCopyPropertiesStandard() {
 
         // Set up an origin bean with customized properties
@@ -320,38 +322,39 @@ public class BeanUtilsBeanTestCase extends TestCase {
         }
 
         // Validate the results for scalar properties
-        assertEquals("Copied boolean property", false, bean.getBooleanProperty());
-        assertEquals("Copied byte property", (byte) 111, bean.getByteProperty());
-        assertEquals("Copied double property", 333.33, bean.getDoubleProperty(), 0.005);
-        assertEquals("Copied int property", 333, bean.getIntProperty());
-        assertEquals("Copied long property", 3333, bean.getLongProperty());
-        assertEquals("Copied short property", (short) 33, bean.getShortProperty());
-        assertEquals("Copied string property", "Custom string", bean.getStringProperty());
+        assertEquals(false, bean.getBooleanProperty(), "Copied boolean property");
+        assertEquals((byte) 111, bean.getByteProperty(), "Copied byte property");
+        assertEquals(333.33, bean.getDoubleProperty(), 0.005, "Copied double property");
+        assertEquals(333, bean.getIntProperty(), "Copied int property");
+        assertEquals(3333, bean.getLongProperty(), "Copied long property");
+        assertEquals((short) 33, bean.getShortProperty(), "Copied short property");
+        assertEquals("Custom string", bean.getStringProperty(), "Copied string property");
 
         // Validate the results for array properties
         final String[] dupProperty = bean.getDupProperty();
-        assertNotNull("dupProperty present", dupProperty);
-        assertEquals("dupProperty length", 3, dupProperty.length);
-        assertEquals("dupProperty[0]", "New 0", dupProperty[0]);
-        assertEquals("dupProperty[1]", "New 1", dupProperty[1]);
-        assertEquals("dupProperty[2]", "New 2", dupProperty[2]);
+        assertNotNull(dupProperty, "dupProperty present");
+        assertEquals(3, dupProperty.length, "dupProperty length");
+        assertEquals("New 0", dupProperty[0], "dupProperty[0]");
+        assertEquals("New 1", dupProperty[1], "dupProperty[1]");
+        assertEquals("New 2", dupProperty[2], "dupProperty[2]");
         final int[] intArray = bean.getIntArray();
-        assertNotNull("intArray present", intArray);
-        assertEquals("intArray length", 3, intArray.length);
-        assertEquals("intArray[0]", 100, intArray[0]);
-        assertEquals("intArray[1]", 200, intArray[1]);
-        assertEquals("intArray[2]", 300, intArray[2]);
+        assertNotNull(intArray, "intArray present");
+        assertEquals(3, intArray.length, "intArray length");
+        assertEquals(100, intArray[0], "intArray[0]");
+        assertEquals(200, intArray[1], "intArray[1]");
+        assertEquals(300, intArray[2], "intArray[2]");
         final String[] stringArray = bean.getStringArray();
-        assertNotNull("stringArray present", stringArray);
-        assertEquals("stringArray length", 2, stringArray.length);
-        assertEquals("stringArray[0]", "New 0", stringArray[0]);
-        assertEquals("stringArray[1]", "New 1", stringArray[1]);
+        assertNotNull(stringArray, "stringArray present");
+        assertEquals(2, stringArray.length, "stringArray length");
+        assertEquals("New 0", stringArray[0], "stringArray[0]");
+        assertEquals("New 1", stringArray[1], "stringArray[1]");
 
     }
 
     /**
      * Test narrowing and widening conversions on byte.
      */
+    @Test
     public void testCopyPropertyByte() throws Exception {
 
         BeanUtils.copyProperty(bean, "byteProperty", Byte.valueOf((byte) 123));
@@ -372,42 +375,46 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test {@code copyProperty()} conversion.
      */
+    @Test
     public void testCopyPropertyConvert() {
         try {
             BeanUtils.copyProperty(bean, "dateProperty", testCalendar);
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("Calendar --> java.util.Date", testUtilDate, bean.getDateProperty());
+        assertEquals(testUtilDate, bean.getDateProperty(), "Calendar --> java.util.Date");
     }
 
     /**
      * Test {@code copyProperty()} converting from a String.
      */
+    @Test
     public void testCopyPropertyConvertFromString() {
         try {
             BeanUtils.copyProperty(bean, "dateProperty", testStringDate);
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("String --> java.util.Date", testUtilDate, bean.getDateProperty());
+        assertEquals(testUtilDate, bean.getDateProperty(), "String --> java.util.Date");
     }
 
     /**
      * Test {@code copyProperty()} converting to a String.
      */
+    @Test
     public void testCopyPropertyConvertToString() {
         try {
             BeanUtils.copyProperty(bean, "stringProperty", testUtilDate);
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("java.util.Date --> String", testUtilDate.toString(), bean.getStringProperty());
+        assertEquals(testUtilDate.toString(), bean.getStringProperty(), "java.util.Date --> String");
     }
 
     /**
      * Test {@code copyProperty()} converting to a String.
      */
+    @Test
     public void testCopyPropertyConvertToStringArray() {
         try {
             bean.setStringArray(null);
@@ -415,13 +422,15 @@ public class BeanUtilsBeanTestCase extends TestCase {
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("java.util.Date[] --> String[] length", 1, bean.getStringArray().length);
-        assertEquals("java.util.Date[] --> String[] value ", testUtilDate.toString(), bean.getStringArray()[0]);
+        assertEquals(1, bean.getStringArray().length, "java.util.Date[] --> String[] length");
+        assertEquals(testUtilDate.toString(), bean.getStringArray()[0],
+                                "java.util.Date[] --> String[] value ");
     }
 
     /**
      * Test {@code copyProperty()} converting to a String on indexed property
      */
+    @Test
     public void testCopyPropertyConvertToStringIndexed() {
         try {
             bean.setStringArray(new String[1]);
@@ -429,12 +438,13 @@ public class BeanUtilsBeanTestCase extends TestCase {
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("java.util.Date --> String[]", testUtilDate.toString(), bean.getStringArray()[0]);
+        assertEquals(testUtilDate.toString(), bean.getStringArray()[0], "java.util.Date --> String[]");
     }
 
     /**
      * Test narrowing and widening conversions on double.
      */
+    @Test
     public void testCopyPropertyDouble() throws Exception {
 
         BeanUtils.copyProperty(bean, "doubleProperty", Byte.valueOf((byte) 123));
@@ -455,6 +465,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test narrowing and widening conversions on float.
      */
+    @Test
     public void testCopyPropertyFloat() throws Exception {
 
         BeanUtils.copyProperty(bean, "floatProperty", Byte.valueOf((byte) 123));
@@ -475,6 +486,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test narrowing and widening conversions on int.
      */
+    @Test
     public void testCopyPropertyInteger() throws Exception {
 
         BeanUtils.copyProperty(bean, "longProperty", Byte.valueOf((byte) 123));
@@ -495,6 +507,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test narrowing and widening conversions on long.
      */
+    @Test
     public void testCopyPropertyLong() throws Exception {
 
         BeanUtils.copyProperty(bean, "longProperty", Byte.valueOf((byte) 123));
@@ -515,6 +528,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test copying a property using a nested indexed array expression, with and without conversions.
      */
+    @Test
     public void testCopyPropertyNestedIndexedArray() throws Exception {
 
         final int[] origArray = { 0, 10, 20, 30, 40 };
@@ -551,6 +565,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test copying a property using a nested mapped map property.
      */
+    @Test
     public void testCopyPropertyNestedMappedMap() throws Exception {
 
         final Map<String, Object> origMap = new HashMap<>();
@@ -571,6 +586,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test copying a property using a nested simple expression, with and without conversions.
      */
+    @Test
     public void testCopyPropertyNestedSimple() throws Exception {
 
         bean.setIntProperty(0);
@@ -605,17 +621,19 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test copying a null property value.
      */
+    @Test
     public void testCopyPropertyNull() throws Exception {
 
         bean.setNullProperty("non-null value");
         BeanUtils.copyProperty(bean, "nullProperty", null);
-        assertNull("nullProperty is null", bean.getNullProperty());
+        assertNull(bean.getNullProperty(), "nullProperty is null");
 
     }
 
     /**
      * Test narrowing and widening conversions on short.
      */
+    @Test
     public void testCopyPropertyShort() throws Exception {
 
         BeanUtils.copyProperty(bean, "shortProperty", Byte.valueOf((byte) 123));
@@ -636,6 +654,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test copying a new value to a write-only property, with and without conversions.
      */
+    @Test
     public void testCopyPropertyWriteOnly() throws Exception {
 
         bean.setWriteOnlyProperty("Original value");
@@ -653,52 +672,54 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test the describe() method.
      */
+    @Test
     public void testDescribe() throws Exception {
         assertTrue(BeanUtils.describe(null).isEmpty());
         Map<String, String> map = null;
         map = BeanUtils.describe(bean);
         // Verify existence of all the properties that should be present
         for (final String describe : describes) {
-            assertTrue("Property '" + describe + "' is present", map.containsKey(describe));
+            assertTrue(map.containsKey(describe), "Property '" + describe + "' is present");
         }
-        assertTrue("Property 'writeOnlyProperty' is not present", !map.containsKey("writeOnlyProperty"));
+        assertTrue(!map.containsKey("writeOnlyProperty"), "Property 'writeOnlyProperty' is not present");
         // Verify the values of scalar properties
-        assertEquals("Value of 'booleanProperty'", "true", map.get("booleanProperty"));
-        assertEquals("Value of 'byteProperty'", "121", map.get("byteProperty"));
-        assertEquals("Value of 'doubleProperty'", "321.0", map.get("doubleProperty"));
-        assertEquals("Value of 'floatProperty'", "123.0", map.get("floatProperty"));
-        assertEquals("Value of 'intProperty'", "123", map.get("intProperty"));
-        assertEquals("Value of 'longProperty'", "321", map.get("longProperty"));
-        assertEquals("Value of 'shortProperty'", "987", map.get("shortProperty"));
-        assertEquals("Value of 'stringProperty'", "This is a string", map.get("stringProperty"));
+        assertEquals("true", map.get("booleanProperty"), "Value of 'booleanProperty'");
+        assertEquals("121", map.get("byteProperty"), "Value of 'byteProperty'");
+        assertEquals("321.0", map.get("doubleProperty"), "Value of 'doubleProperty'");
+        assertEquals("123.0", map.get("floatProperty"), "Value of 'floatProperty'");
+        assertEquals("123", map.get("intProperty"), "Value of 'intProperty'");
+        assertEquals("321", map.get("longProperty"), "Value of 'longProperty'");
+        assertEquals("987", map.get("shortProperty"), "Value of 'shortProperty'");
+        assertEquals("This is a string", map.get("stringProperty"), "Value of 'stringProperty'");
     }
 
     /**
      * tests the string and int arrays of TestBean
      */
+    @Test
     public void testGetArrayProperty() {
         try {
             String[] arr = BeanUtils.getArrayProperty(bean, "stringArray");
             final String[] comp = bean.getStringArray();
 
-            assertEquals("String array length = " + comp.length, comp.length, arr.length);
+            assertEquals(comp.length, arr.length, "String array length = " + comp.length);
 
             arr = BeanUtils.getArrayProperty(bean, "intArray");
             final int[] iarr = bean.getIntArray();
 
-            assertEquals("String array length = " + iarr.length, iarr.length, arr.length);
+            assertEquals(iarr.length, arr.length, "String array length = " + iarr.length);
 
             // Test property which isn't array or collection
             arr = BeanUtils.getArrayProperty(bean, "shortProperty");
             final String shortAsString = "" + bean.getShortProperty();
-            assertEquals("Short List Test lth", 1, arr.length);
-            assertEquals("Short Test value", shortAsString, arr[0]);
+            assertEquals(1, arr.length, "Short List Test lth");
+            assertEquals(shortAsString, arr[0], "Short Test value");
 
             // Test comma delimited list
             bean.setStringProperty("ABC");
             arr = BeanUtils.getArrayProperty(bean, "stringProperty");
-            assertEquals("Delimited List Test lth", 1, arr.length);
-            assertEquals("Delimited List Test value1", "ABC", arr[0]);
+            assertEquals(1, arr.length, "Delimited List Test lth");
+            assertEquals("ABC", arr[0], "Delimited List Test value1");
 
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
@@ -713,6 +734,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test {@code getArrayProperty()} converting to a String.
      */
+    @Test
     public void testGetArrayPropertyDate() {
         String[] value = null;
         try {
@@ -721,19 +743,20 @@ public class BeanUtilsBeanTestCase extends TestCase {
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("java.util.Date[] --> String[] length", 1, value.length);
-        assertEquals("java.util.Date[] --> String[] value ", testUtilDate.toString(), value[0]);
+        assertEquals(1, value.length, "java.util.Date[] --> String[] length");
+        assertEquals(testUtilDate.toString(), value[0], "java.util.Date[] --> String[] value ");
     }
 
     /**
      * tests getting a 'whatever' property
      */
+    @Test
     public void testGetGeneralProperty() {
         try {
             final String val = BeanUtils.getProperty(bean, "nested.intIndexed[2]");
             final String comp = String.valueOf(bean.getIntIndexed(2));
 
-            assertEquals("nested.intIndexed[2] == " + comp, val, comp);
+            assertEquals(val, comp, "nested.intIndexed[2] == " + comp);
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final InvocationTargetException e) {
@@ -746,15 +769,16 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * tests getting an indexed property
      */
+    @Test
     public void testGetIndexedProperty1() {
         try {
             String val = BeanUtils.getIndexedProperty(bean, "intIndexed[3]");
             String comp = String.valueOf(bean.getIntIndexed(3));
-            assertEquals("intIndexed[3] == " + comp, val, comp);
+            assertEquals(val, comp, "intIndexed[3] == " + comp);
 
             val = BeanUtils.getIndexedProperty(bean, "stringIndexed[3]");
             comp = bean.getStringIndexed(3);
-            assertEquals("stringIndexed[3] == " + comp, val, comp);
+            assertEquals(val, comp, "stringIndexed[3] == " + comp);
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final InvocationTargetException e) {
@@ -767,17 +791,18 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * tests getting an indexed property
      */
+    @Test
     public void testGetIndexedProperty2() {
         try {
             String val = BeanUtils.getIndexedProperty(bean, "intIndexed", 3);
             String comp = String.valueOf(bean.getIntIndexed(3));
 
-            assertEquals("intIndexed,3 == " + comp, val, comp);
+            assertEquals(val, comp, "intIndexed,3 == " + comp);
 
             val = BeanUtils.getIndexedProperty(bean, "stringIndexed", 3);
             comp = bean.getStringIndexed(3);
 
-            assertEquals("stringIndexed,3 == " + comp, val, comp);
+            assertEquals(val, comp, "stringIndexed,3 == " + comp);
 
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
@@ -791,6 +816,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test {@code getArrayProperty()} converting to a String.
      */
+    @Test
     public void testGetIndexedPropertyDate() {
         String value = null;
         try {
@@ -799,15 +825,17 @@ public class BeanUtilsBeanTestCase extends TestCase {
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("java.util.Date[0] --> String", testUtilDate.toString(), value);
+        assertEquals(testUtilDate.toString(), value, "java.util.Date[0] --> String");
     }
 
+    @Test
     public void testGetMappedProperty2Args() throws Exception {
         assertThrows(NullPointerException.class, () -> BeanUtils.getMappedProperty(null, null));
         assertThrows(NullPointerException.class, () -> BeanUtils.getMappedProperty(null, ""));
         assertThrows(NullPointerException.class, () -> BeanUtils.getMappedProperty("", null));
     }
 
+    @Test
     public void testGetMappedProperty3Args() throws Exception {
         assertThrows(NullPointerException.class, () -> BeanUtils.getMappedProperty(null, null));
         assertThrows(NullPointerException.class, () -> BeanUtils.getMappedProperty(null, "", null));
@@ -817,11 +845,12 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * tests getting a nested property
      */
+    @Test
     public void testGetNestedProperty() {
         try {
             final String val = BeanUtils.getNestedProperty(bean, "nested.stringProperty");
             final String comp = bean.getNested().getStringProperty();
-            assertEquals("nested.StringProperty == " + comp, val, comp);
+            assertEquals(val, comp, "nested.StringProperty == " + comp);
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final InvocationTargetException e) {
@@ -834,12 +863,13 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * tests getting a 'whatever' property
      */
+    @Test
     public void testGetSimpleProperty() {
         try {
             final String val = BeanUtils.getSimpleProperty(bean, "shortProperty");
             final String comp = String.valueOf(bean.getShortProperty());
 
-            assertEquals("shortProperty == " + comp, val, comp);
+            assertEquals(val, comp, "shortProperty == " + comp);
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final InvocationTargetException e) {
@@ -852,6 +882,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test {@code getSimpleProperty()} converting to a String.
      */
+    @Test
     public void testGetSimplePropertyDate() {
         String value = null;
         try {
@@ -860,17 +891,20 @@ public class BeanUtilsBeanTestCase extends TestCase {
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("java.util.Date --> String", testUtilDate.toString(), value);
+        assertEquals(testUtilDate.toString(), value, "java.util.Date --> String");
     }
 
+    @Test
     public void testMappedProperty() throws Exception {
         final MappedPropertyTestBean bean = new MappedPropertyTestBean();
 
         BeanUtils.setProperty(bean, "mapproperty(this.that.the-other)", "some.dotty.value");
 
-        assertEquals("Mapped property set correctly", "some.dotty.value", bean.getMapproperty("this.that.the-other"));
+        assertEquals("some.dotty.value", bean.getMapproperty("this.that.the-other"),
+                                "Mapped property set correctly");
     }
 
+    @Test
     public void testPopulate() throws Exception {
         BeanUtilsBean.getInstance().populate(null, null);
         BeanUtilsBean.getInstance().populate("", null);
@@ -880,6 +914,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test populate() method on individual array elements.
      */
+    @Test
     public void testPopulateArrayElements() {
 
         try {
@@ -891,11 +926,11 @@ public class BeanUtilsBeanTestCase extends TestCase {
 
             BeanUtils.populate(bean, map);
 
-            assertEquals("intIndexed[0] is 100", 100, bean.getIntIndexed(0));
-            assertEquals("intIndexed[1] is 10", 10, bean.getIntIndexed(1));
-            assertEquals("intIndexed[2] is 120", 120, bean.getIntIndexed(2));
-            assertEquals("intIndexed[3] is 30", 30, bean.getIntIndexed(3));
-            assertEquals("intIndexed[4] is 140", 140, bean.getIntIndexed(4));
+            assertEquals(100, bean.getIntIndexed(0), "intIndexed[0] is 100");
+            assertEquals(10, bean.getIntIndexed(1), "intIndexed[1] is 10");
+            assertEquals(120, bean.getIntIndexed(2), "intIndexed[2] is 120");
+            assertEquals(30, bean.getIntIndexed(3), "intIndexed[3] is 30");
+            assertEquals(140, bean.getIntIndexed(4), "intIndexed[4] is 140");
 
             map.clear();
             map.put("stringIndexed[1]", "New String 1");
@@ -903,11 +938,11 @@ public class BeanUtilsBeanTestCase extends TestCase {
 
             BeanUtils.populate(bean, map);
 
-            assertEquals("stringIndexed[0] is \"String 0\"", "String 0", bean.getStringIndexed(0));
-            assertEquals("stringIndexed[1] is \"New String 1\"", "New String 1", bean.getStringIndexed(1));
-            assertEquals("stringIndexed[2] is \"String 2\"", "String 2", bean.getStringIndexed(2));
-            assertEquals("stringIndexed[3] is \"New String 3\"", "New String 3", bean.getStringIndexed(3));
-            assertEquals("stringIndexed[4] is \"String 4\"", "String 4", bean.getStringIndexed(4));
+            assertEquals("String 0", bean.getStringIndexed(0), "stringIndexed[0] is \"String 0\"");
+            assertEquals("New String 1", bean.getStringIndexed(1), "stringIndexed[1] is \"New String 1\"");
+            assertEquals("String 2", bean.getStringIndexed(2), "stringIndexed[2] is \"String 2\"");
+            assertEquals("New String 3", bean.getStringIndexed(3), "stringIndexed[3] is \"New String 3\"");
+            assertEquals("String 4", bean.getStringIndexed(4), "stringIndexed[4] is \"String 4\"");
 
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
@@ -920,6 +955,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test populate() method on array properties as a whole.
      */
+    @Test
     public void testPopulateArrayProperties() {
 
         try {
@@ -933,16 +969,16 @@ public class BeanUtilsBeanTestCase extends TestCase {
             BeanUtils.populate(bean, map);
 
             intArray = bean.getIntArray();
-            assertNotNull("intArray is present", intArray);
-            assertEquals("intArray length", 3, intArray.length);
-            assertEquals("intArray[0]", 123, intArray[0]);
-            assertEquals("intArray[1]", 456, intArray[1]);
-            assertEquals("intArray[2]", 789, intArray[2]);
+            assertNotNull(intArray, "intArray is present");
+            assertEquals(3, intArray.length, "intArray length");
+            assertEquals(123, intArray[0], "intArray[0]");
+            assertEquals(456, intArray[1], "intArray[1]");
+            assertEquals(789, intArray[2], "intArray[2]");
             stringArray = bean.getStringArray();
-            assertNotNull("stringArray is present", stringArray);
-            assertEquals("stringArray length", 2, stringArray.length);
-            assertEquals("stringArray[0]", "New String 0", stringArray[0]);
-            assertEquals("stringArray[1]", "New String 1", stringArray[1]);
+            assertNotNull(stringArray, "stringArray is present");
+            assertEquals(2, stringArray.length, "stringArray length");
+            assertEquals("New String 0", stringArray[0], "stringArray[0]");
+            assertEquals("New String 1", stringArray[1], "stringArray[1]");
 
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
@@ -955,6 +991,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test populate() on mapped properties.
      */
+    @Test
     public void testPopulateMapped() {
 
         try {
@@ -965,10 +1002,12 @@ public class BeanUtilsBeanTestCase extends TestCase {
 
             BeanUtils.populate(bean, map);
 
-            assertEquals("mappedProperty(First Key)", "New First Value", bean.getMappedProperty("First Key"));
-            assertEquals("mappedProperty(Second Key)", "Second Value", bean.getMappedProperty("Second Key"));
-            assertEquals("mappedProperty(Third Key)", "New Third Value", bean.getMappedProperty("Third Key"));
-            assertNull("mappedProperty(Fourth Key", bean.getMappedProperty("Fourth Key"));
+            assertEquals("New First Value", bean.getMappedProperty("First Key"),
+                                    "mappedProperty(First Key)");
+            assertEquals("Second Value", bean.getMappedProperty("Second Key"), "mappedProperty(Second Key)");
+            assertEquals("New Third Value", bean.getMappedProperty("Third Key"),
+                                    "mappedProperty(Third Key)");
+            assertNull(bean.getMappedProperty("Fourth Key"), "mappedProperty(Fourth Key");
 
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
@@ -981,6 +1020,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test populate() method on nested properties.
      */
+    @Test
     public void testPopulateNested() {
 
         try {
@@ -998,15 +1038,18 @@ public class BeanUtilsBeanTestCase extends TestCase {
 
             BeanUtils.populate(bean, map);
 
-            assertTrue("booleanProperty is false", !bean.getNested().getBooleanProperty());
-            assertTrue("booleanSecond is true", bean.getNested().isBooleanSecond());
-            assertEquals("doubleProperty is 432.0", 432.0, bean.getNested().getDoubleProperty(), 0.005);
-            assertEquals("floatProperty is 123.0", (float) 123.0, bean.getNested().getFloatProperty(), (float) 0.005);
-            assertEquals("intProperty is 543", 543, bean.getNested().getIntProperty());
-            assertEquals("longProperty is 321", 321, bean.getNested().getLongProperty());
-            assertEquals("shortProperty is 654", (short) 654, bean.getNested().getShortProperty());
-            assertEquals("stringProperty is \"This is a string\"", "This is a string", bean.getNested().getStringProperty());
-            assertEquals("writeOnlyProperty is \"New writeOnlyProperty value\"", "New writeOnlyProperty value", bean.getNested().getWriteOnlyPropertyValue());
+            assertTrue(!bean.getNested().getBooleanProperty(), "booleanProperty is false");
+            assertTrue(bean.getNested().isBooleanSecond(), "booleanSecond is true");
+            assertEquals(432.0, bean.getNested().getDoubleProperty(), 0.005, "doubleProperty is 432.0");
+            assertEquals((float) 123.0, bean.getNested().getFloatProperty(), (float) 0.005,
+                                    "floatProperty is 123.0");
+            assertEquals(543, bean.getNested().getIntProperty(), "intProperty is 543");
+            assertEquals(321, bean.getNested().getLongProperty(), "longProperty is 321");
+            assertEquals((short) 654, bean.getNested().getShortProperty(), "shortProperty is 654");
+            assertEquals("This is a string", bean.getNested().getStringProperty(),
+                                    "stringProperty is \"This is a string\"");
+            assertEquals("New writeOnlyProperty value", bean.getNested().getWriteOnlyPropertyValue(),
+                                    "writeOnlyProperty is \"New writeOnlyProperty value\"");
 
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
@@ -1019,6 +1062,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test populate() method on scalar properties.
      */
+    @Test
     public void testPopulateScalar() {
 
         try {
@@ -1041,18 +1085,21 @@ public class BeanUtilsBeanTestCase extends TestCase {
 
             BeanUtils.populate(bean, map);
 
-            assertTrue("booleanProperty is false", !bean.getBooleanProperty());
-            assertTrue("booleanSecond is true", bean.isBooleanSecond());
-            assertEquals("byteProperty is 111", (byte) 111, bean.getByteProperty());
-            assertEquals("doubleProperty is 432.0", 432.0, bean.getDoubleProperty(), 0.005);
-            assertEquals("floatProperty is 123.0", (float) 123.0, bean.getFloatProperty(), (float) 0.005);
-            assertEquals("intProperty is 543", 543, bean.getIntProperty());
-            assertEquals("longProperty is 0", 0, bean.getLongProperty());
-            assertNull("nullProperty is null", bean.getNullProperty());
-            assertEquals("shortProperty is 654", (short) 654, bean.getShortProperty());
-            assertEquals("stringProperty is \"This is a string\"", "This is a string", bean.getStringProperty());
-            assertEquals("writeOnlyProperty is \"New writeOnlyProperty value\"", "New writeOnlyProperty value", bean.getWriteOnlyPropertyValue());
-            assertEquals("readOnlyProperty is \"Read Only String Property\"", "Read Only String Property", bean.getReadOnlyProperty());
+            assertTrue(!bean.getBooleanProperty(), "booleanProperty is false");
+            assertTrue(bean.isBooleanSecond(), "booleanSecond is true");
+            assertEquals((byte) 111, bean.getByteProperty(), "byteProperty is 111");
+            assertEquals(432.0, bean.getDoubleProperty(), 0.005, "doubleProperty is 432.0");
+            assertEquals((float) 123.0, bean.getFloatProperty(), (float) 0.005, "floatProperty is 123.0");
+            assertEquals(543, bean.getIntProperty(), "intProperty is 543");
+            assertEquals(0, bean.getLongProperty(), "longProperty is 0");
+            assertNull(bean.getNullProperty(), "nullProperty is null");
+            assertEquals((short) 654, bean.getShortProperty(), "shortProperty is 654");
+            assertEquals("This is a string", bean.getStringProperty(),
+                                    "stringProperty is \"This is a string\"");
+            assertEquals("New writeOnlyProperty value", bean.getWriteOnlyPropertyValue(),
+                                    "writeOnlyProperty is \"New writeOnlyProperty value\"");
+            assertEquals("Read Only String Property", bean.getReadOnlyProperty(),
+                                    "readOnlyProperty is \"Read Only String Property\"");
 
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
@@ -1063,6 +1110,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     }
 
     /** Tests that separate instances can register separate instances */
+    @Test
     public void testSeparateInstances() throws Exception {
         final BeanUtilsBean utilsOne = new BeanUtilsBean(new ConvertUtilsBean(), new PropertyUtilsBean());
         final BeanUtilsBean utilsTwo = new BeanUtilsBean(new ConvertUtilsBean(), new PropertyUtilsBean());
@@ -1072,11 +1120,11 @@ public class BeanUtilsBeanTestCase extends TestCase {
         // Make sure what we're testing works
         bean.setBooleanProperty(false);
         utilsOne.setProperty(bean, "booleanProperty", "true");
-        assertEquals("Set property failed (1)", bean.getBooleanProperty(), true);
+        assertEquals(bean.getBooleanProperty(), true, "Set property failed (1)");
 
         bean.setBooleanProperty(false);
         utilsTwo.setProperty(bean, "booleanProperty", "true");
-        assertEquals("Set property failed (2)", bean.getBooleanProperty(), true);
+        assertEquals(bean.getBooleanProperty(), true, "Set property failed (2)");
 
         // now change the registered conversion
 
@@ -1095,7 +1143,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
 
             bean.setBooleanProperty(false);
             utilsTwo.setProperty(bean, "booleanProperty", "true");
-            assertEquals("Set property failed (3)", bean.getBooleanProperty(), true);
+            assertEquals(bean.getBooleanProperty(), true, "Set property failed (3)");
 
         } catch (final PassTestException e) {
             fail("Registered converter is used by other instances");
@@ -1105,6 +1153,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test setting a value out of a mapped Map
      */
+    @Test
     public void testSetMappedMap() {
         final TestBean bean = new TestBean();
         final Map<String, Object> map = new HashMap<>();
@@ -1113,18 +1162,21 @@ public class BeanUtilsBeanTestCase extends TestCase {
         map.put("sub-key-3", "sub-value-3");
         bean.getMapProperty().put("mappedMap", map);
 
-        assertEquals("BEFORE", "sub-value-3", ((Map<?, ?>) bean.getMapProperty().get("mappedMap")).get("sub-key-3"));
+        assertEquals("sub-value-3", ((Map<?, ?>) bean.getMapProperty().get("mappedMap")).get("sub-key-3"),
+                                "BEFORE");
         try {
             BeanUtils.setProperty(bean, "mapProperty(mappedMap)(sub-key-3)", "SUB-KEY-3-UPDATED");
         } catch (final Throwable t) {
             fail("Threw " + t + "");
         }
-        assertEquals("AFTER", "SUB-KEY-3-UPDATED", ((Map<?, ?>) bean.getMapProperty().get("mappedMap")).get("sub-key-3"));
+        assertEquals("SUB-KEY-3-UPDATED", ((Map<?, ?>) bean.getMapProperty().get("mappedMap")).get("sub-key-3"),
+                                "AFTER");
     }
 
     /**
      * Test narrowing and widening conversions on byte.
      */
+    @Test
     public void testSetPropertyByte() throws Exception {
 
         BeanUtils.setProperty(bean, "byteProperty", Byte.valueOf((byte) 123));
@@ -1145,42 +1197,46 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test {@code setProperty()} conversion.
      */
+    @Test
     public void testSetPropertyConvert() {
         try {
             BeanUtils.setProperty(bean, "dateProperty", testCalendar);
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("Calendar --> java.util.Date", testUtilDate, bean.getDateProperty());
+        assertEquals(testUtilDate, bean.getDateProperty(), "Calendar --> java.util.Date");
     }
 
     /**
      * Test {@code setProperty()} converting from a String.
      */
+    @Test
     public void testSetPropertyConvertFromString() {
         try {
             BeanUtils.setProperty(bean, "dateProperty", testStringDate);
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("String --> java.util.Date", testUtilDate, bean.getDateProperty());
+        assertEquals(testUtilDate, bean.getDateProperty(), "String --> java.util.Date");
     }
 
     /**
      * Test {@code setProperty()} converting to a String.
      */
+    @Test
     public void testSetPropertyConvertToString() {
         try {
             BeanUtils.setProperty(bean, "stringProperty", testUtilDate);
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("java.util.Date --> String", testUtilDate.toString(), bean.getStringProperty());
+        assertEquals(testUtilDate.toString(), bean.getStringProperty(), "java.util.Date --> String");
     }
 
     /**
      * Test {@code setProperty()} converting to a String array.
      */
+    @Test
     public void testSetPropertyConvertToStringArray() {
         try {
             bean.setStringArray(null);
@@ -1188,13 +1244,15 @@ public class BeanUtilsBeanTestCase extends TestCase {
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("java.util.Date[] --> String[] length", 1, bean.getStringArray().length);
-        assertEquals("java.util.Date[] --> String[] value ", testUtilDate.toString(), bean.getStringArray()[0]);
+        assertEquals(1, bean.getStringArray().length, "java.util.Date[] --> String[] length");
+        assertEquals(testUtilDate.toString(), bean.getStringArray()[0],
+                                "java.util.Date[] --> String[] value ");
     }
 
     /**
      * Test {@code setProperty()} converting to a String on indexed property
      */
+    @Test
     public void testSetPropertyConvertToStringIndexed() {
         try {
             bean.setStringArray(new String[1]);
@@ -1202,12 +1260,13 @@ public class BeanUtilsBeanTestCase extends TestCase {
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
-        assertEquals("java.util.Date --> String[]", testUtilDate.toString(), bean.getStringArray()[0]);
+        assertEquals(testUtilDate.toString(), bean.getStringArray()[0], "java.util.Date --> String[]");
     }
 
     /**
      * Test narrowing and widening conversions on double.
      */
+    @Test
     public void testSetPropertyDouble() throws Exception {
 
         BeanUtils.setProperty(bean, "doubleProperty", Byte.valueOf((byte) 123));
@@ -1228,6 +1287,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test narrowing and widening conversions on float.
      */
+    @Test
     public void testSetPropertyFloat() throws Exception {
 
         BeanUtils.setProperty(bean, "floatProperty", Byte.valueOf((byte) 123));
@@ -1248,6 +1308,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test narrowing and widening conversions on int.
      */
+    @Test
     public void testSetPropertyInteger() throws Exception {
 
         BeanUtils.setProperty(bean, "longProperty", Byte.valueOf((byte) 123));
@@ -1268,6 +1329,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test narrowing and widening conversions on long.
      */
+    @Test
     public void testSetPropertyLong() throws Exception {
 
         BeanUtils.setProperty(bean, "longProperty", Byte.valueOf((byte) 123));
@@ -1288,17 +1350,19 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test setting a null property value.
      */
+    @Test
     public void testSetPropertyNull() throws Exception {
 
         bean.setNullProperty("non-null value");
         BeanUtils.setProperty(bean, "nullProperty", null);
-        assertNull("nullProperty is null", bean.getNullProperty());
+        assertNull(bean.getNullProperty(), "nullProperty is null");
 
     }
 
     /**
      * Test calling setProperty() with null property values.
      */
+    @Test
     public void testSetPropertyNullValues() throws Exception {
 
         Object oldValue;
@@ -1308,30 +1372,31 @@ public class BeanUtilsBeanTestCase extends TestCase {
         oldValue = PropertyUtils.getSimpleProperty(bean, "stringArray");
         BeanUtils.setProperty(bean, "stringArray", null);
         newValue = PropertyUtils.getSimpleProperty(bean, "stringArray");
-        assertNotNull("stringArray is not null", newValue);
-        assertTrue("stringArray of correct type", newValue instanceof String[]);
-        assertEquals("stringArray length", 1, ((String[]) newValue).length);
+        assertNotNull(newValue, "stringArray is not null");
+        assertTrue(newValue instanceof String[], "stringArray of correct type");
+        assertEquals(1, ((String[]) newValue).length, "stringArray length");
         PropertyUtils.setProperty(bean, "stringArray", oldValue);
 
         // Indexed value into array
         oldValue = PropertyUtils.getSimpleProperty(bean, "stringArray");
         BeanUtils.setProperty(bean, "stringArray[2]", null);
         newValue = PropertyUtils.getSimpleProperty(bean, "stringArray");
-        assertNotNull("stringArray is not null", newValue);
-        assertTrue("stringArray of correct type", newValue instanceof String[]);
-        assertEquals("stringArray length", 5, ((String[]) newValue).length);
-        assertNull("stringArray[2] is null", ((String[]) newValue)[2]);
+        assertNotNull(newValue, "stringArray is not null");
+        assertTrue(newValue instanceof String[], "stringArray of correct type");
+        assertEquals(5, ((String[]) newValue).length, "stringArray length");
+        assertNull(((String[]) newValue)[2], "stringArray[2] is null");
         PropertyUtils.setProperty(bean, "stringArray", oldValue);
 
         // Value into scalar
         BeanUtils.setProperty(bean, "stringProperty", null);
-        assertNull("stringProperty is now null", BeanUtils.getProperty(bean, "stringProperty"));
+        assertNull(BeanUtils.getProperty(bean, "stringProperty"), "stringProperty is now null");
 
     }
 
     /**
      * Test converting to and from primitive wrapper types.
      */
+    @Test
     public void testSetPropertyOnPrimitiveWrappers() throws Exception {
 
         BeanUtils.setProperty(bean, "intProperty", Integer.valueOf(1));
@@ -1344,6 +1409,7 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test narrowing and widening conversions on short.
      */
+    @Test
     public void testSetPropertyShort() throws Exception {
 
         BeanUtils.setProperty(bean, "shortProperty", Byte.valueOf((byte) 123));
@@ -1364,27 +1430,29 @@ public class BeanUtilsBeanTestCase extends TestCase {
     /**
      * Test setting a String value to a String array property
      */
+    @Test
     public void testSetPropertyStringToArray() throws Exception {
         BeanUtils.setProperty(bean, "stringArray", "ABC,DEF,GHI");
         final String[] strArray = bean.getStringArray();
-        assertEquals("length", 3, strArray.length);
-        assertEquals("value[0]", "ABC", strArray[0]);
-        assertEquals("value[1]", "DEF", strArray[1]);
-        assertEquals("value[2]", "GHI", strArray[2]);
+        assertEquals(3, strArray.length, "length");
+        assertEquals("ABC", strArray[0], "value[0]");
+        assertEquals("DEF", strArray[1], "value[1]");
+        assertEquals("GHI", strArray[2], "value[2]");
 
         BeanUtils.setProperty(bean, "intArray", "0, 10, 20, 30, 40");
         final int[] intArray = bean.getIntArray();
-        assertEquals("length", 5, intArray.length);
-        assertEquals("value[0]", 0, intArray[0]);
-        assertEquals("value[1]", 10, intArray[1]);
-        assertEquals("value[2]", 20, intArray[2]);
-        assertEquals("value[3]", 30, intArray[3]);
-        assertEquals("value[4]", 40, intArray[4]);
+        assertEquals(5, intArray.length, "length");
+        assertEquals(0, intArray[0], "value[0]");
+        assertEquals(10, intArray[1], "value[1]");
+        assertEquals(20, intArray[2], "value[2]");
+        assertEquals(30, intArray[3], "value[3]");
+        assertEquals(40, intArray[4], "value[4]");
     }
 
     /**
      * Test setting a new value to a write-only property, with and without conversions.
      */
+    @Test
     public void testSetPropertyWriteOnly() throws Exception {
 
         bean.setWriteOnlyProperty("Original value");

--- a/src/test/java/org/apache/commons/beanutils2/BeanUtilsBenchCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/BeanUtilsBenchCase.java
@@ -21,12 +21,14 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit Test Case containing microbenchmarks for BeanUtils.
  */
-public class BeanUtilsBenchCase extends TestCase {
+public class BeanUtilsBenchCase {
 
     // Basic loop counter
     private long counter = 100000;
@@ -48,18 +50,9 @@ public class BeanUtilsBenchCase extends TestCase {
     private BeanUtilsBean bu;
 
     /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public BeanUtilsBenchCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Sets up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
 
         // Set up loop counter (if property specified)
@@ -114,7 +107,7 @@ public class BeanUtilsBenchCase extends TestCase {
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     public void tearDown() {
         dynaClass = null;
         inBean = null;
@@ -126,6 +119,7 @@ public class BeanUtilsBenchCase extends TestCase {
     }
 
     // Time copyProperties() from a bean
+    @Test
     public void testCopyPropertiesBean() throws Exception {
 
         long startMillis;
@@ -156,6 +150,7 @@ public class BeanUtilsBenchCase extends TestCase {
     }
 
     // Time copyProperties() from a DynaBean
+    @Test
     public void testCopyPropertiesDyna() throws Exception {
 
         long startMillis;
@@ -186,6 +181,7 @@ public class BeanUtilsBenchCase extends TestCase {
     }
 
     // Time copyProperties() from a Map of Objects
+    @Test
     public void testCopyPropertiesMap() throws Exception {
 
         long startMillis;
@@ -216,6 +212,7 @@ public class BeanUtilsBenchCase extends TestCase {
     }
 
     // Time copyProperties() from a Map of Strings
+    @Test
     public void testCopyPropertiesStrs() throws Exception {
 
         long startMillis;
@@ -246,6 +243,7 @@ public class BeanUtilsBenchCase extends TestCase {
     }
 
     // Time populate() from a Map of Objects
+    @Test
     public void testPopulateMap() throws Exception {
 
         long startMillis;
@@ -277,6 +275,7 @@ public class BeanUtilsBenchCase extends TestCase {
 
     // Time populate() from a Map of Strings
     // NOTE - This simulates what Struts does when processing form beans
+    @Test
     public void testPopulateStrs() throws Exception {
 
         long startMillis;

--- a/src/test/java/org/apache/commons/beanutils2/ConstructorUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/ConstructorUtilsTestCase.java
@@ -17,43 +17,42 @@
 
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>
  * Test case for {@code ConstructorUtils}
  * </p>
  */
-public class ConstructorUtilsTestCase extends TestCase {
-
-    /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public ConstructorUtilsTestCase(final String name) {
-        super(name);
-    }
+public class ConstructorUtilsTestCase {
 
     /**
      * Sets up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
     }
 
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
     }
 
+    @Test
     public void testGetAccessibleConstructor() throws Exception {
         {
             final Constructor<?> ctor = ConstructorUtils.getAccessibleConstructor(TestBean.class, String.class);
@@ -71,6 +70,7 @@ public class ConstructorUtilsTestCase extends TestCase {
         }
     }
 
+    @Test
     public void testGetAccessibleConstructorWithConstructorArg() throws Exception {
         {
             final Class<?>[] types = { Integer.class };
@@ -94,6 +94,7 @@ public class ConstructorUtilsTestCase extends TestCase {
         }
     }
 
+    @Test
     public void testGetAccessibleConstructorWithTypeArray() throws Exception {
         {
             final Class<?>[] types = { Boolean.TYPE, String.class };
@@ -108,44 +109,48 @@ public class ConstructorUtilsTestCase extends TestCase {
         }
     }
 
+    @Test
     public void testInvokeConstructor() throws Exception {
         {
             final Object obj = ConstructorUtils.invokeConstructor(TestBean.class, "TEST");
             assertNotNull(obj);
-            assertTrue(obj instanceof TestBean);
+            assertInstanceOf(TestBean.class, obj);
             assertEquals("TEST", ((TestBean) obj).getStringProperty());
         }
         {
             final Object obj = ConstructorUtils.invokeConstructor(TestBean.class, Float.valueOf(17.3f));
             assertNotNull(obj);
-            assertTrue(obj instanceof TestBean);
+            assertInstanceOf(TestBean.class, obj);
             assertEquals(17.3f, ((TestBean) obj).getFloatProperty(), 0.0f);
         }
     }
 
+    @Test
     public void testInvokeConstructorNull() throws Exception {
         final Object obj = ConstructorUtils.invokeConstructor(TestBean.class, (Object) null);
         assertNotNull(obj);
-        assertTrue(obj instanceof TestBean);
+        assertInstanceOf(TestBean.class, obj);
     }
 
+    @Test
     public void testInvokeConstructorWithArgArray() throws Exception {
         final Object[] args = { Float.valueOf(17.3f), "TEST" };
         final Object obj = ConstructorUtils.invokeConstructor(TestBean.class, args);
         assertNotNull(obj);
-        assertTrue(obj instanceof TestBean);
+        assertInstanceOf(TestBean.class, obj);
         assertEquals(17.3f, ((TestBean) obj).getFloatProperty(), 0.0f);
         assertEquals("TEST", ((TestBean) obj).getStringProperty());
     }
 
+    @Test
     public void testInvokeConstructorWithTypeArray() throws Exception {
         {
             final Object[] args = { Boolean.TRUE, "TEST" };
             final Class<?>[] types = { Boolean.TYPE, String.class };
             final Object obj = ConstructorUtils.invokeConstructor(TestBean.class, args, types);
             assertNotNull(obj);
-            assertTrue(obj instanceof TestBean);
-            assertTrue( ((TestBean) obj).getBooleanProperty());
+            assertInstanceOf(TestBean.class, obj);
+            assertTrue(((TestBean) obj).getBooleanProperty());
             assertEquals("TEST", ((TestBean) obj).getStringProperty());
         }
         {
@@ -153,17 +158,18 @@ public class ConstructorUtilsTestCase extends TestCase {
             final Class<?>[] types = { Boolean.class, String.class };
             final Object obj = ConstructorUtils.invokeConstructor(TestBean.class, args, types);
             assertNotNull(obj);
-            assertTrue(obj instanceof TestBean);
-            assertTrue( ((TestBean) obj).isBooleanSecond());
+            assertInstanceOf(TestBean.class, obj);
+            assertTrue(((TestBean) obj).isBooleanSecond());
             assertEquals("TEST", ((TestBean) obj).getStringProperty());
         }
     }
 
+    @Test
     public void testInvokeExactConstructor() throws Exception {
         {
             final Object obj = ConstructorUtils.invokeExactConstructor(TestBean.class, "TEST");
             assertNotNull(obj);
-            assertTrue(obj instanceof TestBean);
+            assertInstanceOf(TestBean.class, obj);
             assertEquals("TEST", ((TestBean) obj).getStringProperty());
         }
         {
@@ -177,11 +183,12 @@ public class ConstructorUtilsTestCase extends TestCase {
         {
             final Object obj = ConstructorUtils.invokeExactConstructor(TestBean.class, Boolean.TRUE);
             assertNotNull(obj);
-            assertTrue(obj instanceof TestBean);
-            assertTrue( ((TestBean) obj).isBooleanSecond());
+            assertInstanceOf(TestBean.class, obj);
+            assertTrue(((TestBean) obj).isBooleanSecond());
         }
     }
 
+    @Test
     public void testInvokeExactConstructorWithArgArray() throws Exception {
         {
             final Object[] args = { Float.valueOf(17.3f), "TEST" };
@@ -196,26 +203,28 @@ public class ConstructorUtilsTestCase extends TestCase {
             final Object[] args = { Boolean.TRUE, "TEST" };
             final Object obj = ConstructorUtils.invokeExactConstructor(TestBean.class, args);
             assertNotNull(obj);
-            assertTrue(obj instanceof TestBean);
-            assertTrue( ((TestBean) obj).isBooleanSecond());
+            assertInstanceOf(TestBean.class, obj);
+            assertTrue(((TestBean) obj).isBooleanSecond());
             assertEquals("TEST", ((TestBean) obj).getStringProperty());
         }
     }
 
+    @Test
     public void testInvokeExactConstructorWithNull() throws Exception {
         final Object obj = ConstructorUtils.invokeExactConstructor(TestBean.class, (Object) null);
         assertNotNull(obj);
-        assertTrue(obj instanceof TestBean);
+        assertInstanceOf(TestBean.class, obj);
     }
 
+    @Test
     public void testInvokeExactConstructorWithTypeArray() throws Exception {
         {
             final Object[] args = { Boolean.TRUE, "TEST" };
             final Class<?>[] types = { Boolean.TYPE, String.class };
             final Object obj = ConstructorUtils.invokeExactConstructor(TestBean.class, args, types);
             assertNotNull(obj);
-            assertTrue(obj instanceof TestBean);
-            assertTrue( ((TestBean) obj).getBooleanProperty());
+            assertInstanceOf(TestBean.class, obj);
+            assertTrue(((TestBean) obj).getBooleanProperty());
             assertEquals("TEST", ((TestBean) obj).getStringProperty());
         }
         {
@@ -223,8 +232,8 @@ public class ConstructorUtilsTestCase extends TestCase {
             final Class<?>[] types = { Boolean.class, String.class };
             final Object obj = ConstructorUtils.invokeExactConstructor(TestBean.class, args, types);
             assertNotNull(obj);
-            assertTrue(obj instanceof TestBean);
-            assertTrue( ((TestBean) obj).isBooleanSecond());
+            assertInstanceOf(TestBean.class, obj);
+            assertTrue(((TestBean) obj).isBooleanSecond());
             assertEquals("TEST", ((TestBean) obj).getStringProperty());
         }
         {
@@ -232,7 +241,7 @@ public class ConstructorUtilsTestCase extends TestCase {
             final Class<?>[] types = { Float.TYPE, String.class };
             final Object obj = ConstructorUtils.invokeExactConstructor(TestBean.class, args, types);
             assertNotNull(obj);
-            assertTrue(obj instanceof TestBean);
+            assertInstanceOf(TestBean.class, obj);
             assertEquals(17.3f, ((TestBean) obj).getFloatProperty(), 0.0f);
             assertEquals("TEST", ((TestBean) obj).getStringProperty());
         }

--- a/src/test/java/org/apache/commons/beanutils2/ConvertUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/ConvertUtilsTestCase.java
@@ -17,6 +17,13 @@
 
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -24,48 +31,35 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.beanutils2.converters.DateConverter;
 import org.apache.commons.lang3.ArrayUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-/**
- * <p>
- * Test Case for the ConvertUtils class.
- * </p>
- */
 
-public class ConvertUtilsTestCase extends TestCase {
-
-    /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public ConvertUtilsTestCase(final String name) {
-        super(name);
-    }
+public class ConvertUtilsTestCase {
 
     private void checkIntegerArray(final Object value, final int[] intArray) {
 
-        assertNotNull("Returned value is not null", value);
-        assertEquals("Returned value is int[]", intArray.getClass(), value.getClass());
+        assertNotNull(value, "Returned value is not null");
+        assertEquals(intArray.getClass(), value.getClass(), "Returned value is int[]");
         final int[] results = (int[]) value;
-        assertEquals("Returned array length", intArray.length, results.length);
+        assertEquals(intArray.length, results.length, "Returned array length");
         for (int i = 0; i < intArray.length; i++) {
-            assertEquals("Returned array value " + i, intArray[i], results[i]);
+            assertEquals(intArray[i], results[i], "Returned array value " + i);
         }
 
     }
 
     private void checkStringArray(final Object value, final String[] stringArray) {
 
-        assertNotNull("Returned value is not null", value);
-        assertEquals("Returned value is String[]", stringArray.getClass(), value.getClass());
+        assertNotNull(value, "Returned value is not null");
+        assertEquals(stringArray.getClass(), value.getClass(), "Returned value is String[]");
         final String[] results = (String[]) value;
-        assertEquals("Returned array length", stringArray.length, results.length);
+        assertEquals(stringArray.length, results.length, "Returned array length");
         for (int i = 0; i < stringArray.length; i++) {
-            assertEquals("Returned array value " + i, stringArray[i], results[i]);
+            assertEquals(stringArray[i], results[i], "Returned array value " + i);
         }
 
     }
@@ -73,7 +67,7 @@ public class ConvertUtilsTestCase extends TestCase {
     /**
      * Sets up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     public void setUp() {
         BeanUtilsBean.setInstance(new BeanUtilsBean());
         ConvertUtils.deregister();
@@ -83,11 +77,12 @@ public class ConvertUtilsTestCase extends TestCase {
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     public void tearDown() {
         // No action required
     }
 
+    @Test
     @SuppressWarnings({ "unchecked", "rawtypes" })
     // We need to use raw types in order to test legacy converters
     public void testConvertToString() throws Exception {
@@ -106,50 +101,55 @@ public class ConvertUtilsTestCase extends TestCase {
         final java.util.Date today = new java.util.Date();
         final DateFormat fmt = new SimpleDateFormat("M/d/yy"); /* US Short Format */
         final String expected = fmt.format(today);
-        assertEquals("DateConverter M/d/yy", expected, utils.convert(today, String.class));
+        assertEquals(expected, utils.convert(today, String.class), "DateConverter M/d/yy");
 
         // Date converter doesn't do String conversion - use String Converter
         utils.register(dummyConverter, java.util.Date.class);
-        assertEquals("Date Converter doesn't do String conversion", "Foo-Converter", utils.convert(today, String.class));
+        assertEquals("Foo-Converter", utils.convert(today, String.class),
+                                "Date Converter doesn't do String conversion");
 
         // No registered Date converter - use String Converter
         utils.deregister(java.util.Date.class);
-        assertEquals("No registered Date converter", "Foo-Converter", utils.convert(today, String.class));
+        assertEquals("Foo-Converter", utils.convert(today, String.class), "No registered Date converter");
 
         // String Converter doesn't do Strings!!!
         utils.register(dummyConverter, String.class);
-        assertEquals("String Converter doesn't do Strings!!!", today.toString(), utils.convert(today, String.class));
+        assertEquals(today.toString(), utils.convert(today, String.class),
+                                "String Converter doesn't do Strings!!!");
 
         // No registered Date or String converter - use Object's toString()
         utils.deregister(String.class);
-        assertEquals("Object's toString()", today.toString(), utils.convert(today, String.class));
+        assertEquals(today.toString(), utils.convert(today, String.class), "Object's toString()");
 
     }
 
     /**
      * Tests a conversion to an unsupported target type.
      */
+    @Test
     public void testConvertUnsupportedTargetType() {
         final ConvertUtilsBean utils = new ConvertUtilsBean();
         final Object value = "A test value";
-        assertSame("Got different object", value, utils.convert(value, getClass()));
+        assertSame(value, utils.convert(value, getClass()), "Got different object");
     }
 
+    @Test
     public void testDeregisteringSingleConverter() throws Exception {
         // make sure that the test work ok before anything's changed
         final Object value = ConvertUtils.convert("true", Boolean.TYPE);
-        assertTrue(value instanceof Boolean);
-        assertEquals("Standard conversion failed (1)", ((Boolean) value).booleanValue(), true);
+        assertInstanceOf(Boolean.class, value);
+        assertEquals(((Boolean) value).booleanValue(), true, "Standard conversion failed (1)");
 
         // we'll test deregister
         ConvertUtils.deregister(Boolean.TYPE);
-        assertNull("Converter should be null", ConvertUtils.lookup(Boolean.TYPE));
+        assertNull(ConvertUtils.lookup(Boolean.TYPE), "Converter should be null");
 
     }
 
     /**
      * Negative String to primitive integer array tests.
      */
+    @Test
     public void testNegativeIntegerArray() {
 
         Object value;
@@ -175,24 +175,25 @@ public class ConvertUtilsTestCase extends TestCase {
     /**
      * Negative scalar conversion tests. These rely on the standard default value conversions in ConvertUtils.
      */
+    @Test
     public void testNegativeScalar() {
 
         Object value;
 
         value = ConvertUtils.convert("foo", Boolean.TYPE);
-        assertTrue(value instanceof Boolean);
+        assertInstanceOf(Boolean.class, value);
         assertEquals(((Boolean) value).booleanValue(), false);
 
         value = ConvertUtils.convert("foo", Boolean.class);
-        assertTrue(value instanceof Boolean);
+        assertInstanceOf(Boolean.class, value);
         assertEquals(((Boolean) value).booleanValue(), false);
 
         value = ConvertUtils.convert("foo", Byte.TYPE);
-        assertTrue(value instanceof Byte);
+        assertInstanceOf(Byte.class, value);
         assertEquals(((Byte) value).byteValue(), (byte) 0);
 
         value = ConvertUtils.convert("foo", Byte.class);
-        assertTrue(value instanceof Byte);
+        assertInstanceOf(Byte.class, value);
         assertEquals(((Byte) value).byteValue(), (byte) 0);
 
         try {
@@ -203,43 +204,43 @@ public class ConvertUtilsTestCase extends TestCase {
         }
 
         value = ConvertUtils.convert("foo", Double.TYPE);
-        assertTrue(value instanceof Double);
+        assertInstanceOf(Double.class, value);
         assertEquals(((Double) value).doubleValue(), 0.0, 0.005);
 
         value = ConvertUtils.convert("foo", Double.class);
-        assertTrue(value instanceof Double);
+        assertInstanceOf(Double.class, value);
         assertEquals(((Double) value).doubleValue(), 0.0, 0.005);
 
         value = ConvertUtils.convert("foo", Float.TYPE);
-        assertTrue(value instanceof Float);
+        assertInstanceOf(Float.class, value);
         assertEquals(((Float) value).floatValue(), (float) 0.0, (float) 0.005);
 
         value = ConvertUtils.convert("foo", Float.class);
-        assertTrue(value instanceof Float);
+        assertInstanceOf(Float.class, value);
         assertEquals(((Float) value).floatValue(), (float) 0.0, (float) 0.005);
 
         value = ConvertUtils.convert("foo", Integer.TYPE);
-        assertTrue(value instanceof Integer);
+        assertInstanceOf(Integer.class, value);
         assertEquals(((Integer) value).intValue(), 0);
 
         value = ConvertUtils.convert("foo", Integer.class);
-        assertTrue(value instanceof Integer);
+        assertInstanceOf(Integer.class, value);
         assertEquals(((Integer) value).intValue(), 0);
 
         value = ConvertUtils.convert("foo", Byte.TYPE);
-        assertTrue(value instanceof Byte);
+        assertInstanceOf(Byte.class, value);
         assertEquals(((Byte) value).byteValue(), (byte) 0);
 
         value = ConvertUtils.convert("foo", Long.class);
-        assertTrue(value instanceof Long);
+        assertInstanceOf(Long.class, value);
         assertEquals(((Long) value).longValue(), 0);
 
         value = ConvertUtils.convert("foo", Short.TYPE);
-        assertTrue(value instanceof Short);
+        assertInstanceOf(Short.class, value);
         assertEquals(((Short) value).shortValue(), (short) 0);
 
         value = ConvertUtils.convert("foo", Short.class);
-        assertTrue(value instanceof Short);
+        assertInstanceOf(Short.class, value);
         assertEquals(((Short) value).shortValue(), (short) 0);
 
     }
@@ -247,6 +248,7 @@ public class ConvertUtilsTestCase extends TestCase {
     /**
      * Negative String to String array tests.
      */
+    @Test
     public void testNegativeStringArray() {
 
         Object value;
@@ -260,6 +262,7 @@ public class ConvertUtilsTestCase extends TestCase {
     /**
      * Test conversion of object to string for arrays.
      */
+    @Test
     public void testObjectToStringArray() {
 
         final int[] intArray0 = {};
@@ -269,38 +272,40 @@ public class ConvertUtilsTestCase extends TestCase {
         final String[] stringArray1 = { "abc" };
         final String[] stringArray2 = { "abc", "def" };
 
-        assertEquals("intArray0", null, ConvertUtils.convert(intArray0));
-        assertEquals("intArray1", "123", ConvertUtils.convert(intArray1));
-        assertEquals("intArray2", "123", ConvertUtils.convert(intArray2));
+        assertEquals(null, ConvertUtils.convert(intArray0), "intArray0");
+        assertEquals("123", ConvertUtils.convert(intArray1), "intArray1");
+        assertEquals("123", ConvertUtils.convert(intArray2), "intArray2");
 
-        assertEquals("stringArray0", null, ConvertUtils.convert(stringArray0));
-        assertEquals("stringArray1", "abc", ConvertUtils.convert(stringArray1));
-        assertEquals("stringArray2", "abc", ConvertUtils.convert(stringArray2));
+        assertEquals(null, ConvertUtils.convert(stringArray0), "stringArray0");
+        assertEquals("abc", ConvertUtils.convert(stringArray1), "stringArray1");
+        assertEquals("abc", ConvertUtils.convert(stringArray2), "stringArray2");
 
     }
 
     /**
      * Test conversion of object to string for scalars.
      */
+    @Test
     public void testObjectToStringScalar() {
 
-        assertEquals("Boolean->String", "false", ConvertUtils.convert(Boolean.FALSE));
-        assertEquals("Boolean->String", "true", ConvertUtils.convert(Boolean.TRUE));
-        assertEquals("Byte->String", "123", ConvertUtils.convert(Byte.valueOf((byte) 123)));
-        assertEquals("Character->String", "a", ConvertUtils.convert(Character.valueOf('a')));
-        assertEquals("Double->String", "123.0", ConvertUtils.convert(Double.valueOf(123.0)));
-        assertEquals("Float->String", "123.0", ConvertUtils.convert(Float.valueOf((float) 123.0)));
-        assertEquals("Integer->String", "123", ConvertUtils.convert(Integer.valueOf(123)));
-        assertEquals("Long->String", "123", ConvertUtils.convert(Long.valueOf(123)));
-        assertEquals("Short->String", "123", ConvertUtils.convert(Short.valueOf((short) 123)));
-        assertEquals("String->String", "abc", ConvertUtils.convert("abc"));
-        assertEquals("String->String null", null, ConvertUtils.convert(null));
+        assertEquals("false", ConvertUtils.convert(Boolean.FALSE), "Boolean->String");
+        assertEquals("true", ConvertUtils.convert(Boolean.TRUE), "Boolean->String");
+        assertEquals("123", ConvertUtils.convert(Byte.valueOf((byte) 123)), "Byte->String");
+        assertEquals("a", ConvertUtils.convert(Character.valueOf('a')), "Character->String");
+        assertEquals("123.0", ConvertUtils.convert(Double.valueOf(123.0)), "Double->String");
+        assertEquals("123.0", ConvertUtils.convert(Float.valueOf((float) 123.0)), "Float->String");
+        assertEquals("123", ConvertUtils.convert(Integer.valueOf(123)), "Integer->String");
+        assertEquals("123", ConvertUtils.convert(Long.valueOf(123)), "Long->String");
+        assertEquals("123", ConvertUtils.convert(Short.valueOf((short) 123)), "Short->String");
+        assertEquals("abc", ConvertUtils.convert("abc"), "String->String");
+        assertEquals(null, ConvertUtils.convert(null), "String->String null");
 
     }
 
     /**
      * Positive array conversion tests.
      */
+    @Test
     public void testPositiveArray() {
 
         final String[] values1 = { "10", "20", "30" };
@@ -325,6 +330,7 @@ public class ConvertUtilsTestCase extends TestCase {
     /**
      * Positive String to primitive integer array tests.
      */
+    @Test
     public void testPositiveIntegerArray() {
 
         Object value;
@@ -360,149 +366,150 @@ public class ConvertUtilsTestCase extends TestCase {
     /**
      * Positive scalar conversion tests.
      */
+    @Test
     public void testPositiveScalar() {
 
         Object value;
 
         value = ConvertUtils.convert("true", Boolean.TYPE);
-        assertTrue(value instanceof Boolean);
+        assertInstanceOf(Boolean.class, value);
         assertEquals(((Boolean) value).booleanValue(), true);
 
         value = ConvertUtils.convert("true", Boolean.class);
-        assertTrue(value instanceof Boolean);
+        assertInstanceOf(Boolean.class, value);
         assertEquals(((Boolean) value).booleanValue(), true);
 
         value = ConvertUtils.convert("yes", Boolean.TYPE);
-        assertTrue(value instanceof Boolean);
+        assertInstanceOf(Boolean.class, value);
         assertEquals(((Boolean) value).booleanValue(), true);
 
         value = ConvertUtils.convert("yes", Boolean.class);
-        assertTrue(value instanceof Boolean);
+        assertInstanceOf(Boolean.class, value);
         assertEquals(((Boolean) value).booleanValue(), true);
 
         value = ConvertUtils.convert("y", Boolean.TYPE);
-        assertTrue(value instanceof Boolean);
+        assertInstanceOf(Boolean.class, value);
         assertEquals(((Boolean) value).booleanValue(), true);
 
         value = ConvertUtils.convert("y", Boolean.class);
-        assertTrue(value instanceof Boolean);
+        assertInstanceOf(Boolean.class, value);
         assertEquals(((Boolean) value).booleanValue(), true);
 
         value = ConvertUtils.convert("on", Boolean.TYPE);
-        assertTrue(value instanceof Boolean);
+        assertInstanceOf(Boolean.class, value);
         assertEquals(((Boolean) value).booleanValue(), true);
 
         value = ConvertUtils.convert("on", Boolean.class);
-        assertTrue(value instanceof Boolean);
+        assertInstanceOf(Boolean.class, value);
         assertEquals(((Boolean) value).booleanValue(), true);
 
         value = ConvertUtils.convert("false", Boolean.TYPE);
-        assertTrue(value instanceof Boolean);
+        assertInstanceOf(Boolean.class, value);
         assertEquals(((Boolean) value).booleanValue(), false);
 
         value = ConvertUtils.convert("false", Boolean.class);
-        assertTrue(value instanceof Boolean);
+        assertInstanceOf(Boolean.class, value);
         assertEquals(((Boolean) value).booleanValue(), false);
 
         value = ConvertUtils.convert("no", Boolean.TYPE);
-        assertTrue(value instanceof Boolean);
+        assertInstanceOf(Boolean.class, value);
         assertEquals(((Boolean) value).booleanValue(), false);
 
         value = ConvertUtils.convert("no", Boolean.class);
-        assertTrue(value instanceof Boolean);
+        assertInstanceOf(Boolean.class, value);
         assertEquals(((Boolean) value).booleanValue(), false);
 
         value = ConvertUtils.convert("n", Boolean.TYPE);
-        assertTrue(value instanceof Boolean);
+        assertInstanceOf(Boolean.class, value);
         assertEquals(((Boolean) value).booleanValue(), false);
 
         value = ConvertUtils.convert("n", Boolean.class);
-        assertTrue(value instanceof Boolean);
+        assertInstanceOf(Boolean.class, value);
         assertEquals(((Boolean) value).booleanValue(), false);
 
         value = ConvertUtils.convert("off", Boolean.TYPE);
-        assertTrue(value instanceof Boolean);
+        assertInstanceOf(Boolean.class, value);
         assertEquals(((Boolean) value).booleanValue(), false);
 
         value = ConvertUtils.convert("off", Boolean.class);
-        assertTrue(value instanceof Boolean);
+        assertInstanceOf(Boolean.class, value);
         assertEquals(((Boolean) value).booleanValue(), false);
 
         value = ConvertUtils.convert("123", Byte.TYPE);
-        assertTrue(value instanceof Byte);
+        assertInstanceOf(Byte.class, value);
         assertEquals(((Byte) value).byteValue(), (byte) 123);
 
         value = ConvertUtils.convert("123", Byte.class);
-        assertTrue(value instanceof Byte);
+        assertInstanceOf(Byte.class, value);
         assertEquals(((Byte) value).byteValue(), (byte) 123);
 
         value = ConvertUtils.convert("a", Character.TYPE);
-        assertTrue(value instanceof Character);
+        assertInstanceOf(Character.class, value);
         assertEquals(((Character) value).charValue(), 'a');
 
         value = ConvertUtils.convert("a", Character.class);
-        assertTrue(value instanceof Character);
+        assertInstanceOf(Character.class, value);
         assertEquals(((Character) value).charValue(), 'a');
 
         value = ConvertUtils.convert("java.lang.String", Class.class);
-        assertTrue(value instanceof Class);
+        assertInstanceOf(Class.class, value);
         assertEquals(String.class, value);
 
         value = ConvertUtils.convert("123.456", Double.TYPE);
-        assertTrue(value instanceof Double);
+        assertInstanceOf(Double.class, value);
         assertEquals(((Double) value).doubleValue(), 123.456, 0.005);
 
         value = ConvertUtils.convert("123.456", Double.class);
-        assertTrue(value instanceof Double);
+        assertInstanceOf(Double.class, value);
         assertEquals(((Double) value).doubleValue(), 123.456, 0.005);
 
         value = ConvertUtils.convert("123.456", Float.TYPE);
-        assertTrue(value instanceof Float);
+        assertInstanceOf(Float.class, value);
         assertEquals(((Float) value).floatValue(), (float) 123.456, (float) 0.005);
 
         value = ConvertUtils.convert("123.456", Float.class);
-        assertTrue(value instanceof Float);
+        assertInstanceOf(Float.class, value);
         assertEquals(((Float) value).floatValue(), (float) 123.456, (float) 0.005);
 
         value = ConvertUtils.convert("123", Integer.TYPE);
-        assertTrue(value instanceof Integer);
+        assertInstanceOf(Integer.class, value);
         assertEquals(((Integer) value).intValue(), 123);
 
         value = ConvertUtils.convert("123", Integer.class);
-        assertTrue(value instanceof Integer);
+        assertInstanceOf(Integer.class, value);
         assertEquals(((Integer) value).intValue(), 123);
 
         value = ConvertUtils.convert("123", Long.TYPE);
-        assertTrue(value instanceof Long);
+        assertInstanceOf(Long.class, value);
         assertEquals(((Long) value).longValue(), 123);
 
         value = ConvertUtils.convert("123", Long.class);
-        assertTrue(value instanceof Long);
+        assertInstanceOf(Long.class, value);
         assertEquals(((Long) value).longValue(), 123);
 
         value = ConvertUtils.convert("123", Short.TYPE);
-        assertTrue(value instanceof Short);
+        assertInstanceOf(Short.class, value);
         assertEquals(((Short) value).shortValue(), (short) 123);
 
         value = ConvertUtils.convert("123", Short.class);
-        assertTrue(value instanceof Short);
+        assertInstanceOf(Short.class, value);
         assertEquals(((Short) value).shortValue(), (short) 123);
 
         String input;
 
         input = "2002-03-17";
         value = ConvertUtils.convert(input, Date.class);
-        assertTrue(value instanceof Date);
+        assertInstanceOf(Date.class, value);
         assertEquals(input, value.toString());
 
         input = "20:30:40";
         value = ConvertUtils.convert(input, Time.class);
-        assertTrue(value instanceof Time);
+        assertInstanceOf(Time.class, value);
         assertEquals(input, value.toString());
 
         input = "2002-03-17 20:30:40.0";
         value = ConvertUtils.convert(input, Timestamp.class);
-        assertTrue(value instanceof Timestamp);
+        assertInstanceOf(Timestamp.class, value);
         assertEquals(input, value.toString());
 
     }
@@ -510,6 +517,7 @@ public class ConvertUtilsTestCase extends TestCase {
     /**
      * Positive String to String array tests.
      */
+    @Test
     public void testPositiveStringArray() {
 
         Object value;
@@ -554,18 +562,19 @@ public class ConvertUtilsTestCase extends TestCase {
 
     }
 
+    @Test
     public void testSeparateConvertInstances() throws Exception {
         final ConvertUtilsBean utilsOne = new ConvertUtilsBean();
         final ConvertUtilsBean utilsTwo = new ConvertUtilsBean();
 
         // make sure that the test work ok before anything's changed
         Object value = utilsOne.convert("true", Boolean.TYPE);
-        assertTrue(value instanceof Boolean);
-        assertEquals("Standard conversion failed (1)", ((Boolean) value).booleanValue(), true);
+        assertInstanceOf(Boolean.class, value);
+        assertEquals(((Boolean) value).booleanValue(), true, "Standard conversion failed (1)");
 
         value = utilsTwo.convert("true", Boolean.TYPE);
-        assertTrue(value instanceof Boolean);
-        assertEquals("Standard conversion failed (2)", ((Boolean) value).booleanValue(), true);
+        assertInstanceOf(Boolean.class, value);
+        assertEquals(((Boolean) value).booleanValue(), true, "Standard conversion failed (2)");
 
         // now register a test
 
@@ -581,8 +590,8 @@ public class ConvertUtilsTestCase extends TestCase {
         try {
             // nothing should have changed
             value = utilsTwo.convert("true", Boolean.TYPE);
-            assertTrue(value instanceof Boolean);
-            assertEquals("Standard conversion failed (3)", ((Boolean) value).booleanValue(), true);
+            assertInstanceOf(Boolean.class, value);
+            assertEquals(((Boolean) value).booleanValue(), true, "Standard conversion failed (3)");
 
         } catch (final PassTestException e) {
             // This is a failure since utilsTwo should still have
@@ -593,12 +602,12 @@ public class ConvertUtilsTestCase extends TestCase {
         // nothing we'll test deregister
         utilsOne.deregister();
         value = utilsOne.convert("true", Boolean.TYPE);
-        assertTrue(value instanceof Boolean);
-        assertEquals("Instance deregister failed.", ((Boolean) value).booleanValue(), true);
+        assertInstanceOf(Boolean.class, value);
+        assertEquals(((Boolean) value).booleanValue(), true, "Instance deregister failed.");
 
         value = utilsTwo.convert("true", Boolean.TYPE);
-        assertTrue(value instanceof Boolean);
-        assertEquals("Standard conversion failed (4)", ((Boolean) value).booleanValue(), true);
+        assertInstanceOf(Boolean.class, value);
+        assertEquals(((Boolean) value).booleanValue(), true, "Standard conversion failed (4)");
     }
 
 }

--- a/src/test/java/org/apache/commons/beanutils2/DefaultIntrospectionContextTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/DefaultIntrospectionContextTestCase.java
@@ -16,19 +16,26 @@
  */
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.util.HashSet;
 import java.util.Set;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for {@code IntrospectionContext}.
  */
-public class DefaultIntrospectionContextTestCase extends TestCase {
+public class DefaultIntrospectionContextTestCase {
 
     /** Constant for the name of a property. */
     private static final String PROP = "foo";
@@ -50,25 +57,26 @@ public class DefaultIntrospectionContextTestCase extends TestCase {
     /** The context to be tested. */
     private DefaultIntrospectionContext context;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         context = new DefaultIntrospectionContext(getClass());
     }
 
     /**
      * Tests whether a property descriptor can be added.
      */
+    @Test
     public void testAddPropertyDescriptor() {
         final PropertyDescriptor desc = createDescriptor(PROP);
         context.addPropertyDescriptor(desc);
-        assertTrue("Property not found", context.hasProperty(PROP));
-        assertSame("Wrong descriptor", desc, context.getPropertyDescriptor(PROP));
+        assertTrue(context.hasProperty(PROP), "Property not found");
+        assertSame(desc, context.getPropertyDescriptor(PROP), "Wrong descriptor");
     }
 
     /**
      * Tries to add a null descriptor.
      */
+    @Test
     public void testAddPropertyDescriptorNull() {
         assertThrows(NullPointerException.class, () -> context.addPropertyDescriptor(null));
     }
@@ -76,6 +84,7 @@ public class DefaultIntrospectionContextTestCase extends TestCase {
     /**
      * Tests whether multiple descriptors can be added.
      */
+    @Test
     public void testAddPropertyDescriptors() {
         final int count = 4;
         final PropertyDescriptor[] descs = new PropertyDescriptor[count];
@@ -89,21 +98,22 @@ public class DefaultIntrospectionContextTestCase extends TestCase {
         context.addPropertyDescriptor(d);
         descSet.add(d);
         final Set<String> names = context.propertyNames();
-        assertEquals("Wrong number of property names", count + 1, names.size());
-        assertTrue("Property not found: " + PROP, names.contains(PROP));
+        assertEquals(count + 1, names.size(), "Wrong number of property names");
+        assertTrue(names.contains(PROP), "Property not found: " + PROP);
         for (int i = 0; i < count; i++) {
-            assertTrue("Property not found: " + PROP + i, names.contains(PROP + i));
+            assertTrue(names.contains(PROP + i), "Property not found: " + PROP + i);
         }
         final PropertyDescriptor[] addedDescs = context.getPropertyDescriptors();
-        assertEquals("Wrong number of added descriptors", count + 1, addedDescs.length);
+        assertEquals(count + 1, addedDescs.length, "Wrong number of added descriptors");
         for (final PropertyDescriptor pd : addedDescs) {
-            assertTrue("Unexpected descriptor: " + pd, descSet.remove(pd));
+            assertTrue(descSet.remove(pd), "Unexpected descriptor: " + pd);
         }
     }
 
     /**
      * Tries to add a null array with property descriptors.
      */
+    @Test
     public void testAddPropertyDescriptorsNull() {
         assertThrows(NullPointerException.class, () -> context.addPropertyDescriptors(null));
     }
@@ -111,32 +121,36 @@ public class DefaultIntrospectionContextTestCase extends TestCase {
     /**
      * Tests getPropertyDescriptor() if the property name is unknown.
      */
+    @Test
     public void testGetPropertyDescriptorUnknown() {
-        assertNull("Got a property (1)", context.getPropertyDescriptor(PROP));
+        assertNull(context.getPropertyDescriptor(PROP), "Got a property (1)");
         context.addPropertyDescriptor(createDescriptor(PROP));
-        assertNull("Got a property (2)", context.getPropertyDescriptor("other"));
+        assertNull(context.getPropertyDescriptor("other"), "Got a property (2)");
     }
 
     /**
      * Tests hasProperty() if the expected result is false.
      */
+    @Test
     public void testHasPropertyFalse() {
-        assertFalse("Wrong result (1)", context.hasProperty(PROP));
+        assertFalse(context.hasProperty(PROP), "Wrong result (1)");
         context.addPropertyDescriptor(createDescriptor(PROP));
-        assertFalse("Wrong result (2)", context.hasProperty("other"));
+        assertFalse(context.hasProperty("other"), "Wrong result (2)");
     }
 
     /**
      * Tests a newly created instance.
      */
+    @Test
     public void testInit() {
-        assertEquals("Wrong current class", getClass(), context.getTargetClass());
-        assertTrue("Got property names", context.propertyNames().isEmpty());
+        assertEquals(getClass(), context.getTargetClass(), "Wrong current class");
+        assertTrue(context.propertyNames().isEmpty(), "Got property names");
     }
 
     /**
      * Tests that the set with property names cannot be changed.
      */
+    @Test
     public void testPropertyNamesModify() {
         final Set<String> names = context.propertyNames();
         try {
@@ -150,10 +164,11 @@ public class DefaultIntrospectionContextTestCase extends TestCase {
     /**
      * Tests whether a descriptor can be removed.
      */
+    @Test
     public void testRemovePropertyDescriptor() {
         context.addPropertyDescriptor(createDescriptor(PROP));
         context.removePropertyDescriptor(PROP);
-        assertTrue("Got property names", context.propertyNames().isEmpty());
-        assertEquals("Got descriptors", 0, context.getPropertyDescriptors().length);
+        assertTrue(context.propertyNames().isEmpty(), "Got property names");
+        assertEquals(0, context.getPropertyDescriptors().length, "Got descriptors");
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/DynaBeanMapDecoratorTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/DynaBeanMapDecoratorTestCase.java
@@ -16,6 +16,11 @@
  */
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -26,7 +31,9 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>
@@ -34,7 +41,7 @@ import junit.framework.TestCase;
  * </p>
  */
 @SuppressWarnings("deprecation")
-public class DynaBeanMapDecoratorTestCase extends TestCase {
+public class DynaBeanMapDecoratorTestCase {
 
     private static final DynaProperty stringProp = new DynaProperty("stringProp", String.class);
     private static final DynaProperty nullProp = new DynaProperty("nullProp", String.class);
@@ -56,15 +63,6 @@ public class DynaBeanMapDecoratorTestCase extends TestCase {
     private Map<String, Object> decoratedMap;
 
     private Map<String, Object> modifiableMap;
-
-    /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public DynaBeanMapDecoratorTestCase(final String name) {
-        super(name);
-    }
 
     /**
      * Check that a Collection is not modifiable
@@ -124,7 +122,7 @@ public class DynaBeanMapDecoratorTestCase extends TestCase {
     /**
      * Sets up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
 
         mapVal.clear();
@@ -146,7 +144,7 @@ public class DynaBeanMapDecoratorTestCase extends TestCase {
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     public void tearDown() {
         dynaBean = null;
         decoratedMap = null;
@@ -156,6 +154,7 @@ public class DynaBeanMapDecoratorTestCase extends TestCase {
     /**
      * Test clear() method
      */
+    @Test
     public void testClear() {
         try {
             decoratedMap.clear();
@@ -174,22 +173,25 @@ public class DynaBeanMapDecoratorTestCase extends TestCase {
     /**
      * Test containsKey() method
      */
+    @Test
     public void testContainsKey() {
-        assertTrue("decoratedMap true", decoratedMap.containsKey(stringProp.getName()));
-        assertFalse("decoratedMap false", decoratedMap.containsKey("xyz"));
+        assertTrue(decoratedMap.containsKey(stringProp.getName()), "decoratedMap true");
+        assertFalse(decoratedMap.containsKey("xyz"), "decoratedMap false");
     }
 
     /**
      * Test containsValue() method
      */
+    @Test
     public void testContainsValue() {
-        assertTrue("decoratedMap true", decoratedMap.containsValue(stringVal));
-        assertFalse("decoratedMap false", decoratedMap.containsValue("xyz"));
+        assertTrue(decoratedMap.containsValue(stringVal), "decoratedMap true");
+        assertFalse(decoratedMap.containsValue("xyz"), "decoratedMap false");
     }
 
     /**
      * Test entrySet() method
      */
+    @Test
     public void testEntrySet() {
         final Set<Map.Entry<String, Object>> set = modifiableMap.entrySet();
 
@@ -198,7 +200,7 @@ public class DynaBeanMapDecoratorTestCase extends TestCase {
         m.put("key", "value");
         checkUnmodifiable("entrySet()", set, m.entrySet().iterator().next());
 
-        assertEquals("entrySet size", properties.length, set.size());
+        assertEquals(properties.length, set.size(), "entrySet size");
 
         final List<String> namesList = new ArrayList<>();
         int i = 0;
@@ -206,22 +208,23 @@ public class DynaBeanMapDecoratorTestCase extends TestCase {
             final String name = entry.getKey();
             namesList.add(name);
             final Object expectValue = decoratedMap.get(name);
-            assertEquals("entrySet(" + i + ") val", expectValue, entry.getValue());
+            assertEquals(expectValue, entry.getValue(), "entrySet(" + i + ") val");
             i++;
         }
         for (int j = 0; j < properties.length; j++) {
             final String name = properties[j].getName();
-            assertTrue("Check property[" + j + "]", namesList.contains(name));
+            assertTrue(namesList.contains(name), "Check property[" + j + "]");
         }
     }
 
     /**
      * Test get() method
      */
+    @Test
     public void testGet() {
 
         // valid property name
-        assertEquals("decoratedMap valid", stringVal, decoratedMap.get(stringProp.getName()));
+        assertEquals(stringVal, decoratedMap.get(stringProp.getName()), "decoratedMap valid");
 
         // invalid property name
         try {
@@ -235,39 +238,43 @@ public class DynaBeanMapDecoratorTestCase extends TestCase {
     /**
      * Test isEmpty() method
      */
+    @Test
     public void testIsEmpty() {
-        assertTrue("Empty", emptyMap.isEmpty());
-        assertFalse("Not Empty", decoratedMap.isEmpty());
+        assertTrue(emptyMap.isEmpty(), "Empty");
+        assertFalse(decoratedMap.isEmpty(), "Not Empty");
     }
 
     /**
      * Test isReadOnly() method
      */
+    @Test
     public void testIsReadOnly() {
-        assertTrue("decoratedMap true", ((DynaBeanPropertyMapDecorator) decoratedMap).isReadOnly());
-        assertFalse("modifiableMap false", ((DynaBeanPropertyMapDecorator) modifiableMap).isReadOnly());
+        assertTrue(((DynaBeanPropertyMapDecorator) decoratedMap).isReadOnly(), "decoratedMap true");
+        assertFalse(((DynaBeanPropertyMapDecorator) modifiableMap).isReadOnly(), "modifiableMap false");
     }
 
     /**
      * Test keySet() method
      */
+    @Test
     public void testKeySet() {
         final Set<String> set = modifiableMap.keySet();
 
         // Check the Set can't be modified
         checkUnmodifiable("keySet()", set, "xyz");
 
-        assertEquals("keySet size", properties.length, set.size());
+        assertEquals(properties.length, set.size(), "keySet size");
 
         for (int i = 0; i < properties.length; i++) {
             final String name = properties[i].getName();
-            assertTrue("Check property[" + i + "]", set.contains(name));
+            assertTrue(set.contains(name), "Check property[" + i + "]");
         }
     }
 
     /**
      * Test put() method
      */
+    @Test
     public void testPut() {
 
         final String newValue = "ABC";
@@ -281,14 +288,15 @@ public class DynaBeanMapDecoratorTestCase extends TestCase {
         }
 
         // Test Writable
-        assertEquals("modifiableMap put", stringVal, modifiableMap.put(stringProp.getName(), newValue));
-        assertEquals("dynaBean get", newValue, dynaBean.get(stringProp.getName()));
-        assertEquals("modifiableMap get", newValue, modifiableMap.get(stringProp.getName()));
+        assertEquals(stringVal, modifiableMap.put(stringProp.getName(), newValue), "modifiableMap put");
+        assertEquals(newValue, dynaBean.get(stringProp.getName()), "dynaBean get");
+        assertEquals(newValue, modifiableMap.get(stringProp.getName()), "modifiableMap get");
     }
 
     /**
      * Test putAll() method
      */
+    @Test
     public void testPutAll() {
 
         final String newValue = "ABC";
@@ -304,14 +312,15 @@ public class DynaBeanMapDecoratorTestCase extends TestCase {
         }
 
         // Test Writable
-        assertEquals("before putAll", stringVal, dynaBean.get(stringProp.getName()));
+        assertEquals(stringVal, dynaBean.get(stringProp.getName()), "before putAll");
         modifiableMap.putAll(newMap);
-        assertEquals("after putAll", newValue, dynaBean.get(stringProp.getName()));
+        assertEquals(newValue, dynaBean.get(stringProp.getName()), "after putAll");
     }
 
     /**
      * Test remove() method
      */
+    @Test
     public void testRemove() {
         try {
             decoratedMap.remove(stringProp.getName());
@@ -330,27 +339,29 @@ public class DynaBeanMapDecoratorTestCase extends TestCase {
     /**
      * Test size() method
      */
+    @Test
     public void testSize() {
-        assertEquals("Empty", 0, emptyMap.size());
-        assertEquals("Not Empty", properties.length, decoratedMap.size());
+        assertEquals(0, emptyMap.size(), "Empty");
+        assertEquals(properties.length, decoratedMap.size(), "Not Empty");
     }
 
     /**
      * Test values() method
      */
+    @Test
     public void testValues() {
         final Collection<Object> collection = modifiableMap.values();
 
         // Check the Collection can't be modified
         checkUnmodifiable("values()", collection, "xyz");
 
-        assertEquals("values size", values.length, collection.size());
+        assertEquals(values.length, collection.size(), "values size");
 
         // Collection should be ordered in same sequence as properties
         final Iterator<Object> iterator = collection.iterator();
         int i = 0;
         while (iterator.hasNext()) {
-            assertEquals("values(" + i + ")", values[i], iterator.next());
+            assertEquals(values[i], iterator.next(), "values(" + i + ")");
             i++;
         }
     }

--- a/src/test/java/org/apache/commons/beanutils2/DynaBeanUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/DynaBeanUtilsTestCase.java
@@ -17,19 +17,27 @@
 
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for BeanUtils when the underlying bean is actually a DynaBean.
  */
-
-public class DynaBeanUtilsTestCase extends TestCase {
+public class DynaBeanUtilsTestCase {
 
     /**
      * Create and return a {@code DynaClass} instance for our test {@code DynaBean}.
@@ -70,39 +78,28 @@ public class DynaBeanUtilsTestCase extends TestCase {
             // "readOnlyProperty",
             "shortProperty", "stringArray", "stringIndexed", "stringProperty" };
 
-    /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public DynaBeanUtilsTestCase(final String name) {
-
-        super(name);
-
-    }
-
     // Ensure that the nested intArray matches the specified values
     protected void checkIntArray(final int[] actual, final int[] expected) {
-        assertNotNull("actual array not null", actual);
-        assertEquals("actual array length", expected.length, actual.length);
+        assertNotNull(actual, "actual array not null");
+        assertEquals(expected.length, actual.length, "actual array length");
         for (int i = 0; i < actual.length; i++) {
-            assertEquals("actual array value[" + i + "]", expected[i], actual[i]);
+            assertEquals(expected[i], actual[i], "actual array value[" + i + "]");
         }
     }
 
     // Ensure that the actual Map matches the expected Map
     protected void checkMap(final Map<?, ?> actual, final Map<?, ?> expected) {
-        assertNotNull("actual map not null", actual);
-        assertEquals("actual map size", expected.size(), actual.size());
+        assertNotNull(actual, "actual map not null");
+        assertEquals(expected.size(), actual.size(), "actual map size");
         for (final Object key : expected.keySet()) {
-            assertEquals("actual map value(" + key + ")", expected.get(key), actual.get(key));
+            assertEquals(expected.get(key), actual.get(key), "actual map value(" + key + ")");
         }
     }
 
     /**
      * Sets up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
 
         ConvertUtils.deregister();
@@ -159,7 +156,7 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     public void tearDown() {
 
         bean = null;
@@ -170,6 +167,7 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * Test the cloneBean() method from a DynaBean.
      */
+    @Test
     public void testCloneDynaBean() {
 
         // Set up an origin bean with customized properties
@@ -200,38 +198,43 @@ public class DynaBeanUtilsTestCase extends TestCase {
         }
 
         // Validate the results for scalar properties
-        assertEquals("Cloned boolean property", false, ((Boolean) clonedBean.get("booleanProperty")).booleanValue());
-        assertEquals("Cloned byte property", (byte) 111, ((Byte) clonedBean.get("byteProperty")).byteValue());
-        assertEquals("Cloned double property", 333.33, ((Double) clonedBean.get("doubleProperty")).doubleValue(), 0.005);
-        assertEquals("Cloned int property", 333, ((Integer) clonedBean.get("intProperty")).intValue());
-        assertEquals("Cloned long property", 3333, ((Long) clonedBean.get("longProperty")).longValue());
-        assertEquals("Cloned short property", (short) 33, ((Short) clonedBean.get("shortProperty")).shortValue());
-        assertEquals("Cloned string property", "Custom string", (String) clonedBean.get("stringProperty"));
+        assertEquals(false, ((Boolean) clonedBean.get("booleanProperty")).booleanValue(),
+                                "Cloned boolean property");
+        assertEquals((byte) 111, ((Byte) clonedBean.get("byteProperty")).byteValue(),
+                                "Cloned byte property");
+        assertEquals(333.33, ((Double) clonedBean.get("doubleProperty")).doubleValue(), 0.005,
+                                "Cloned double property");
+        assertEquals(333, ((Integer) clonedBean.get("intProperty")).intValue(), "Cloned int property");
+        assertEquals(3333, ((Long) clonedBean.get("longProperty")).longValue(), "Cloned long property");
+        assertEquals((short) 33, ((Short) clonedBean.get("shortProperty")).shortValue(),
+                                "Cloned short property");
+        assertEquals("Custom string", (String) clonedBean.get("stringProperty"), "Cloned string property");
 
         // Validate the results for array properties
         final String[] dupProperty = (String[]) clonedBean.get("dupProperty");
-        assertNotNull("dupProperty present", dupProperty);
-        assertEquals("dupProperty length", 3, dupProperty.length);
-        assertEquals("dupProperty[0]", "New 0", dupProperty[0]);
-        assertEquals("dupProperty[1]", "New 1", dupProperty[1]);
-        assertEquals("dupProperty[2]", "New 2", dupProperty[2]);
+        assertNotNull(dupProperty, "dupProperty present");
+        assertEquals(3, dupProperty.length, "dupProperty length");
+        assertEquals("New 0", dupProperty[0], "dupProperty[0]");
+        assertEquals("New 1", dupProperty[1], "dupProperty[1]");
+        assertEquals("New 2", dupProperty[2], "dupProperty[2]");
         final int[] intArray = (int[]) clonedBean.get("intArray");
-        assertNotNull("intArray present", intArray);
-        assertEquals("intArray length", 3, intArray.length);
-        assertEquals("intArray[0]", 100, intArray[0]);
-        assertEquals("intArray[1]", 200, intArray[1]);
-        assertEquals("intArray[2]", 300, intArray[2]);
+        assertNotNull(intArray, "intArray present");
+        assertEquals(3, intArray.length, "intArray length");
+        assertEquals(100, intArray[0], "intArray[0]");
+        assertEquals(200, intArray[1], "intArray[1]");
+        assertEquals(300, intArray[2], "intArray[2]");
         final String[] stringArray = (String[]) clonedBean.get("stringArray");
-        assertNotNull("stringArray present", stringArray);
-        assertEquals("stringArray length", 2, stringArray.length);
-        assertEquals("stringArray[0]", "New 0", stringArray[0]);
-        assertEquals("stringArray[1]", "New 1", stringArray[1]);
+        assertNotNull(stringArray, "stringArray present");
+        assertEquals(2, stringArray.length, "stringArray length");
+        assertEquals("New 0", stringArray[0], "stringArray[0]");
+        assertEquals("New 1", stringArray[1], "stringArray[1]");
 
     }
 
     /**
      * Test the copyProperties() method from a DynaBean.
      */
+    @Test
     public void testCopyPropertiesDynaBean() {
 
         // Set up an origin bean with customized properties
@@ -261,38 +264,41 @@ public class DynaBeanUtilsTestCase extends TestCase {
         }
 
         // Validate the results for scalar properties
-        assertEquals("Copied boolean property", false, ((Boolean) bean.get("booleanProperty")).booleanValue());
-        assertEquals("Copied byte property", (byte) 111, ((Byte) bean.get("byteProperty")).byteValue());
-        assertEquals("Copied double property", 333.33, ((Double) bean.get("doubleProperty")).doubleValue(), 0.005);
-        assertEquals("Copied int property", 333, ((Integer) bean.get("intProperty")).intValue());
-        assertEquals("Copied long property", 3333, ((Long) bean.get("longProperty")).longValue());
-        assertEquals("Copied short property", (short) 33, ((Short) bean.get("shortProperty")).shortValue());
-        assertEquals("Copied string property", "Custom string", (String) bean.get("stringProperty"));
+        assertEquals(false, ((Boolean) bean.get("booleanProperty")).booleanValue(),
+                                "Copied boolean property");
+        assertEquals((byte) 111, ((Byte) bean.get("byteProperty")).byteValue(), "Copied byte property");
+        assertEquals(333.33, ((Double) bean.get("doubleProperty")).doubleValue(), 0.005,
+                                "Copied double property");
+        assertEquals(333, ((Integer) bean.get("intProperty")).intValue(), "Copied int property");
+        assertEquals(3333, ((Long) bean.get("longProperty")).longValue(), "Copied long property");
+        assertEquals((short) 33, ((Short) bean.get("shortProperty")).shortValue(), "Copied short property");
+        assertEquals("Custom string", (String) bean.get("stringProperty"), "Copied string property");
 
         // Validate the results for array properties
         final String[] dupProperty = (String[]) bean.get("dupProperty");
-        assertNotNull("dupProperty present", dupProperty);
-        assertEquals("dupProperty length", 3, dupProperty.length);
-        assertEquals("dupProperty[0]", "New 0", dupProperty[0]);
-        assertEquals("dupProperty[1]", "New 1", dupProperty[1]);
-        assertEquals("dupProperty[2]", "New 2", dupProperty[2]);
+        assertNotNull(dupProperty, "dupProperty present");
+        assertEquals(3, dupProperty.length, "dupProperty length");
+        assertEquals("New 0", dupProperty[0], "dupProperty[0]");
+        assertEquals("New 1", dupProperty[1], "dupProperty[1]");
+        assertEquals("New 2", dupProperty[2], "dupProperty[2]");
         final int[] intArray = (int[]) bean.get("intArray");
-        assertNotNull("intArray present", intArray);
-        assertEquals("intArray length", 3, intArray.length);
-        assertEquals("intArray[0]", 100, intArray[0]);
-        assertEquals("intArray[1]", 200, intArray[1]);
-        assertEquals("intArray[2]", 300, intArray[2]);
+        assertNotNull(intArray, "intArray present");
+        assertEquals(3, intArray.length, "intArray length");
+        assertEquals(100, intArray[0], "intArray[0]");
+        assertEquals(200, intArray[1], "intArray[1]");
+        assertEquals(300, intArray[2], "intArray[2]");
         final String[] stringArray = (String[]) bean.get("stringArray");
-        assertNotNull("stringArray present", stringArray);
-        assertEquals("stringArray length", 2, stringArray.length);
-        assertEquals("stringArray[0]", "New 0", stringArray[0]);
-        assertEquals("stringArray[1]", "New 1", stringArray[1]);
+        assertNotNull(stringArray, "stringArray present");
+        assertEquals(2, stringArray.length, "stringArray length");
+        assertEquals("New 0", stringArray[0], "stringArray[0]");
+        assertEquals("New 1", stringArray[1], "stringArray[1]");
 
     }
 
     /**
      * Test copyProperties() when the origin is a {@code Map}.
      */
+    @Test
     public void testCopyPropertiesMap() {
 
         final Map<String, Object> map = new HashMap<>();
@@ -314,34 +320,36 @@ public class DynaBeanUtilsTestCase extends TestCase {
         }
 
         // Scalar properties
-        assertEquals("booleanProperty", false, ((Boolean) bean.get("booleanProperty")).booleanValue());
-        assertEquals("byteProperty", (byte) 111, ((Byte) bean.get("byteProperty")).byteValue());
-        assertEquals("doubleProperty", 333.0, ((Double) bean.get("doubleProperty")).doubleValue(), 0.005);
-        assertEquals("floatProperty", (float) 222.0, ((Float) bean.get("floatProperty")).floatValue(), (float) 0.005);
-        assertEquals("intProperty", 111, ((Integer) bean.get("intProperty")).intValue());
-        assertEquals("longProperty", 444, ((Long) bean.get("longProperty")).longValue());
-        assertEquals("shortProperty", (short) 555, ((Short) bean.get("shortProperty")).shortValue());
-        assertEquals("stringProperty", "New String Property", (String) bean.get("stringProperty"));
+        assertEquals(false, ((Boolean) bean.get("booleanProperty")).booleanValue(), "booleanProperty");
+        assertEquals((byte) 111, ((Byte) bean.get("byteProperty")).byteValue(), "byteProperty");
+        assertEquals(333.0, ((Double) bean.get("doubleProperty")).doubleValue(), 0.005, "doubleProperty");
+        assertEquals((float) 222.0, ((Float) bean.get("floatProperty")).floatValue(), (float) 0.005,
+                                "floatProperty");
+        assertEquals(111, ((Integer) bean.get("intProperty")).intValue(), "intProperty");
+        assertEquals(444, ((Long) bean.get("longProperty")).longValue(), "longProperty");
+        assertEquals((short) 555, ((Short) bean.get("shortProperty")).shortValue(), "shortProperty");
+        assertEquals("New String Property", (String) bean.get("stringProperty"), "stringProperty");
 
         // Indexed Properties
         final String[] dupProperty = (String[]) bean.get("dupProperty");
-        assertNotNull("dupProperty present", dupProperty);
-        assertEquals("dupProperty length", 3, dupProperty.length);
-        assertEquals("dupProperty[0]", "New 0", dupProperty[0]);
-        assertEquals("dupProperty[1]", "New 1", dupProperty[1]);
-        assertEquals("dupProperty[2]", "New 2", dupProperty[2]);
+        assertNotNull(dupProperty, "dupProperty present");
+        assertEquals(3, dupProperty.length, "dupProperty length");
+        assertEquals("New 0", dupProperty[0], "dupProperty[0]");
+        assertEquals("New 1", dupProperty[1], "dupProperty[1]");
+        assertEquals("New 2", dupProperty[2], "dupProperty[2]");
         final int[] intArray = (int[]) bean.get("intArray");
-        assertNotNull("intArray present", intArray);
-        assertEquals("intArray length", 3, intArray.length);
-        assertEquals("intArray[0]", 0, intArray[0]);
-        assertEquals("intArray[1]", 100, intArray[1]);
-        assertEquals("intArray[2]", 200, intArray[2]);
+        assertNotNull(intArray, "intArray present");
+        assertEquals(3, intArray.length, "intArray length");
+        assertEquals(0, intArray[0], "intArray[0]");
+        assertEquals(100, intArray[1], "intArray[1]");
+        assertEquals(200, intArray[2], "intArray[2]");
 
     }
 
     /**
      * Test the copyProperties() method from a standard JavaBean.
      */
+    @Test
     public void testCopyPropertiesStandard() {
 
         // Set up an origin bean with customized properties
@@ -365,38 +373,41 @@ public class DynaBeanUtilsTestCase extends TestCase {
         }
 
         // Validate the results for scalar properties
-        assertEquals("Copied boolean property", false, ((Boolean) bean.get("booleanProperty")).booleanValue());
-        assertEquals("Copied byte property", (byte) 111, ((Byte) bean.get("byteProperty")).byteValue());
-        assertEquals("Copied double property", 333.33, ((Double) bean.get("doubleProperty")).doubleValue(), 0.005);
-        assertEquals("Copied int property", 333, ((Integer) bean.get("intProperty")).intValue());
-        assertEquals("Copied long property", 3333, ((Long) bean.get("longProperty")).longValue());
-        assertEquals("Copied short property", (short) 33, ((Short) bean.get("shortProperty")).shortValue());
-        assertEquals("Copied string property", "Custom string", (String) bean.get("stringProperty"));
+        assertEquals(false, ((Boolean) bean.get("booleanProperty")).booleanValue(),
+                                "Copied boolean property");
+        assertEquals((byte) 111, ((Byte) bean.get("byteProperty")).byteValue(), "Copied byte property");
+        assertEquals(333.33, ((Double) bean.get("doubleProperty")).doubleValue(), 0.005,
+                                "Copied double property");
+        assertEquals(333, ((Integer) bean.get("intProperty")).intValue(), "Copied int property");
+        assertEquals(3333, ((Long) bean.get("longProperty")).longValue(), "Copied long property");
+        assertEquals((short) 33, ((Short) bean.get("shortProperty")).shortValue(), "Copied short property");
+        assertEquals("Custom string", (String) bean.get("stringProperty"), "Copied string property");
 
         // Validate the results for array properties
         final String[] dupProperty = (String[]) bean.get("dupProperty");
-        assertNotNull("dupProperty present", dupProperty);
-        assertEquals("dupProperty length", 3, dupProperty.length);
-        assertEquals("dupProperty[0]", "New 0", dupProperty[0]);
-        assertEquals("dupProperty[1]", "New 1", dupProperty[1]);
-        assertEquals("dupProperty[2]", "New 2", dupProperty[2]);
+        assertNotNull(dupProperty, "dupProperty present");
+        assertEquals(3, dupProperty.length, "dupProperty length");
+        assertEquals("New 0", dupProperty[0], "dupProperty[0]");
+        assertEquals("New 1", dupProperty[1], "dupProperty[1]");
+        assertEquals("New 2", dupProperty[2], "dupProperty[2]");
         final int[] intArray = (int[]) bean.get("intArray");
-        assertNotNull("intArray present", intArray);
-        assertEquals("intArray length", 3, intArray.length);
-        assertEquals("intArray[0]", 100, intArray[0]);
-        assertEquals("intArray[1]", 200, intArray[1]);
-        assertEquals("intArray[2]", 300, intArray[2]);
+        assertNotNull(intArray, "intArray present");
+        assertEquals(3, intArray.length, "intArray length");
+        assertEquals(100, intArray[0], "intArray[0]");
+        assertEquals(200, intArray[1], "intArray[1]");
+        assertEquals(300, intArray[2], "intArray[2]");
         final String[] stringArray = (String[]) bean.get("stringArray");
-        assertNotNull("stringArray present", stringArray);
-        assertEquals("stringArray length", 2, stringArray.length);
-        assertEquals("stringArray[0]", "New 0", stringArray[0]);
-        assertEquals("stringArray[1]", "New 1", stringArray[1]);
+        assertNotNull(stringArray, "stringArray present");
+        assertEquals(2, stringArray.length, "stringArray length");
+        assertEquals("New 0", stringArray[0], "stringArray[0]");
+        assertEquals("New 1", stringArray[1], "stringArray[1]");
 
     }
 
     /**
      * Test narrowing and widening conversions on byte.
      */
+    @Test
     public void testCopyPropertyByte() throws Exception {
 
         BeanUtils.setProperty(bean, "byteProperty", Byte.valueOf((byte) 123));
@@ -417,6 +428,7 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * Test narrowing and widening conversions on double.
      */
+    @Test
     public void testCopyPropertyDouble() throws Exception {
 
         BeanUtils.setProperty(bean, "doubleProperty", Byte.valueOf((byte) 123));
@@ -437,6 +449,7 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * Test narrowing and widening conversions on float.
      */
+    @Test
     public void testCopyPropertyFloat() throws Exception {
 
         BeanUtils.setProperty(bean, "floatProperty", Byte.valueOf((byte) 123));
@@ -457,6 +470,7 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * Test narrowing and widening conversions on int.
      */
+    @Test
     public void testCopyPropertyInteger() throws Exception {
 
         BeanUtils.setProperty(bean, "longProperty", Byte.valueOf((byte) 123));
@@ -477,6 +491,7 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * Test narrowing and widening conversions on long.
      */
+    @Test
     public void testCopyPropertyLong() throws Exception {
 
         BeanUtils.setProperty(bean, "longProperty", Byte.valueOf((byte) 123));
@@ -497,6 +512,7 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * Test copying a property using a nested indexed array expression, with and without conversions.
      */
+    @Test
     public void testCopyPropertyNestedIndexedArray() throws Exception {
 
         final int[] origArray = { 0, 10, 20, 30, 40 };
@@ -533,6 +549,7 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * Test copying a property using a nested mapped map property.
      */
+    @Test
     public void testCopyPropertyNestedMappedMap() throws Exception {
 
         final Map<String, Object> origMap = new HashMap<>();
@@ -553,6 +570,7 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * Test copying a property using a nested simple expression, with and without conversions.
      */
+    @Test
     public void testCopyPropertyNestedSimple() throws Exception {
 
         bean.set("intProperty", Integer.valueOf(0));
@@ -583,17 +601,19 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * Test copying a null property value.
      */
+    @Test
     public void testCopyPropertyNull() throws Exception {
 
         bean.set("nullProperty", "non-null value");
         BeanUtils.copyProperty(bean, "nullProperty", null);
-        assertNull("nullProperty is null", bean.get("nullProperty"));
+        assertNull(bean.get("nullProperty"), "nullProperty is null");
 
     }
 
     /**
      * Test narrowing and widening conversions on short.
      */
+    @Test
     public void testCopyPropertyShort() throws Exception {
 
         BeanUtils.setProperty(bean, "shortProperty", Byte.valueOf((byte) 123));
@@ -614,6 +634,7 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * Test the describe() method.
      */
+    @Test
     public void testDescribe() {
 
         Map<String, Object> map = null;
@@ -625,36 +646,37 @@ public class DynaBeanUtilsTestCase extends TestCase {
 
         // Verify existence of all the properties that should be present
         for (final String describe : describes) {
-            assertTrue("Property '" + describe + "' is present", map.containsKey(describe));
+            assertTrue(map.containsKey(describe), "Property '" + describe + "' is present");
         }
-        assertTrue("Property 'writeOnlyProperty' is not present", !map.containsKey("writeOnlyProperty"));
+        assertFalse(map.containsKey("writeOnlyProperty"), "Property 'writeOnlyProperty' is not present");
 
         // Verify the values of scalar properties
-        assertEquals("Value of 'booleanProperty'", Boolean.TRUE, map.get("booleanProperty"));
-        assertEquals("Value of 'byteProperty'", Byte.valueOf((byte) 121), map.get("byteProperty"));
-        assertEquals("Value of 'doubleProperty'", Double.valueOf(321.0), map.get("doubleProperty"));
-        assertEquals("Value of 'floatProperty'", Float.valueOf((float) 123.0), map.get("floatProperty"));
-        assertEquals("Value of 'intProperty'", Integer.valueOf(123), map.get("intProperty"));
-        assertEquals("Value of 'longProperty'", Long.valueOf(321), map.get("longProperty"));
-        assertEquals("Value of 'shortProperty'", Short.valueOf((short) 987), map.get("shortProperty"));
-        assertEquals("Value of 'stringProperty'", "This is a string", (String) map.get("stringProperty"));
+        assertEquals(Boolean.TRUE, map.get("booleanProperty"), "Value of 'booleanProperty'");
+        assertEquals(Byte.valueOf((byte) 121), map.get("byteProperty"), "Value of 'byteProperty'");
+        assertEquals(Double.valueOf(321.0), map.get("doubleProperty"), "Value of 'doubleProperty'");
+        assertEquals(Float.valueOf((float) 123.0), map.get("floatProperty"), "Value of 'floatProperty'");
+        assertEquals(Integer.valueOf(123), map.get("intProperty"), "Value of 'intProperty'");
+        assertEquals(Long.valueOf(321), map.get("longProperty"), "Value of 'longProperty'");
+        assertEquals(Short.valueOf((short) 987), map.get("shortProperty"), "Value of 'shortProperty'");
+        assertEquals("This is a string", (String) map.get("stringProperty"), "Value of 'stringProperty'");
 
     }
 
     /**
      * tests the string and int arrays of TestBean
      */
+    @Test
     public void testGetArrayProperty() {
         try {
             String[] arr = BeanUtils.getArrayProperty(bean, "stringArray");
             final String[] comp = (String[]) bean.get("stringArray");
 
-            assertEquals("String array length = " + comp.length, comp.length, arr.length);
+            assertEquals(comp.length, arr.length, "String array length = " + comp.length);
 
             arr = BeanUtils.getArrayProperty(bean, "intArray");
             final int[] iarr = (int[]) bean.get("intArray");
 
-            assertEquals("String array length = " + iarr.length, iarr.length, arr.length);
+            assertEquals(iarr.length, arr.length, "String array length = " + iarr.length);
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final InvocationTargetException e) {
@@ -668,12 +690,13 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * tests getting a 'whatever' property
      */
+    @Test
     public void testGetGeneralProperty() {
         try {
             final String val = BeanUtils.getProperty(bean, "nested.intIndexed[2]");
             final String comp = String.valueOf(bean.get("intIndexed", 2));
 
-            assertEquals("nested.intIndexed[2] == " + comp, val, comp);
+            assertEquals(val, comp, "nested.intIndexed[2] == " + comp);
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final InvocationTargetException e) {
@@ -686,15 +709,16 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * tests getting an indexed property
      */
+    @Test
     public void testGetIndexedProperty1() {
         try {
             String val = BeanUtils.getIndexedProperty(bean, "intIndexed[3]");
             String comp = String.valueOf(bean.get("intIndexed", 3));
-            assertEquals("intIndexed[3] == " + comp, val, comp);
+            assertEquals(val, comp, "intIndexed[3] == " + comp);
 
             val = BeanUtils.getIndexedProperty(bean, "stringIndexed[3]");
             comp = (String) bean.get("stringIndexed", 3);
-            assertEquals("stringIndexed[3] == " + comp, val, comp);
+            assertEquals(val, comp, "stringIndexed[3] == " + comp);
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final InvocationTargetException e) {
@@ -707,17 +731,18 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * tests getting an indexed property
      */
+    @Test
     public void testGetIndexedProperty2() {
         try {
             String val = BeanUtils.getIndexedProperty(bean, "intIndexed", 3);
             String comp = String.valueOf(bean.get("intIndexed", 3));
 
-            assertEquals("intIndexed,3 == " + comp, val, comp);
+            assertEquals(val, comp, "intIndexed,3 == " + comp);
 
             val = BeanUtils.getIndexedProperty(bean, "stringIndexed", 3);
             comp = (String) bean.get("stringIndexed", 3);
 
-            assertEquals("stringIndexed,3 == " + comp, val, comp);
+            assertEquals(val, comp, "stringIndexed,3 == " + comp);
 
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
@@ -731,11 +756,12 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * tests getting a nested property
      */
+    @Test
     public void testGetNestedProperty() {
         try {
             final String val = BeanUtils.getNestedProperty(bean, "nested.stringProperty");
             final String comp = nested.getStringProperty();
-            assertEquals("nested.StringProperty == " + comp, val, comp);
+            assertEquals(val, comp, "nested.StringProperty == " + comp);
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final InvocationTargetException e) {
@@ -748,12 +774,13 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * tests getting a 'whatever' property
      */
+    @Test
     public void testGetSimpleProperty() {
         try {
             final String val = BeanUtils.getSimpleProperty(bean, "shortProperty");
             final String comp = String.valueOf(bean.get("shortProperty"));
 
-            assertEquals("shortProperty == " + comp, val, comp);
+            assertEquals(val, comp, "shortProperty == " + comp);
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final InvocationTargetException e) {
@@ -766,6 +793,7 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * Test populate() method on individual array elements.
      */
+    @Test
     public void testPopulateArrayElements() {
 
         try {
@@ -777,15 +805,15 @@ public class DynaBeanUtilsTestCase extends TestCase {
 
             BeanUtils.populate(bean, map);
             final Integer intIndexed0 = (Integer) bean.get("intIndexed", 0);
-            assertEquals("intIndexed[0] is 100", 100, intIndexed0.intValue());
+            assertEquals(100, intIndexed0.intValue(), "intIndexed[0] is 100");
             final Integer intIndexed1 = (Integer) bean.get("intIndexed", 1);
-            assertEquals("intIndexed[1] is 10", 10, intIndexed1.intValue());
+            assertEquals(10, intIndexed1.intValue(), "intIndexed[1] is 10");
             final Integer intIndexed2 = (Integer) bean.get("intIndexed", 2);
-            assertEquals("intIndexed[2] is 120", 120, intIndexed2.intValue());
+            assertEquals(120, intIndexed2.intValue(), "intIndexed[2] is 120");
             final Integer intIndexed3 = (Integer) bean.get("intIndexed", 3);
-            assertEquals("intIndexed[3] is 30", 30, intIndexed3.intValue());
+            assertEquals(30, intIndexed3.intValue(), "intIndexed[3] is 30");
             final Integer intIndexed4 = (Integer) bean.get("intIndexed", 4);
-            assertEquals("intIndexed[4] is 140", 140, intIndexed4.intValue());
+            assertEquals(140, intIndexed4.intValue(), "intIndexed[4] is 140");
 
             map.clear();
             map.put("stringIndexed[1]", "New String 1");
@@ -793,11 +821,16 @@ public class DynaBeanUtilsTestCase extends TestCase {
 
             BeanUtils.populate(bean, map);
 
-            assertEquals("stringIndexed[0] is \"String 0\"", "String 0", (String) bean.get("stringIndexed", 0));
-            assertEquals("stringIndexed[1] is \"New String 1\"", "New String 1", (String) bean.get("stringIndexed", 1));
-            assertEquals("stringIndexed[2] is \"String 2\"", "String 2", (String) bean.get("stringIndexed", 2));
-            assertEquals("stringIndexed[3] is \"New String 3\"", "New String 3", (String) bean.get("stringIndexed", 3));
-            assertEquals("stringIndexed[4] is \"String 4\"", "String 4", (String) bean.get("stringIndexed", 4));
+            assertEquals("String 0", (String) bean.get("stringIndexed", 0),
+                                    "stringIndexed[0] is \"String 0\"");
+            assertEquals("New String 1", (String) bean.get("stringIndexed", 1),
+                                    "stringIndexed[1] is \"New String 1\"");
+            assertEquals("String 2", (String) bean.get("stringIndexed", 2),
+                                    "stringIndexed[2] is \"String 2\"");
+            assertEquals("New String 3", (String) bean.get("stringIndexed", 3),
+                                    "stringIndexed[3] is \"New String 3\"");
+            assertEquals("String 4", (String) bean.get("stringIndexed", 4),
+                                    "stringIndexed[4] is \"String 4\"");
 
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
@@ -810,6 +843,7 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * Test populate() method on array properties as a whole.
      */
+    @Test
     public void testPopulateArrayProperties() {
 
         try {
@@ -824,16 +858,16 @@ public class DynaBeanUtilsTestCase extends TestCase {
             BeanUtils.populate(bean, map);
 
             final int[] intArray = (int[]) bean.get("intArray");
-            assertNotNull("intArray is present", intArray);
-            assertEquals("intArray length", 3, intArray.length);
-            assertEquals("intArray[0]", 123, intArray[0]);
-            assertEquals("intArray[1]", 456, intArray[1]);
-            assertEquals("intArray[2]", 789, intArray[2]);
+            assertNotNull(intArray, "intArray is present");
+            assertEquals(3, intArray.length, "intArray length");
+            assertEquals(123, intArray[0], "intArray[0]");
+            assertEquals(456, intArray[1], "intArray[1]");
+            assertEquals(789, intArray[2], "intArray[2]");
             stringArray = (String[]) bean.get("stringArray");
-            assertNotNull("stringArray is present", stringArray);
-            assertEquals("stringArray length", 2, stringArray.length);
-            assertEquals("stringArray[0]", "New String 0", stringArray[0]);
-            assertEquals("stringArray[1]", "New String 1", stringArray[1]);
+            assertNotNull(stringArray, "stringArray is present");
+            assertEquals(2, stringArray.length, "stringArray length");
+            assertEquals("New String 0", stringArray[0], "stringArray[0]");
+            assertEquals("New String 1", stringArray[1], "stringArray[1]");
 
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
@@ -846,6 +880,7 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * Test populate() on mapped properties.
      */
+    @Test
     public void testPopulateMapped() {
 
         try {
@@ -856,10 +891,13 @@ public class DynaBeanUtilsTestCase extends TestCase {
 
             BeanUtils.populate(bean, map);
 
-            assertEquals("mappedProperty(First Key)", "New First Value", (String) bean.get("mappedProperty", "First Key"));
-            assertEquals("mappedProperty(Second Key)", "Second Value", (String) bean.get("mappedProperty", "Second Key"));
-            assertEquals("mappedProperty(Third Key)", "New Third Value", (String) bean.get("mappedProperty", "Third Key"));
-            assertNull("mappedProperty(Fourth Key", bean.get("mappedProperty", "Fourth Key"));
+            assertEquals("New First Value", (String) bean.get("mappedProperty", "First Key"),
+                                    "mappedProperty(First Key)");
+            assertEquals("Second Value", (String) bean.get("mappedProperty", "Second Key"),
+                                    "mappedProperty(Second Key)");
+            assertEquals("New Third Value", (String) bean.get("mappedProperty", "Third Key"),
+                                    "mappedProperty(Third Key)");
+            assertNull(bean.get("mappedProperty", "Fourth Key"), "mappedProperty(Fourth Key");
 
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
@@ -872,6 +910,7 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * Test populate() method on nested properties.
      */
+    @Test
     public void testPopulateNested() {
 
         try {
@@ -889,14 +928,15 @@ public class DynaBeanUtilsTestCase extends TestCase {
             BeanUtils.populate(bean, map);
 
             final TestBean nested = (TestBean) bean.get("nested");
-            assertTrue("booleanProperty is false", !nested.getBooleanProperty());
-            assertTrue("booleanSecond is true", nested.isBooleanSecond());
-            assertEquals("doubleProperty is 432.0", 432.0, nested.getDoubleProperty(), 0.005);
-            assertEquals("floatProperty is 123.0", (float) 123.0, nested.getFloatProperty(), (float) 0.005);
-            assertEquals("intProperty is 543", 543, nested.getIntProperty());
-            assertEquals("longProperty is 321", 321, nested.getLongProperty());
-            assertEquals("shortProperty is 654", (short) 654, nested.getShortProperty());
-            assertEquals("stringProperty is \"This is a string\"", "This is a string", nested.getStringProperty());
+            assertFalse(nested.getBooleanProperty(), "booleanProperty is false");
+            assertTrue(nested.isBooleanSecond(), "booleanSecond is true");
+            assertEquals(432.0, nested.getDoubleProperty(), 0.005, "doubleProperty is 432.0");
+            assertEquals((float) 123.0, nested.getFloatProperty(), (float) 0.005, "floatProperty is 123.0");
+            assertEquals(543, nested.getIntProperty(), "intProperty is 543");
+            assertEquals(321, nested.getLongProperty(), "longProperty is 321");
+            assertEquals((short) 654, nested.getShortProperty(), "shortProperty is 654");
+            assertEquals("This is a string", nested.getStringProperty(),
+                                    "stringProperty is \"This is a string\"");
 
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
@@ -909,6 +949,7 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * Test populate() method on scalar properties.
      */
+    @Test
     public void testPopulateScalar() {
 
         try {
@@ -929,21 +970,22 @@ public class DynaBeanUtilsTestCase extends TestCase {
             BeanUtils.populate(bean, map);
 
             final Boolean booleanProperty = (Boolean) bean.get("booleanProperty");
-            assertTrue("booleanProperty is false", !booleanProperty.booleanValue());
+            assertFalse(booleanProperty.booleanValue(), "booleanProperty is false");
             final Boolean booleanSecond = (Boolean) bean.get("booleanSecond");
-            assertTrue("booleanSecond is true", booleanSecond.booleanValue());
+            assertTrue(booleanSecond.booleanValue(), "booleanSecond is true");
             final Double doubleProperty = (Double) bean.get("doubleProperty");
-            assertEquals("doubleProperty is 432.0", 432.0, doubleProperty.doubleValue(), 0.005);
+            assertEquals(432.0, doubleProperty.doubleValue(), 0.005, "doubleProperty is 432.0");
             final Float floatProperty = (Float) bean.get("floatProperty");
-            assertEquals("floatProperty is 123.0", (float) 123.0, floatProperty.floatValue(), (float) 0.005);
+            assertEquals((float) 123.0, floatProperty.floatValue(), (float) 0.005, "floatProperty is 123.0");
             final Integer intProperty = (Integer) bean.get("intProperty");
-            assertEquals("intProperty is 543", 543, intProperty.intValue());
+            assertEquals(543, intProperty.intValue(), "intProperty is 543");
             final Long longProperty = (Long) bean.get("longProperty");
-            assertEquals("longProperty is 321", 321, longProperty.longValue());
-            assertNull("nullProperty is null", bean.get("nullProperty"));
+            assertEquals(321, longProperty.longValue(), "longProperty is 321");
+            assertNull(bean.get("nullProperty"), "nullProperty is null");
             final Short shortProperty = (Short) bean.get("shortProperty");
-            assertEquals("shortProperty is 654", (short) 654, shortProperty.shortValue());
-            assertEquals("stringProperty is \"This is a string\"", "This is a string", (String) bean.get("stringProperty"));
+            assertEquals((short) 654, shortProperty.shortValue(), "shortProperty is 654");
+            assertEquals("This is a string", (String) bean.get("stringProperty"),
+                                    "stringProperty is \"This is a string\"");
 
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
@@ -956,17 +998,19 @@ public class DynaBeanUtilsTestCase extends TestCase {
     /**
      * Test setting a null property value.
      */
+    @Test
     public void testSetPropertyNull() throws Exception {
 
         bean.set("nullProperty", "non-null value");
         BeanUtils.setProperty(bean, "nullProperty", null);
-        assertNull("nullProperty is null", bean.get("nullProperty"));
+        assertNull(bean.get("nullProperty"), "nullProperty is null");
 
     }
 
     /**
      * Test calling setProperty() with null property values.
      */
+    @Test
     public void testSetPropertyNullValues() throws Exception {
 
         Object oldValue;
@@ -976,30 +1020,31 @@ public class DynaBeanUtilsTestCase extends TestCase {
         oldValue = PropertyUtils.getSimpleProperty(bean, "stringArray");
         BeanUtils.setProperty(bean, "stringArray", null);
         newValue = PropertyUtils.getSimpleProperty(bean, "stringArray");
-        assertNotNull("stringArray is not null", newValue);
-        assertTrue("stringArray of correct type", newValue instanceof String[]);
-        assertEquals("stringArray length", 1, ((String[]) newValue).length);
+        assertNotNull(newValue, "stringArray is not null");
+        assertTrue(newValue instanceof String[], "stringArray of correct type");
+        assertEquals(1, ((String[]) newValue).length, "stringArray length");
         PropertyUtils.setProperty(bean, "stringArray", oldValue);
 
         // Indexed value into array
         oldValue = PropertyUtils.getSimpleProperty(bean, "stringArray");
         BeanUtils.setProperty(bean, "stringArray[2]", null);
         newValue = PropertyUtils.getSimpleProperty(bean, "stringArray");
-        assertNotNull("stringArray is not null", newValue);
-        assertTrue("stringArray of correct type", newValue instanceof String[]);
-        assertEquals("stringArray length", 5, ((String[]) newValue).length);
-        assertNull("stringArray[2] is null", ((String[]) newValue)[2]);
+        assertNotNull(newValue, "stringArray is not null");
+        assertTrue(newValue instanceof String[], "stringArray of correct type");
+        assertEquals(5, ((String[]) newValue).length, "stringArray length");
+        assertNull(((String[]) newValue)[2], "stringArray[2] is null");
         PropertyUtils.setProperty(bean, "stringArray", oldValue);
 
         // Value into scalar
         BeanUtils.setProperty(bean, "stringProperty", null);
-        assertNull("stringProperty is now null", BeanUtils.getProperty(bean, "stringProperty"));
+        assertNull(BeanUtils.getProperty(bean, "stringProperty"), "stringProperty is now null");
 
     }
 
     /**
      * Test converting to and from primitive wrapper types.
      */
+    @Test
     public void testSetPropertyOnPrimitiveWrappers() throws Exception {
 
         BeanUtils.setProperty(bean, "intProperty", Integer.valueOf(1));

--- a/src/test/java/org/apache/commons/beanutils2/DynaPropertyTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/DynaPropertyTestCase.java
@@ -16,14 +16,19 @@
  */
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import java.util.Collection;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link DynaProperty}.
  */
-public class DynaPropertyTestCase extends TestCase {
+public class DynaPropertyTestCase {
 
     private DynaProperty testPropertyWithName;
     private DynaProperty testProperty1Duplicate;
@@ -34,21 +39,10 @@ public class DynaPropertyTestCase extends TestCase {
     private DynaProperty testProperty3Duplicate;
 
     /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public DynaPropertyTestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Sets up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-
-        super.setUp();
 
         testPropertyWithName = new DynaProperty("test1");
         testProperty1Duplicate = new DynaProperty("test1");
@@ -63,18 +57,18 @@ public class DynaPropertyTestCase extends TestCase {
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
 
         testPropertyWithName = testProperty1Duplicate = null;
         testPropertyWithNameAndType = testProperty2Duplicate = null;
         testPropertyWithNameAndTypeAndContentType = testProperty3Duplicate = null;
-        super.tearDown();
     }
 
     /**
      * Class under test for boolean equals(Object)
      */
+    @Test
     public void testEqualsObject() {
 
         assertEquals(testPropertyWithName, testProperty1Duplicate);
@@ -88,12 +82,14 @@ public class DynaPropertyTestCase extends TestCase {
     /**
      * Class under test for int hashCode(Object)
      */
+    @Test
     public void testHashCode() {
 
         final int initialHashCode = testPropertyWithNameAndTypeAndContentType.hashCode();
         assertEquals(testPropertyWithName.hashCode(), testProperty1Duplicate.hashCode());
         assertEquals(testPropertyWithNameAndType.hashCode(), testProperty2Duplicate.hashCode());
-        assertEquals(testPropertyWithNameAndTypeAndContentType.hashCode(), testProperty3Duplicate.hashCode());
+        assertEquals(testPropertyWithNameAndTypeAndContentType.hashCode(),
+                                testProperty3Duplicate.hashCode());
         assertEquals(initialHashCode, testPropertyWithNameAndTypeAndContentType.hashCode());
     }
 

--- a/src/test/java/org/apache/commons/beanutils2/DynaPropertyUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/DynaPropertyUtilsTestCase.java
@@ -17,7 +17,13 @@
 
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -25,12 +31,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test accessing DynaBeans transparently via PropertyUtils.
  */
-public class DynaPropertyUtilsTestCase extends TestCase {
+public class DynaPropertyUtilsTestCase {
 
     /**
      * The basic test bean for each test.
@@ -49,15 +57,6 @@ public class DynaPropertyUtilsTestCase extends TestCase {
      * The nested bean pointed at by the "nested" property.
      */
     protected TestBean nested;
-
-    /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public DynaPropertyUtilsTestCase(final String name) {
-        super(name);
-    }
 
     /**
      * Create and return a {@code DynaClass} instance for our test {@code DynaBean}.
@@ -80,7 +79,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Sets up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         // Instantiate a new DynaBean instance
         final DynaClass dynaClass = createDynaClass();
@@ -134,7 +133,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     public void tearDown() {
         bean = null;
         nested = null;
@@ -143,6 +142,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test copyProperties() when the origin is a {@code Map}.
      */
+    @Test
     public void testCopyPropertiesMap() {
         final Map<String, Object> map = new HashMap<>();
         map.put("booleanProperty", Boolean.FALSE);
@@ -161,33 +161,35 @@ public class DynaPropertyUtilsTestCase extends TestCase {
         }
 
         // Scalar properties
-        assertEquals("booleanProperty", false, ((Boolean) bean.get("booleanProperty")).booleanValue());
-        assertEquals("doubleProperty", 333.0, ((Double) bean.get("doubleProperty")).doubleValue(), 0.005);
-        assertEquals("floatProperty", (float) 222.0, ((Float) bean.get("floatProperty")).floatValue(), (float) 0.005);
-        assertEquals("intProperty", 111, ((Integer) bean.get("intProperty")).intValue());
-        assertEquals("longProperty", 444, ((Long) bean.get("longProperty")).longValue());
-        assertEquals("shortProperty", (short) 555, ((Short) bean.get("shortProperty")).shortValue());
-        assertEquals("stringProperty", "New String Property", (String) bean.get("stringProperty"));
+        assertEquals(false, ((Boolean) bean.get("booleanProperty")).booleanValue(), "booleanProperty");
+        assertEquals(333.0, ((Double) bean.get("doubleProperty")).doubleValue(), 0.005, "doubleProperty");
+        assertEquals((float) 222.0, ((Float) bean.get("floatProperty")).floatValue(), (float) 0.005,
+                                "floatProperty");
+        assertEquals(111, ((Integer) bean.get("intProperty")).intValue(), "intProperty");
+        assertEquals(444, ((Long) bean.get("longProperty")).longValue(), "longProperty");
+        assertEquals((short) 555, ((Short) bean.get("shortProperty")).shortValue(), "shortProperty");
+        assertEquals("New String Property", (String) bean.get("stringProperty"), "stringProperty");
 
         // Indexed Properties
         final String[] dupProperty = (String[]) bean.get("dupProperty");
-        assertNotNull("dupProperty present", dupProperty);
-        assertEquals("dupProperty length", 3, dupProperty.length);
-        assertEquals("dupProperty[0]", "New 0", dupProperty[0]);
-        assertEquals("dupProperty[1]", "New 1", dupProperty[1]);
-        assertEquals("dupProperty[2]", "New 2", dupProperty[2]);
+        assertNotNull(dupProperty, "dupProperty present");
+        assertEquals(3, dupProperty.length, "dupProperty length");
+        assertEquals("New 0", dupProperty[0], "dupProperty[0]");
+        assertEquals("New 1", dupProperty[1], "dupProperty[1]");
+        assertEquals("New 2", dupProperty[2], "dupProperty[2]");
         final int[] intArray = (int[]) bean.get("intArray");
-        assertNotNull("intArray present", intArray);
-        assertEquals("intArray length", 3, intArray.length);
-        assertEquals("intArray[0]", 0, intArray[0]);
-        assertEquals("intArray[1]", 100, intArray[1]);
-        assertEquals("intArray[2]", 200, intArray[2]);
+        assertNotNull(intArray, "intArray present");
+        assertEquals(3, intArray.length, "intArray length");
+        assertEquals(0, intArray[0], "intArray[0]");
+        assertEquals(100, intArray[1], "intArray[1]");
+        assertEquals(200, intArray[2], "intArray[2]");
 
     }
 
     /**
      * Test the describe() method.
      */
+    @Test
     public void testDescribe() {
 
         Map<String, Object> map = null;
@@ -199,24 +201,25 @@ public class DynaPropertyUtilsTestCase extends TestCase {
 
         // Verify existence of all the properties that should be present
         for (final String describe : describes) {
-            assertTrue("Property '" + describe + "' is present", map.containsKey(describe));
+            assertTrue(map.containsKey(describe), "Property '" + describe + "' is present");
         }
-        assertTrue("Property 'writeOnlyProperty' is not present", !map.containsKey("writeOnlyProperty"));
+        assertFalse(map.containsKey("writeOnlyProperty"), "Property 'writeOnlyProperty' is not present");
 
         // Verify the values of scalar properties
-        assertEquals("Value of 'booleanProperty'", Boolean.TRUE, map.get("booleanProperty"));
-        assertEquals("Value of 'doubleProperty'", Double.valueOf(321.0), map.get("doubleProperty"));
-        assertEquals("Value of 'floatProperty'", Float.valueOf((float) 123.0), map.get("floatProperty"));
-        assertEquals("Value of 'intProperty'", Integer.valueOf(123), map.get("intProperty"));
-        assertEquals("Value of 'longProperty'", Long.valueOf(321), map.get("longProperty"));
-        assertEquals("Value of 'shortProperty'", Short.valueOf((short) 987), map.get("shortProperty"));
-        assertEquals("Value of 'stringProperty'", "This is a string", (String) map.get("stringProperty"));
+        assertEquals(Boolean.TRUE, map.get("booleanProperty"), "Value of 'booleanProperty'");
+        assertEquals(Double.valueOf(321.0), map.get("doubleProperty"), "Value of 'doubleProperty'");
+        assertEquals(Float.valueOf((float) 123.0), map.get("floatProperty"), "Value of 'floatProperty'");
+        assertEquals(Integer.valueOf(123), map.get("intProperty"), "Value of 'intProperty'");
+        assertEquals(Long.valueOf(321), map.get("longProperty"), "Value of 'longProperty'");
+        assertEquals(Short.valueOf((short) 987), map.get("shortProperty"), "Value of 'shortProperty'");
+        assertEquals("This is a string", (String) map.get("stringProperty"), "Value of 'stringProperty'");
 
     }
 
     /**
      * Corner cases on getIndexedProperty invalid arguments.
      */
+    @Test
     public void testGetIndexedArguments() {
         // Use explicit index argument
         assertThrows(NullPointerException.class, () -> PropertyUtils.getIndexedProperty(null, "intArray", 0));
@@ -237,6 +240,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Positive and negative tests on getIndexedProperty valid arguments.
      */
+    @Test
     public void testGetIndexedValues() {
 
         Object value = null;
@@ -247,45 +251,45 @@ public class DynaPropertyUtilsTestCase extends TestCase {
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "intArray", i);
-                assertNotNull("intArray returned value " + i, value);
-                assertTrue("intArray returned Integer " + i, value instanceof Integer);
-                assertEquals("intArray returned correct " + i, i * 10, ((Integer) value).intValue());
+                assertNotNull(value, "intArray returned value " + i);
+                assertTrue(value instanceof Integer, "intArray returned Integer " + i);
+                assertEquals(i * 10, ((Integer) value).intValue(), "intArray returned correct " + i);
             } catch (final Throwable t) {
                 fail("intArray " + i + " threw " + t);
             }
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "intIndexed", i);
-                assertNotNull("intIndexed returned value " + i, value);
-                assertTrue("intIndexed returned Integer " + i, value instanceof Integer);
-                assertEquals("intIndexed returned correct " + i, i * 10, ((Integer) value).intValue());
+                assertNotNull(value, "intIndexed returned value " + i);
+                assertTrue(value instanceof Integer, "intIndexed returned Integer " + i);
+                assertEquals(i * 10, ((Integer) value).intValue(), "intIndexed returned correct " + i);
             } catch (final Throwable t) {
                 fail("intIndexed " + i + " threw " + t);
             }
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "listIndexed", i);
-                assertNotNull("listIndexed returned value " + i, value);
-                assertTrue("list returned String " + i, value instanceof String);
-                assertEquals("listIndexed returned correct " + i, "String " + i, (String) value);
+                assertNotNull(value, "listIndexed returned value " + i);
+                assertTrue(value instanceof String, "list returned String " + i);
+                assertEquals("String " + i, (String) value, "listIndexed returned correct " + i);
             } catch (final Throwable t) {
                 fail("listIndexed " + i + " threw " + t);
             }
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "stringArray", i);
-                assertNotNull("stringArray returned value " + i, value);
-                assertTrue("stringArray returned String " + i, value instanceof String);
-                assertEquals("stringArray returned correct " + i, "String " + i, (String) value);
+                assertNotNull(value, "stringArray returned value " + i);
+                assertTrue(value instanceof String, "stringArray returned String " + i);
+                assertEquals("String " + i, (String) value, "stringArray returned correct " + i);
             } catch (final Throwable t) {
                 fail("stringArray " + i + " threw " + t);
             }
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "stringIndexed", i);
-                assertNotNull("stringIndexed returned value " + i, value);
-                assertTrue("stringIndexed returned String " + i, value instanceof String);
-                assertEquals("stringIndexed returned correct " + i, "String " + i, (String) value);
+                assertNotNull(value, "stringIndexed returned value " + i);
+                assertTrue(value instanceof String, "stringIndexed returned String " + i);
+                assertEquals("String " + i, (String) value, "stringIndexed returned correct " + i);
             } catch (final Throwable t) {
                 fail("stringIndexed " + i + " threw " + t);
             }
@@ -298,45 +302,45 @@ public class DynaPropertyUtilsTestCase extends TestCase {
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "intArray[" + i + "]");
-                assertNotNull("intArray returned value " + i, value);
-                assertTrue("intArray returned Integer " + i, value instanceof Integer);
-                assertEquals("intArray returned correct " + i, i * 10, ((Integer) value).intValue());
+                assertNotNull(value, "intArray returned value " + i);
+                assertTrue(value instanceof Integer, "intArray returned Integer " + i);
+                assertEquals(i * 10, ((Integer) value).intValue(), "intArray returned correct " + i);
             } catch (final Throwable t) {
                 fail("intArray " + i + " threw " + t);
             }
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "intIndexed[" + i + "]");
-                assertNotNull("intIndexed returned value " + i, value);
-                assertTrue("intIndexed returned Integer " + i, value instanceof Integer);
-                assertEquals("intIndexed returned correct " + i, i * 10, ((Integer) value).intValue());
+                assertNotNull(value, "intIndexed returned value " + i);
+                assertTrue(value instanceof Integer, "intIndexed returned Integer " + i);
+                assertEquals(i * 10, ((Integer) value).intValue(), "intIndexed returned correct " + i);
             } catch (final Throwable t) {
                 fail("intIndexed " + i + " threw " + t);
             }
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "listIndexed[" + i + "]");
-                assertNotNull("listIndexed returned value " + i, value);
-                assertTrue("listIndexed returned String " + i, value instanceof String);
-                assertEquals("listIndexed returned correct " + i, "String " + i, (String) value);
+                assertNotNull(value, "listIndexed returned value " + i);
+                assertTrue(value instanceof String, "listIndexed returned String " + i);
+                assertEquals("String " + i, (String) value, "listIndexed returned correct " + i);
             } catch (final Throwable t) {
                 fail("listIndexed " + i + " threw " + t);
             }
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "stringArray[" + i + "]");
-                assertNotNull("stringArray returned value " + i, value);
-                assertTrue("stringArray returned String " + i, value instanceof String);
-                assertEquals("stringArray returned correct " + i, "String " + i, (String) value);
+                assertNotNull(value, "stringArray returned value " + i);
+                assertTrue(value instanceof String, "stringArray returned String " + i);
+                assertEquals("String " + i, (String) value, "stringArray returned correct " + i);
             } catch (final Throwable t) {
                 fail("stringArray " + i + " threw " + t);
             }
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "stringIndexed[" + i + "]");
-                assertNotNull("stringIndexed returned value " + i, value);
-                assertTrue("stringIndexed returned String " + i, value instanceof String);
-                assertEquals("stringIndexed returned correct " + i, "String " + i, (String) value);
+                assertNotNull(value, "stringIndexed returned value " + i);
+                assertTrue(value instanceof String, "stringIndexed returned String " + i);
+                assertEquals("String " + i, (String) value, "stringIndexed returned correct " + i);
             } catch (final Throwable t) {
                 fail("stringIndexed " + i + " threw " + t);
             }
@@ -440,6 +444,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Corner cases on getMappedProperty invalid arguments.
      */
+    @Test
     public void testGetMappedArguments() {
         // Use explicit key argument
         assertThrows(NullPointerException.class, () -> PropertyUtils.getMappedProperty(null, "mappedProperty", "First Key"));
@@ -455,25 +460,32 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test getting mapped values with periods in the key.
      */
+    @Test
     public void testGetMappedPeriods() {
 
         bean.set("mappedProperty", "key.with.a.dot", "Special Value");
-        assertEquals("Can retrieve directly", "Special Value", (String) bean.get("mappedProperty", "key.with.a.dot"));
+        assertEquals("Special Value", (String) bean.get("mappedProperty", "key.with.a.dot"),
+                                "Can retrieve directly");
         try {
-            assertEquals("Can retrieve via getMappedProperty", "Special Value", PropertyUtils.getMappedProperty(bean, "mappedProperty", "key.with.a.dot"));
+            assertEquals("Special Value",
+                                    PropertyUtils.getMappedProperty(bean, "mappedProperty", "key.with.a.dot"),
+                                    "Can retrieve via getMappedProperty");
         } catch (final Exception e) {
             fail("Thew exception: " + e);
         }
         try {
-            assertEquals("Can retrieve via getNestedProperty", "Special Value", PropertyUtils.getNestedProperty(bean, "mappedProperty(key.with.a.dot)"));
+            assertEquals("Special Value",
+                                    PropertyUtils.getNestedProperty(bean, "mappedProperty(key.with.a.dot)"),
+                                    "Can retrieve via getNestedProperty");
         } catch (final Exception e) {
             fail("Thew exception: " + e);
         }
 
         bean.set("mappedObjects", "nested.property", new TestBean());
-        assertNotNull("Can retrieve directly", bean.get("mappedObjects", "nested.property"));
+        assertNotNull(bean.get("mappedObjects", "nested.property"), "Can retrieve directly");
         try {
-            assertEquals("Can retrieve nested", "This is a string", PropertyUtils.getNestedProperty(bean, "mappedObjects(nested.property).stringProperty"));
+            assertEquals("This is a string", PropertyUtils.getNestedProperty(bean, "mappedObjects(nested.property).stringProperty"),
+                                    "Can retrieve nested");
         } catch (final Exception e) {
             fail("Thew exception: " + e);
         }
@@ -483,25 +495,32 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test getting mapped values with slashes in the key. This is different from periods because slashes are not syntactically significant.
      */
+    @Test
     public void testGetMappedSlashes() {
 
         bean.set("mappedProperty", "key/with/a/slash", "Special Value");
-        assertEquals("Can retrieve directly", "Special Value", bean.get("mappedProperty", "key/with/a/slash"));
+        assertEquals("Special Value", bean.get("mappedProperty", "key/with/a/slash"),
+                                "Can retrieve directly");
         try {
-            assertEquals("Can retrieve via getMappedProperty", "Special Value", PropertyUtils.getMappedProperty(bean, "mappedProperty", "key/with/a/slash"));
+            assertEquals("Special Value",
+                                    PropertyUtils.getMappedProperty(bean, "mappedProperty", "key/with/a/slash"),
+                                    "Can retrieve via getMappedProperty");
         } catch (final Exception e) {
             fail("Thew exception: " + e);
         }
         try {
-            assertEquals("Can retrieve via getNestedProperty", "Special Value", PropertyUtils.getNestedProperty(bean, "mappedProperty(key/with/a/slash)"));
+            assertEquals("Special Value",
+                                    PropertyUtils.getNestedProperty(bean, "mappedProperty(key/with/a/slash)"),
+                                    "Can retrieve via getNestedProperty");
         } catch (final Exception e) {
             fail("Thew exception: " + e);
         }
 
         bean.set("mappedObjects", "nested/property", new TestBean());
-        assertNotNull("Can retrieve directly", bean.get("mappedObjects", "nested/property"));
+        assertNotNull(bean.get("mappedObjects", "nested/property"), "Can retrieve directly");
         try {
-            assertEquals("Can retrieve nested", "This is a string", PropertyUtils.getNestedProperty(bean, "mappedObjects(nested/property).stringProperty"));
+            assertEquals("This is a string", PropertyUtils.getNestedProperty(bean, "mappedObjects(nested/property).stringProperty"),
+                                    "Can retrieve nested");
         } catch (final Exception e) {
             fail("Thew exception: " + e);
         }
@@ -511,6 +530,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Positive and negative tests on getMappedProperty valid arguments.
      */
+    @Test
     public void testGetMappedValues() {
 
         Object value = null;
@@ -519,21 +539,21 @@ public class DynaPropertyUtilsTestCase extends TestCase {
 
         try {
             value = PropertyUtils.getMappedProperty(bean, "mappedProperty", "First Key");
-            assertEquals("Can find first value", "First Value", value);
+            assertEquals("First Value", value, "Can find first value");
         } catch (final Throwable t) {
             fail("Finding first value threw " + t);
         }
 
         try {
             value = PropertyUtils.getMappedProperty(bean, "mappedProperty", "Second Key");
-            assertEquals("Can find second value", "Second Value", value);
+            assertEquals("Second Value", value, "Can find second value");
         } catch (final Throwable t) {
             fail("Finding second value threw " + t);
         }
 
         try {
             value = PropertyUtils.getMappedProperty(bean, "mappedProperty", "Third Key");
-            assertNull("Can not find third value", value);
+            assertNull(value, "Can not find third value");
         } catch (final Throwable t) {
             fail("Finding third value threw " + t);
         }
@@ -542,21 +562,21 @@ public class DynaPropertyUtilsTestCase extends TestCase {
 
         try {
             value = PropertyUtils.getMappedProperty(bean, "mappedProperty(First Key)");
-            assertEquals("Can find first value", "First Value", value);
+            assertEquals("First Value", value, "Can find first value");
         } catch (final Throwable t) {
             fail("Finding first value threw " + t);
         }
 
         try {
             value = PropertyUtils.getMappedProperty(bean, "mappedProperty(Second Key)");
-            assertEquals("Can find second value", "Second Value", value);
+            assertEquals("Second Value", value, "Can find second value");
         } catch (final Throwable t) {
             fail("Finding second value threw " + t);
         }
 
         try {
             value = PropertyUtils.getMappedProperty(bean, "mappedProperty(Third Key)");
-            assertNull("Can not find third value", value);
+            assertNull(value, "Can not find third value");
         } catch (final Throwable t) {
             fail("Finding third value threw " + t);
         }
@@ -565,21 +585,21 @@ public class DynaPropertyUtilsTestCase extends TestCase {
 
         try {
             value = PropertyUtils.getNestedProperty(bean, "mapProperty.First Key");
-            assertEquals("Can find first value", "First Value", value);
+            assertEquals("First Value", value, "Can find first value");
         } catch (final Throwable t) {
             fail("Finding first value threw " + t);
         }
 
         try {
             value = PropertyUtils.getNestedProperty(bean, "mapProperty.Second Key");
-            assertEquals("Can find second value", "Second Value", value);
+            assertEquals("Second Value", value, "Can find second value");
         } catch (final Throwable t) {
             fail("Finding second value threw " + t);
         }
 
         try {
             value = PropertyUtils.getNestedProperty(bean, "mapProperty.Third Key");
-            assertNull("Can not find third value", value);
+            assertNull(value, "Can not find third value");
         } catch (final Throwable t) {
             fail("Finding third value threw " + t);
         }
@@ -589,6 +609,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Corner cases on getNestedProperty invalid arguments.
      */
+    @Test
     public void testGetNestedArguments() {
         assertThrows(NullPointerException.class, () -> PropertyUtils.getNestedProperty(null, "stringProperty"));
         assertThrows(NullPointerException.class, () -> PropertyUtils.getNestedProperty(bean, null));
@@ -597,14 +618,15 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test getNestedProperty on a boolean property.
      */
+    @Test
     public void testGetNestedBoolean() {
 
         try {
             final Object value = PropertyUtils.getNestedProperty(bean, "nested.booleanProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Boolean);
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Boolean, "Got correct type");
             final TestBean nested = (TestBean) bean.get("nested");
-            assertEquals("Got correct value", ((Boolean) value).booleanValue(), nested.getBooleanProperty());
+            assertEquals(((Boolean) value).booleanValue(), nested.getBooleanProperty(), "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -620,14 +642,16 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test getNestedProperty on a double property.
      */
+    @Test
     public void testGetNestedDouble() {
 
         try {
             final Object value = PropertyUtils.getNestedProperty(bean, "nested.doubleProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Double);
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Double, "Got correct type");
             final TestBean nested = (TestBean) bean.get("nested");
-            assertEquals("Got correct value", ((Double) value).doubleValue(), nested.getDoubleProperty(), 0.005);
+            assertEquals(((Double) value).doubleValue(), nested.getDoubleProperty(), 0.005,
+                                    "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -643,14 +667,16 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test getNestedProperty on a float property.
      */
+    @Test
     public void testGetNestedFloat() {
 
         try {
             final Object value = PropertyUtils.getNestedProperty(bean, "nested.floatProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Float);
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Float, "Got correct type");
             final TestBean nested = (TestBean) bean.get("nested");
-            assertEquals("Got correct value", ((Float) value).floatValue(), nested.getFloatProperty(), (float) 0.005);
+            assertEquals(((Float) value).floatValue(), nested.getFloatProperty(), (float) 0.005,
+                                    "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -666,14 +692,15 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test getNestedProperty on an int property.
      */
+    @Test
     public void testGetNestedInt() {
 
         try {
             final Object value = PropertyUtils.getNestedProperty(bean, "nested.intProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Integer);
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Integer, "Got correct type");
             final TestBean nested = (TestBean) bean.get("nested");
-            assertEquals("Got correct value", ((Integer) value).intValue(), nested.getIntProperty());
+            assertEquals(((Integer) value).intValue(), nested.getIntProperty(), "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -689,14 +716,15 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test getNestedProperty on a long property.
      */
+    @Test
     public void testGetNestedLong() {
 
         try {
             final Object value = PropertyUtils.getNestedProperty(bean, "nested.longProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Long);
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Long, "Got correct type");
             final TestBean nested = (TestBean) bean.get("nested");
-            assertEquals("Got correct value", ((Long) value).longValue(), nested.getLongProperty());
+            assertEquals(((Long) value).longValue(), nested.getLongProperty(), "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -712,14 +740,15 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test getNestedProperty on a read-only String property.
      */
+    @Test
     public void testGetNestedReadOnly() {
 
         try {
             final Object value = PropertyUtils.getNestedProperty(bean, "nested.readOnlyProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof String);
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof String, "Got correct type");
             final TestBean nested = (TestBean) bean.get("nested");
-            assertEquals("Got correct value", (String) value, nested.getReadOnlyProperty());
+            assertEquals((String) value, nested.getReadOnlyProperty(), "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -735,14 +764,15 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test getNestedProperty on a short property.
      */
+    @Test
     public void testGetNestedShort() {
 
         try {
             final Object value = PropertyUtils.getNestedProperty(bean, "nested.shortProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Short);
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Short, "Got correct type");
             final TestBean nested = (TestBean) bean.get("nested");
-            assertEquals("Got correct value", ((Short) value).shortValue(), nested.getShortProperty());
+            assertEquals(((Short) value).shortValue(), nested.getShortProperty(), "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -758,14 +788,15 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test getNestedProperty on a String property.
      */
+    @Test
     public void testGetNestedString() {
 
         try {
             final Object value = PropertyUtils.getNestedProperty(bean, "nested.stringProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof String);
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof String, "Got correct type");
             final TestBean nested = (TestBean) bean.get("nested");
-            assertEquals("Got correct value", (String) value, nested.getStringProperty());
+            assertEquals((String) value, nested.getStringProperty(), "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -781,6 +812,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Negative test getNestedProperty on an unknown property.
      */
+    @Test
     public void testGetNestedUnknown() {
 
         try {
@@ -801,6 +833,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Corner cases on getSimpleProperty invalid arguments.
      */
+    @Test
     public void testGetSimpleArguments() {
         assertThrows(NullPointerException.class, () -> PropertyUtils.getSimpleProperty(null, "stringProperty"));
         assertThrows(NullPointerException.class, () -> PropertyUtils.getSimpleProperty(bean, null));
@@ -809,13 +842,14 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test getSimpleProperty on a boolean property.
      */
+    @Test
     public void testGetSimpleBoolean() {
 
         try {
             final Object value = PropertyUtils.getSimpleProperty(bean, "booleanProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Boolean);
-            assertTrue("Got correct value", ((Boolean) value).booleanValue());
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Boolean, "Got correct type");
+            assertTrue(((Boolean) value).booleanValue(), "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -831,13 +865,14 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test getSimpleProperty on a double property.
      */
+    @Test
     public void testGetSimpleDouble() {
 
         try {
             final Object value = PropertyUtils.getSimpleProperty(bean, "doubleProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Double);
-            assertEquals("Got correct value", ((Double) value).doubleValue(), 321.0, 0.005);
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Double, "Got correct type");
+            assertEquals(((Double) value).doubleValue(), 321.0, 0.005, "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -853,13 +888,14 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test getSimpleProperty on a float property.
      */
+    @Test
     public void testGetSimpleFloat() {
 
         try {
             final Object value = PropertyUtils.getSimpleProperty(bean, "floatProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Float);
-            assertEquals("Got correct value", ((Float) value).floatValue(), (float) 123.0, (float) 0.005);
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Float, "Got correct type");
+            assertEquals(((Float) value).floatValue(), (float) 123.0, (float) 0.005, "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -875,6 +911,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Negative test getSimpleProperty on an indexed property.
      */
+    @Test
     public void testGetSimpleIndexed() {
 
         try {
@@ -895,13 +932,14 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test getSimpleProperty on an int property.
      */
+    @Test
     public void testGetSimpleInt() {
 
         try {
             final Object value = PropertyUtils.getSimpleProperty(bean, "intProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Integer);
-            assertEquals("Got correct value", ((Integer) value).intValue(), 123);
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Integer, "Got correct type");
+            assertEquals(((Integer) value).intValue(), 123, "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -917,13 +955,14 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test getSimpleProperty on a long property.
      */
+    @Test
     public void testGetSimpleLong() {
 
         try {
             final Object value = PropertyUtils.getSimpleProperty(bean, "longProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Long);
-            assertEquals("Got correct value", ((Long) value).longValue(), 321);
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Long, "Got correct type");
+            assertEquals(((Long) value).longValue(), 321, "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -939,6 +978,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Negative test getSimpleProperty on a nested property.
      */
+    @Test
     public void testGetSimpleNested() {
 
         try {
@@ -959,13 +999,14 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test getSimpleProperty on a short property.
      */
+    @Test
     public void testGetSimpleShort() {
 
         try {
             final Object value = PropertyUtils.getSimpleProperty(bean, "shortProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Short);
-            assertEquals("Got correct value", ((Short) value).shortValue(), (short) 987);
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Short, "Got correct type");
+            assertEquals(((Short) value).shortValue(), (short) 987, "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -981,13 +1022,14 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test getSimpleProperty on a String property.
      */
+    @Test
     public void testGetSimpleString() {
 
         try {
             final Object value = PropertyUtils.getSimpleProperty(bean, "stringProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof String);
-            assertEquals("Got correct value", (String) value, "This is a string");
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof String, "Got correct type");
+            assertEquals((String) value, "This is a string", "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1003,6 +1045,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Negative test getSimpleProperty on an unknown property.
      */
+    @Test
     public void testGetSimpleUnknown() {
 
         try {
@@ -1016,7 +1059,8 @@ public class DynaPropertyUtilsTestCase extends TestCase {
             fail("InvocationTargetException");
         } catch (final NoSuchMethodException e) {
             // Correct result for this test
-            assertEquals("Unknown property 'unknown' on dynaclass '" + bean.getDynaClass() + "'", e.getMessage());
+            assertEquals("Unknown property 'unknown' on dynaclass '" + bean.getDynaClass() + "'",
+                                    e.getMessage());
         }
 
     }
@@ -1024,6 +1068,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Corner cases on setIndexedProperty invalid arguments.
      */
+    @Test
     public void testSetIndexedArguments() {
         // Use explicit index argument
         assertThrows(NullPointerException.class, () -> PropertyUtils.setIndexedProperty(null, "intArray", 0, Integer.valueOf(1)));
@@ -1044,6 +1089,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Positive and negative tests on setIndexedProperty valid arguments.
      */
+    @Test
     public void testSetIndexedValues() {
 
         Object value = null;
@@ -1053,9 +1099,9 @@ public class DynaPropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "intArray", 0, Integer.valueOf(1));
             value = PropertyUtils.getIndexedProperty(bean, "intArray", 0);
-            assertNotNull("Returned new value 0", value);
-            assertTrue("Returned Integer new value 0", value instanceof Integer);
-            assertEquals("Returned correct new value 0", 1, ((Integer) value).intValue());
+            assertNotNull(value, "Returned new value 0");
+            assertTrue(value instanceof Integer, "Returned Integer new value 0");
+            assertEquals(1, ((Integer) value).intValue(), "Returned correct new value 0");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -1063,9 +1109,9 @@ public class DynaPropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "intIndexed", 1, Integer.valueOf(11));
             value = PropertyUtils.getIndexedProperty(bean, "intIndexed", 1);
-            assertNotNull("Returned new value 1", value);
-            assertTrue("Returned Integer new value 1", value instanceof Integer);
-            assertEquals("Returned correct new value 1", 11, ((Integer) value).intValue());
+            assertNotNull(value, "Returned new value 1");
+            assertTrue(value instanceof Integer, "Returned Integer new value 1");
+            assertEquals(11, ((Integer) value).intValue(), "Returned correct new value 1");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -1073,9 +1119,9 @@ public class DynaPropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "listIndexed", 2, "New Value 2");
             value = PropertyUtils.getIndexedProperty(bean, "listIndexed", 2);
-            assertNotNull("Returned new value 2", value);
-            assertTrue("Returned String new value 2", value instanceof String);
-            assertEquals("Returned correct new value 2", "New Value 2", (String) value);
+            assertNotNull(value, "Returned new value 2");
+            assertTrue(value instanceof String, "Returned String new value 2");
+            assertEquals("New Value 2", (String) value, "Returned correct new value 2");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -1083,9 +1129,9 @@ public class DynaPropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "stringArray", 2, "New Value 2");
             value = PropertyUtils.getIndexedProperty(bean, "stringArray", 2);
-            assertNotNull("Returned new value 2", value);
-            assertTrue("Returned String new value 2", value instanceof String);
-            assertEquals("Returned correct new value 2", "New Value 2", (String) value);
+            assertNotNull(value, "Returned new value 2");
+            assertTrue(value instanceof String, "Returned String new value 2");
+            assertEquals("New Value 2", (String) value, "Returned correct new value 2");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -1093,9 +1139,9 @@ public class DynaPropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "stringArray", 3, "New Value 3");
             value = PropertyUtils.getIndexedProperty(bean, "stringArray", 3);
-            assertNotNull("Returned new value 3", value);
-            assertTrue("Returned String new value 3", value instanceof String);
-            assertEquals("Returned correct new value 3", "New Value 3", (String) value);
+            assertNotNull(value, "Returned new value 3");
+            assertTrue(value instanceof String, "Returned String new value 3");
+            assertEquals("New Value 3", (String) value, "Returned correct new value 3");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -1105,9 +1151,9 @@ public class DynaPropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "intArray[4]", Integer.valueOf(1));
             value = PropertyUtils.getIndexedProperty(bean, "intArray[4]");
-            assertNotNull("Returned new value 4", value);
-            assertTrue("Returned Integer new value 4", value instanceof Integer);
-            assertEquals("Returned correct new value 4", 1, ((Integer) value).intValue());
+            assertNotNull(value, "Returned new value 4");
+            assertTrue(value instanceof Integer, "Returned Integer new value 4");
+            assertEquals(1, ((Integer) value).intValue(), "Returned correct new value 4");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -1115,9 +1161,9 @@ public class DynaPropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "intIndexed[3]", Integer.valueOf(11));
             value = PropertyUtils.getIndexedProperty(bean, "intIndexed[3]");
-            assertNotNull("Returned new value 5", value);
-            assertTrue("Returned Integer new value 5", value instanceof Integer);
-            assertEquals("Returned correct new value 5", 11, ((Integer) value).intValue());
+            assertNotNull(value, "Returned new value 5");
+            assertTrue(value instanceof Integer, "Returned Integer new value 5");
+            assertEquals(11, ((Integer) value).intValue(), "Returned correct new value 5");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -1125,9 +1171,9 @@ public class DynaPropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "listIndexed[1]", "New Value 2");
             value = PropertyUtils.getIndexedProperty(bean, "listIndexed[1]");
-            assertNotNull("Returned new value 6", value);
-            assertTrue("Returned String new value 6", value instanceof String);
-            assertEquals("Returned correct new value 6", "New Value 2", (String) value);
+            assertNotNull(value, "Returned new value 6");
+            assertTrue(value instanceof String, "Returned String new value 6");
+            assertEquals("New Value 2", (String) value, "Returned correct new value 6");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -1135,9 +1181,9 @@ public class DynaPropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "stringArray[1]", "New Value 2");
             value = PropertyUtils.getIndexedProperty(bean, "stringArray[2]");
-            assertNotNull("Returned new value 6", value);
-            assertTrue("Returned String new value 6", value instanceof String);
-            assertEquals("Returned correct new value 6", "New Value 2", (String) value);
+            assertNotNull(value, "Returned new value 6");
+            assertTrue(value instanceof String, "Returned String new value 6");
+            assertEquals("New Value 2", (String) value, "Returned correct new value 6");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -1145,9 +1191,9 @@ public class DynaPropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "stringArray[0]", "New Value 3");
             value = PropertyUtils.getIndexedProperty(bean, "stringArray[0]");
-            assertNotNull("Returned new value 7", value);
-            assertTrue("Returned String new value 7", value instanceof String);
-            assertEquals("Returned correct new value 7", "New Value 3", (String) value);
+            assertNotNull(value, "Returned new value 7");
+            assertTrue(value instanceof String, "Returned String new value 7");
+            assertEquals("New Value 3", (String) value, "Returned correct new value 7");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -1249,6 +1295,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Corner cases on getMappedProperty invalid arguments.
      */
+    @Test
     public void testSetMappedArguments() {
         // Use explicit key argument
         assertThrows(NullPointerException.class, () -> PropertyUtils.setMappedProperty(null, "mappedProperty", "First Key", "First Value"));
@@ -1263,6 +1310,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Positive and negative tests on setMappedProperty valid arguments.
      */
+    @Test
     public void testSetMappedValues() {
 
         Object value = null;
@@ -1271,7 +1319,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
 
         try {
             value = PropertyUtils.getMappedProperty(bean, "mappedProperty", "Fourth Key");
-            assertNull("Can not find fourth value", value);
+            assertNull(value, "Can not find fourth value");
         } catch (final Throwable t) {
             fail("Finding fourth value threw " + t);
         }
@@ -1284,7 +1332,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
 
         try {
             value = PropertyUtils.getMappedProperty(bean, "mappedProperty", "Fourth Key");
-            assertEquals("Can find fourth value", "Fourth Value", value);
+            assertEquals("Fourth Value", value, "Can find fourth value");
         } catch (final Throwable t) {
             fail("Finding fourth value threw " + t);
         }
@@ -1293,7 +1341,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
 
         try {
             value = PropertyUtils.getMappedProperty(bean, "mappedProperty(Fifth Key)");
-            assertNull("Can not find fifth value", value);
+            assertNull(value, "Can not find fifth value");
         } catch (final Throwable t) {
             fail("Finding fifth value threw " + t);
         }
@@ -1306,7 +1354,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
 
         try {
             value = PropertyUtils.getMappedProperty(bean, "mappedProperty(Fifth Key)");
-            assertEquals("Can find fifth value", "Fifth Value", value);
+            assertEquals("Fifth Value", value, "Can find fifth value");
         } catch (final Throwable t) {
             fail("Finding fifth value threw " + t);
         }
@@ -1315,7 +1363,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
 
         try {
             value = PropertyUtils.getNestedProperty(bean, "mapProperty.Sixth Key");
-            assertNull("Can not find sixth value", value);
+            assertNull(value, "Can not find sixth value");
         } catch (final Throwable t) {
             fail("Finding fifth value threw " + t);
         }
@@ -1328,7 +1376,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
 
         try {
             value = PropertyUtils.getNestedProperty(bean, "mapProperty.Sixth Key");
-            assertEquals("Can find sixth value", "Sixth Value", value);
+            assertEquals("Sixth Value", value, "Can find sixth value");
         } catch (final Throwable t) {
             fail("Finding sixth value threw " + t);
         }
@@ -1338,6 +1386,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Corner cases on setNestedProperty invalid arguments.
      */
+    @Test
     public void testSetNestedArguments() {
         assertThrows(NullPointerException.class, () -> PropertyUtils.setNestedProperty(null, "stringProperty", ""));
         assertThrows(NullPointerException.class, () -> PropertyUtils.setNestedProperty(bean, null, ""));
@@ -1346,13 +1395,14 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test setNextedProperty on a boolean property.
      */
+    @Test
     public void testSetNestedBoolean() {
 
         try {
             final boolean oldValue = nested.getBooleanProperty();
             final boolean newValue = !oldValue;
             PropertyUtils.setNestedProperty(bean, "nested.booleanProperty", Boolean.valueOf(newValue));
-            assertEquals("Matched new value", newValue, nested.getBooleanProperty());
+            assertEquals(newValue, nested.getBooleanProperty(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1368,13 +1418,14 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test setNestedProperty on a double property.
      */
+    @Test
     public void testSetNestedDouble() {
 
         try {
             final double oldValue = nested.getDoubleProperty();
             final double newValue = oldValue + 1.0;
             PropertyUtils.setNestedProperty(bean, "nested.doubleProperty", Double.valueOf(newValue));
-            assertEquals("Matched new value", newValue, nested.getDoubleProperty(), 0.005);
+            assertEquals(newValue, nested.getDoubleProperty(), 0.005, "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1390,13 +1441,14 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test setNestedProperty on a float property.
      */
+    @Test
     public void testSetNestedFloat() {
 
         try {
             final float oldValue = nested.getFloatProperty();
             final float newValue = oldValue + (float) 1.0;
             PropertyUtils.setNestedProperty(bean, "nested.floatProperty", Float.valueOf(newValue));
-            assertEquals("Matched new value", newValue, nested.getFloatProperty(), (float) 0.005);
+            assertEquals(newValue, nested.getFloatProperty(), (float) 0.005, "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1412,13 +1464,14 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test setNestedProperty on a int property.
      */
+    @Test
     public void testSetNestedInt() {
 
         try {
             final int oldValue = nested.getIntProperty();
             final int newValue = oldValue + 1;
             PropertyUtils.setNestedProperty(bean, "nested.intProperty", Integer.valueOf(newValue));
-            assertEquals("Matched new value", newValue, nested.getIntProperty());
+            assertEquals(newValue, nested.getIntProperty(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1434,13 +1487,14 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test setNestedProperty on a long property.
      */
+    @Test
     public void testSetNestedLong() {
 
         try {
             final long oldValue = nested.getLongProperty();
             final long newValue = oldValue + 1;
             PropertyUtils.setNestedProperty(bean, "nested.longProperty", Long.valueOf(newValue));
-            assertEquals("Matched new value", newValue, nested.getLongProperty());
+            assertEquals(newValue, nested.getLongProperty(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1456,6 +1510,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test setNestedProperty on a read-only String property.
      */
+    @Test
     public void testSetNestedReadOnly() {
 
         try {
@@ -1478,6 +1533,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test setNestedProperty on a short property.
      */
+    @Test
     public void testSetNestedShort() {
 
         try {
@@ -1485,7 +1541,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
             short newValue = oldValue;
             newValue++;
             PropertyUtils.setNestedProperty(bean, "nested.shortProperty", Short.valueOf(newValue));
-            assertEquals("Matched new value", newValue, nested.getShortProperty());
+            assertEquals(newValue, nested.getShortProperty(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1501,13 +1557,14 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test setNestedProperty on a String property.
      */
+    @Test
     public void testSetNestedString() {
 
         try {
             final String oldValue = nested.getStringProperty();
             final String newValue = oldValue + " Extra Value";
             PropertyUtils.setNestedProperty(bean, "nested.stringProperty", newValue);
-            assertEquals("Matched new value", newValue, nested.getStringProperty());
+            assertEquals(newValue, nested.getStringProperty(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1523,6 +1580,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test setNestedProperty on an unknown property name.
      */
+    @Test
     public void testSetNestedUnknown() {
 
         try {
@@ -1544,13 +1602,14 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test setNestedProperty on a write-only String property.
      */
+    @Test
     public void testSetNestedWriteOnly() {
 
         try {
             final String oldValue = nested.getWriteOnlyPropertyValue();
             final String newValue = oldValue + " Extra Value";
             PropertyUtils.setNestedProperty(bean, "nested.writeOnlyProperty", newValue);
-            assertEquals("Matched new value", newValue, nested.getWriteOnlyPropertyValue());
+            assertEquals(newValue, nested.getWriteOnlyPropertyValue(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1566,6 +1625,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Corner cases on setSimpleProperty invalid arguments.
      */
+    @Test
     public void testSetSimpleArguments() {
         assertThrows(NullPointerException.class, () -> PropertyUtils.setSimpleProperty(null, "stringProperty", ""));
         assertThrows(NullPointerException.class, () -> PropertyUtils.setSimpleProperty(bean, null, ""));
@@ -1574,13 +1634,15 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test setSimpleProperty on a boolean property.
      */
+    @Test
     public void testSetSimpleBoolean() {
 
         try {
             final boolean oldValue = ((Boolean) bean.get("booleanProperty")).booleanValue();
             final boolean newValue = !oldValue;
             PropertyUtils.setSimpleProperty(bean, "booleanProperty", Boolean.valueOf(newValue));
-            assertEquals("Matched new value", newValue, ((Boolean) bean.get("booleanProperty")).booleanValue());
+            assertEquals(newValue, ((Boolean) bean.get("booleanProperty")).booleanValue(),
+                                    "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1596,13 +1658,15 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test setSimpleProperty on a double property.
      */
+    @Test
     public void testSetSimpleDouble() {
 
         try {
             final double oldValue = ((Double) bean.get("doubleProperty")).doubleValue();
             final double newValue = oldValue + 1.0;
             PropertyUtils.setSimpleProperty(bean, "doubleProperty", Double.valueOf(newValue));
-            assertEquals("Matched new value", newValue, ((Double) bean.get("doubleProperty")).doubleValue(), 0.005);
+            assertEquals(newValue, ((Double) bean.get("doubleProperty")).doubleValue(), 0.005,
+                                    "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1618,13 +1682,15 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test setSimpleProperty on a float property.
      */
+    @Test
     public void testSetSimpleFloat() {
 
         try {
             final float oldValue = ((Float) bean.get("floatProperty")).floatValue();
             final float newValue = oldValue + (float) 1.0;
             PropertyUtils.setSimpleProperty(bean, "floatProperty", Float.valueOf(newValue));
-            assertEquals("Matched new value", newValue, ((Float) bean.get("floatProperty")).floatValue(), (float) 0.005);
+            assertEquals(newValue, ((Float) bean.get("floatProperty")).floatValue(), (float) 0.005,
+                                    "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1640,6 +1706,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Negative test setSimpleProperty on an indexed property.
      */
+    @Test
     public void testSetSimpleIndexed() {
 
         try {
@@ -1660,13 +1727,14 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test setSimpleProperty on a int property.
      */
+    @Test
     public void testSetSimpleInt() {
 
         try {
             final int oldValue = ((Integer) bean.get("intProperty")).intValue();
             final int newValue = oldValue + 1;
             PropertyUtils.setSimpleProperty(bean, "intProperty", Integer.valueOf(newValue));
-            assertEquals("Matched new value", newValue, ((Integer) bean.get("intProperty")).intValue());
+            assertEquals(newValue, ((Integer) bean.get("intProperty")).intValue(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1682,13 +1750,14 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test setSimpleProperty on a long property.
      */
+    @Test
     public void testSetSimpleLong() {
 
         try {
             final long oldValue = ((Long) bean.get("longProperty")).longValue();
             final long newValue = oldValue + 1;
             PropertyUtils.setSimpleProperty(bean, "longProperty", Long.valueOf(newValue));
-            assertEquals("Matched new value", newValue, ((Long) bean.get("longProperty")).longValue());
+            assertEquals(newValue, ((Long) bean.get("longProperty")).longValue(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1704,6 +1773,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Negative test setSimpleProperty on a nested property.
      */
+    @Test
     public void testSetSimpleNested() {
 
         try {
@@ -1724,6 +1794,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test setSimpleProperty on a short property.
      */
+    @Test
     public void testSetSimpleShort() {
 
         try {
@@ -1731,7 +1802,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
             short newValue = oldValue;
             newValue++;
             PropertyUtils.setSimpleProperty(bean, "shortProperty", Short.valueOf(newValue));
-            assertEquals("Matched new value", newValue, ((Short) bean.get("shortProperty")).shortValue());
+            assertEquals(newValue, ((Short) bean.get("shortProperty")).shortValue(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1747,13 +1818,14 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test setSimpleProperty on a String property.
      */
+    @Test
     public void testSetSimpleString() {
 
         try {
             final String oldValue = (String) bean.get("stringProperty");
             final String newValue = oldValue + " Extra Value";
             PropertyUtils.setSimpleProperty(bean, "stringProperty", newValue);
-            assertEquals("Matched new value", newValue, (String) bean.get("stringProperty"));
+            assertEquals(newValue, (String) bean.get("stringProperty"), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1769,6 +1841,7 @@ public class DynaPropertyUtilsTestCase extends TestCase {
     /**
      * Test setSimpleProperty on an unknown property name.
      */
+    @Test
     public void testSetSimpleUnknown() {
 
         try {
@@ -1783,7 +1856,8 @@ public class DynaPropertyUtilsTestCase extends TestCase {
             fail("InvocationTargetException");
         } catch (final NoSuchMethodException e) {
             // Correct result for this test
-            assertEquals("Unknown property 'unknown' on dynaclass '" + bean.getDynaClass() + "'", e.getMessage());
+            assertEquals("Unknown property 'unknown' on dynaclass '" + bean.getDynaClass() + "'",
+                                    e.getMessage());
         }
 
     }

--- a/src/test/java/org/apache/commons/beanutils2/FluentPropertyBeanIntrospectorTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/FluentPropertyBeanIntrospectorTestCase.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
@@ -24,12 +27,12 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for {@code FluentPropertyBeanIntrospector}.
  */
-public class FluentPropertyBeanIntrospectorTestCase extends TestCase {
+public class FluentPropertyBeanIntrospectorTestCase {
     public static final class CapsBean {
         private URI mURI;
 
@@ -64,13 +67,14 @@ public class FluentPropertyBeanIntrospectorTestCase extends TestCase {
      * @return the descriptor from the map
      */
     private static PropertyDescriptor fetchDescriptor(final Map<String, PropertyDescriptor> props, final String name) {
-        assertTrue("Property not found: " + name, props.containsKey(name));
+        assertTrue(props.containsKey(name), "Property not found: " + name);
         return props.get(name);
     }
 
     /**
      * Tries to create an instance without a prefix for write methods.
      */
+    @Test
     public void testInitNoPrefix() {
         assertThrows(NullPointerException.class, () -> new FluentPropertyBeanIntrospector(null));
     }
@@ -78,23 +82,25 @@ public class FluentPropertyBeanIntrospectorTestCase extends TestCase {
     /**
      * Tests whether correct property descriptors are detected.
      */
+    @Test
     public void testIntrospection() throws IntrospectionException {
         final PropertyUtilsBean pu = new PropertyUtilsBean();
         final FluentPropertyBeanIntrospector introspector = new FluentPropertyBeanIntrospector();
         pu.addBeanIntrospector(introspector);
         final Map<String, PropertyDescriptor> props = createDescriptorMap(pu.getPropertyDescriptors(FluentIntrospectionTestBean.class));
         PropertyDescriptor pd = fetchDescriptor(props, "name");
-        assertNotNull("No read method for name", pd.getReadMethod());
-        assertNotNull("No write method for name", pd.getWriteMethod());
+        assertNotNull(pd.getReadMethod(), "No read method for name");
+        assertNotNull(pd.getWriteMethod(), "No write method for name");
         fetchDescriptor(props, "stringProperty");
         pd = fetchDescriptor(props, "fluentProperty");
-        assertNull("Read method for fluentProperty", pd.getReadMethod());
-        assertNotNull("No write method for fluentProperty", pd.getWriteMethod());
+        assertNull(pd.getReadMethod(), "Read method for fluentProperty");
+        assertNotNull(pd.getWriteMethod(), "No write method for fluentProperty");
         pd = fetchDescriptor(props, "fluentGetProperty");
-        assertNotNull("No read method for fluentGetProperty", pd.getReadMethod());
-        assertNotNull("No write method for fluentGetProperty", pd.getWriteMethod());
+        assertNotNull(pd.getReadMethod(), "No read method for fluentGetProperty");
+        assertNotNull(pd.getWriteMethod(), "No write method for fluentGetProperty");
     }
 
+    @Test
     public void testIntrospectionCaps() throws Exception {
         final PropertyUtilsBean pu = new PropertyUtilsBean();
 
@@ -106,11 +112,11 @@ public class FluentPropertyBeanIntrospectorTestCase extends TestCase {
 
         final PropertyDescriptor aDescriptor = fetchDescriptor(props, "URI");
 
-        assertNotNull("missing property", aDescriptor);
+        assertNotNull(aDescriptor, "missing property");
 
-        assertNotNull("No read method for uri", aDescriptor.getReadMethod());
-        assertNotNull("No write method for uri", aDescriptor.getWriteMethod());
+        assertNotNull(aDescriptor.getReadMethod(), "No read method for uri");
+        assertNotNull(aDescriptor.getWriteMethod(), "No write method for uri");
 
-        assertNull("Should not find mis-capitalized property", props.get("uRI"));
+        assertNull(props.get("uRI"), "Should not find mis-capitalized property");
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/LazyDynaBeanTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/LazyDynaBeanTestCase.java
@@ -16,20 +16,29 @@
  */
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.TreeMap;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>
  * Test Case for the {@code LazyDynaBean} implementation class.
  * </p>
  */
-public class LazyDynaBeanTestCase extends TestCase {
+public class LazyDynaBeanTestCase {
 
     protected LazyDynaBean bean;
     protected LazyDynaClass dynaClass;
@@ -45,18 +54,9 @@ public class LazyDynaBeanTestCase extends TestCase {
     protected String testKey = "myKey";
 
     /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public LazyDynaBeanTestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Sets up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         bean = new LazyDynaBean();
         dynaClass = (LazyDynaClass) bean.getDynaClass();
@@ -66,7 +66,7 @@ public class LazyDynaBeanTestCase extends TestCase {
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     public void tearDown() {
         bean = null;
     }
@@ -74,40 +74,46 @@ public class LazyDynaBeanTestCase extends TestCase {
     /**
      * Test Getting/Setting an DynaBean[] array
      */
+    @Test
     public void testIndexedDynaBeanArray() {
 
         final int index = 3;
         final Object objectArray = new LazyDynaMap[0];
 
         // Check the property & value doesn't exist
-        assertNull("Check Indexed Property doesn't exist", dynaClass.getDynaProperty(testProperty));
-        assertNull("Check Indexed Property is null", bean.get(testProperty));
+        assertNull(dynaClass.getDynaProperty(testProperty), "Check Indexed Property doesn't exist");
+        assertNull(bean.get(testProperty), "Check Indexed Property is null");
 
         // Add a DynaProperty of type String[]
         dynaClass.add(testProperty, objectArray.getClass());
-        assertEquals("Check Indexed Property exists", objectArray.getClass(), dynaClass.getDynaProperty(testProperty).getType());
-        assertEquals("Check Indexed Property is correct type", objectArray.getClass(), bean.get(testProperty).getClass());
+        assertEquals(objectArray.getClass(), dynaClass.getDynaProperty(testProperty).getType(),
+                                "Check Indexed Property exists");
+        assertEquals(objectArray.getClass(), bean.get(testProperty).getClass(),
+                                "Check Indexed Property is correct type");
 
         // Retrieving from Array should initialize DynaBean
         for (int i = index; i >= 0; i--) {
-            assertEquals("Check Array Components initialized", LazyDynaMap.class, bean.get(testProperty, index).getClass());
+            assertEquals(LazyDynaMap.class, bean.get(testProperty, index).getClass(),
+                                    "Check Array Components initialized");
         }
 
         dynaClass.add(testPropertyB, objectArray.getClass());
         final LazyDynaMap newMap = new LazyDynaMap();
         newMap.set(testPropertyB, testString2);
         bean.set(testPropertyA, index, newMap);
-        assertEquals("Check Indexed Value is correct(a)", testString2, ((DynaBean) bean.get(testPropertyA, index)).get(testPropertyB));
+        assertEquals(testString2, ((DynaBean) bean.get(testPropertyA, index)).get(testPropertyB),
+                                "Check Indexed Value is correct(a)");
 
     }
 
     /**
      * Test setting indexed property for type which is not List or Array
      */
+    @Test
     public void testIndexedInvalidType() {
         final int index = 3;
         dynaClass.add(testProperty, String.class);
-        assertFalse("Check Property is not indexed", dynaClass.getDynaProperty(testProperty).isIndexed());
+        assertFalse(dynaClass.getDynaProperty(testProperty).isIndexed(), "Check Property is not indexed");
         try {
             bean.set(testProperty, index, testString1);
             fail("set(property, index, value) should have thrown IllegalArgumentException");
@@ -119,145 +125,176 @@ public class LazyDynaBeanTestCase extends TestCase {
     /**
      * Test Getting/Setting a List 'Indexed' Property - use alternative List (LinkedList)
      */
+    @Test
     public void testIndexedLinkedList() {
 
         int index = 3;
 
         // Check the property & value doesn't exist
-        assertNull("Check Indexed Property doesn't exist", dynaClass.getDynaProperty(testProperty));
-        assertNull("Check Indexed Property is null", bean.get(testProperty));
+        assertNull(dynaClass.getDynaProperty(testProperty), "Check Indexed Property doesn't exist");
+        assertNull(bean.get(testProperty), "Check Indexed Property is null");
 
         // Add a 'LinkedList' property to the DynaClass
         dynaClass.add(testProperty, LinkedList.class);
-        assertTrue("Check Property is indexed", dynaClass.getDynaProperty(testProperty).isIndexed());
-        assertEquals("Check Property is correct type", LinkedList.class, dynaClass.getDynaProperty(testProperty).getType());
-        assertEquals("Check Property type is correct", LinkedList.class, bean.get(testProperty).getClass());
+        assertTrue(dynaClass.getDynaProperty(testProperty).isIndexed(), "Check Property is indexed");
+        assertEquals(LinkedList.class, dynaClass.getDynaProperty(testProperty).getType(),
+                                "Check Property is correct type");
+        assertEquals(LinkedList.class, bean.get(testProperty).getClass(), "Check Property type is correct");
 
         // Set the property, should instantiate a new LinkedList and set appropriate indexed value
         bean.set(testProperty, index, testString1);
-        assertEquals("Check Property type is correct", LinkedList.class, bean.get(testProperty).getClass());
-        assertEquals("Check First Indexed Value is correct", testString1, bean.get(testProperty, index));
-        assertEquals("Check First Array length is correct", Integer.valueOf(index + 1), Integer.valueOf(((LinkedList<?>) bean.get(testProperty)).size()));
+        assertEquals(LinkedList.class, bean.get(testProperty).getClass(), "Check Property type is correct");
+        assertEquals(testString1, bean.get(testProperty, index), "Check First Indexed Value is correct");
+        assertEquals(Integer.valueOf(index + 1),
+                                Integer.valueOf(((LinkedList<?>) bean.get(testProperty)).size()),
+                                "Check First Array length is correct");
 
         // Set a second indexed value, should automatically grow the LinkedList and set appropriate indexed value
         index += 2;
         bean.set(testProperty, index, testInteger1);
-        assertEquals("Check Second Indexed Value is correct", testInteger1, bean.get(testProperty, index));
-        assertEquals("Check Second Array length is correct", Integer.valueOf(index + 1), Integer.valueOf(((LinkedList<?>) bean.get(testProperty)).size()));
+        assertEquals(testInteger1, bean.get(testProperty, index), "Check Second Indexed Value is correct");
+        assertEquals(Integer.valueOf(index + 1),
+                                Integer.valueOf(((LinkedList<?>) bean.get(testProperty)).size()),
+                                "Check Second Array length is correct");
     }
 
     /**
      * Test Getting/Setting an Object array 'Indexed' Property - use String[]
      */
+    @Test
     public void testIndexedObjectArray() {
 
         int index = 3;
         final Object objectArray = new String[0];
 
         // Check the property & value doesn't exist
-        assertNull("Check Indexed Property doesn't exist", dynaClass.getDynaProperty(testProperty));
-        assertNull("Check Indexed Property is null", bean.get(testProperty));
+        assertNull(dynaClass.getDynaProperty(testProperty), "Check Indexed Property doesn't exist");
+        assertNull(bean.get(testProperty), "Check Indexed Property is null");
 
         // Add a DynaProperty of type String[]
         dynaClass.add(testProperty, objectArray.getClass());
-        assertEquals("Check Indexed Property exists", objectArray.getClass(), dynaClass.getDynaProperty(testProperty).getType());
-        assertEquals("Check Indexed Property is correct type", objectArray.getClass(), bean.get(testProperty).getClass());
+        assertEquals(objectArray.getClass(), dynaClass.getDynaProperty(testProperty).getType(),
+                                "Check Indexed Property exists");
+        assertEquals(objectArray.getClass(), bean.get(testProperty).getClass(),
+                                "Check Indexed Property is correct type");
 
         // Set an indexed value
         bean.set(testProperty, index, testString1);
-        assertNotNull("Check Indexed Property is not null", bean.get(testProperty));
-        assertEquals("Check Indexed Property is correct type", objectArray.getClass(), bean.get(testProperty).getClass());
-        assertEquals("Check First Indexed Value is correct(a)", testString1, bean.get(testProperty, index));
-        assertEquals("Check First Indexed Value is correct(b)", testString1, ((String[]) bean.get(testProperty))[index]);
-        assertEquals("Check Array length is correct", Integer.valueOf(index + 1), Integer.valueOf(((String[]) bean.get(testProperty)).length));
+        assertNotNull(bean.get(testProperty), "Check Indexed Property is not null");
+        assertEquals(objectArray.getClass(), bean.get(testProperty).getClass(),
+                                "Check Indexed Property is correct type");
+        assertEquals(testString1, bean.get(testProperty, index), "Check First Indexed Value is correct(a)");
+        assertEquals(testString1, ((String[]) bean.get(testProperty))[index],
+                                "Check First Indexed Value is correct(b)");
+        assertEquals(Integer.valueOf(index + 1), Integer.valueOf(((String[]) bean.get(testProperty)).length),
+                                "Check Array length is correct");
 
         // Set a second indexed value, should automatically grow the String[] and set appropriate indexed value
         index += 2;
         bean.set(testProperty, index, testString2);
-        assertEquals("Check Second Indexed Value is correct(a)", testString2, bean.get(testProperty, index));
-        assertEquals("Check Second Indexed Value is correct(b)", testString2, ((String[]) bean.get(testProperty))[index]);
-        assertEquals("Check Second Array length is correct", Integer.valueOf(index + 1), Integer.valueOf(((String[]) bean.get(testProperty)).length));
+        assertEquals(testString2, bean.get(testProperty, index), "Check Second Indexed Value is correct(a)");
+        assertEquals(testString2, ((String[]) bean.get(testProperty))[index],
+                                "Check Second Indexed Value is correct(b)");
+        assertEquals(Integer.valueOf(index + 1), Integer.valueOf(((String[]) bean.get(testProperty)).length),
+                                "Check Second Array length is correct");
     }
 
     /**
      * Test Getting/Setting a primitive array 'Indexed' Property - use int[]
      */
+    @Test
     public void testIndexedPrimitiveArray() {
 
         int index = 3;
         final int[] primitiveArray = {};
 
         // Check the property & value doesn't exist
-        assertNull("Check Indexed Property doesn't exist", dynaClass.getDynaProperty(testProperty));
-        assertNull("Check Indexed Property is null", bean.get(testProperty));
+        assertNull(dynaClass.getDynaProperty(testProperty), "Check Indexed Property doesn't exist");
+        assertNull(bean.get(testProperty), "Check Indexed Property is null");
 
         // Add a DynaProperty of type int[]
         dynaClass.add(testProperty, primitiveArray.getClass());
-        assertEquals("Check Indexed Property exists", primitiveArray.getClass(), dynaClass.getDynaProperty(testProperty).getType());
-        assertEquals("Check Indexed Property is correct type", primitiveArray.getClass(), bean.get(testProperty).getClass());
+        assertEquals(primitiveArray.getClass(), dynaClass.getDynaProperty(testProperty).getType(),
+                                "Check Indexed Property exists");
+        assertEquals(primitiveArray.getClass(), bean.get(testProperty).getClass(),
+                                "Check Indexed Property is correct type");
 
         // Set an indexed value
         bean.set(testProperty, index, testInteger1);
-        assertNotNull("Check Indexed Property is not null", bean.get(testProperty));
-        assertEquals("Check Indexed Property is correct type", primitiveArray.getClass(), bean.get(testProperty).getClass());
-        assertEquals("Check First Indexed Value is correct(a)", testInteger1, bean.get(testProperty, index));
-        assertEquals("Check First Indexed Value is correct(b)", testInteger1, Integer.valueOf(((int[]) bean.get(testProperty))[index]));
-        assertEquals("Check Array length is correct", Integer.valueOf(index + 1), Integer.valueOf(((int[]) bean.get(testProperty)).length));
+        assertNotNull(bean.get(testProperty), "Check Indexed Property is not null");
+        assertEquals(primitiveArray.getClass(), bean.get(testProperty).getClass(),
+                                "Check Indexed Property is correct type");
+        assertEquals(testInteger1, bean.get(testProperty, index), "Check First Indexed Value is correct(a)");
+        assertEquals(testInteger1, Integer.valueOf(((int[]) bean.get(testProperty))[index]),
+                                "Check First Indexed Value is correct(b)");
+        assertEquals(Integer.valueOf(index + 1), Integer.valueOf(((int[]) bean.get(testProperty)).length),
+                                "Check Array length is correct");
 
         // Set a second indexed value, should automatically grow the int[] and set appropriate indexed value
         index += 2;
         bean.set(testProperty, index, testInteger2);
-        assertEquals("Check Second Indexed Value is correct(a)", testInteger2, bean.get(testProperty, index));
-        assertEquals("Check Second Indexed Value is correct(b)", testInteger2, Integer.valueOf(((int[]) bean.get(testProperty))[index]));
-        assertEquals("Check Second Array length is correct", Integer.valueOf(index + 1), Integer.valueOf(((int[]) bean.get(testProperty)).length));
+        assertEquals(testInteger2, bean.get(testProperty, index),
+                                "Check Second Indexed Value is correct(a)");
+        assertEquals(testInteger2, Integer.valueOf(((int[]) bean.get(testProperty))[index]),
+                                "Check Second Indexed Value is correct(b)");
+        assertEquals(Integer.valueOf(index + 1), Integer.valueOf(((int[]) bean.get(testProperty)).length),
+                                "Check Second Array length is correct");
 
     }
 
     /**
      * Test Getting/Setting an 'Indexed' Property - default ArrayList property
      */
+    @Test
     public void testIndexedPropertyDefault() {
 
         int index = 3;
 
         // Check the property & value doesn't exist
-        assertNull("Check Indexed Property doesn't exist", dynaClass.getDynaProperty(testProperty));
-        assertNull("Check Indexed Property is null", bean.get(testProperty));
-        assertNull("Check Indexed value is null", bean.get(testProperty, index));
+        assertNull(dynaClass.getDynaProperty(testProperty), "Check Indexed Property doesn't exist");
+        assertNull(bean.get(testProperty), "Check Indexed Property is null");
+        assertNull(bean.get(testProperty, index), "Check Indexed value is null");
 
         // Set the property, should create new ArrayList and set appropriate indexed value
         bean.set(testProperty, index, testInteger1);
-        assertNotNull("Check Indexed Property is not null", bean.get(testProperty));
-        assertEquals("Check Indexed Property is correct type", ArrayList.class, bean.get(testProperty).getClass());
-        assertEquals("Check First Indexed Value is correct", testInteger1, bean.get(testProperty, index));
-        assertEquals("Check First Array length is correct", Integer.valueOf(index + 1), Integer.valueOf(((ArrayList<?>) bean.get(testProperty)).size()));
+        assertNotNull(bean.get(testProperty), "Check Indexed Property is not null");
+        assertEquals(ArrayList.class, bean.get(testProperty).getClass(),
+                                "Check Indexed Property is correct type");
+        assertEquals(testInteger1, bean.get(testProperty, index), "Check First Indexed Value is correct");
+        assertEquals(Integer.valueOf(index + 1),
+                                Integer.valueOf(((ArrayList<?>) bean.get(testProperty)).size()),
+                                "Check First Array length is correct");
 
         // Set a second indexed value, should automatically grow the ArrayList and set appropriate indexed value
         index += 2;
         bean.set(testProperty, index, testString1);
-        assertEquals("Check Second Indexed Value is correct", testString1, bean.get(testProperty, index));
-        assertEquals("Check Second Array length is correct", Integer.valueOf(index + 1), Integer.valueOf(((ArrayList<?>) bean.get(testProperty)).size()));
+        assertEquals(testString1, bean.get(testProperty, index), "Check Second Indexed Value is correct");
+        assertEquals(Integer.valueOf(index + 1),
+                                Integer.valueOf(((ArrayList<?>) bean.get(testProperty)).size()),
+                                "Check Second Array length is correct");
     }
 
     /**
      * Test Setting an Indexed Property when MutableDynaClass is set to restricted
      */
+    @Test
     public void testIndexedPropertyRestricted() {
 
         final int index = 3;
 
         // Set the MutableDyanClass to 'restricted' (i.e. no new properties cab be added
         dynaClass.setRestricted(true);
-        assertTrue("Check MutableDynaClass is restricted", dynaClass.isRestricted());
+        assertTrue(dynaClass.isRestricted(), "Check MutableDynaClass is restricted");
 
         // Check the property & value doesn't exist
-        assertNull("Check Property doesn't exist", dynaClass.getDynaProperty(testProperty));
-        assertNull("Check Value is null", bean.get(testProperty));
+        assertNull(dynaClass.getDynaProperty(testProperty), "Check Property doesn't exist");
+        assertNull(bean.get(testProperty), "Check Value is null");
 
         // Set the property - should fail because property doesn't exist and MutableDynaClass is restricted
         try {
             bean.set(testProperty, index, testInteger1);
-            fail("expected IllegalArgumentException trying to add new property to restricted MutableDynaClass");
+            fail(
+                    "expected IllegalArgumentException trying to add new property to restricted MutableDynaClass");
         } catch (final IllegalArgumentException expected) {
             // expected result
         }
@@ -267,15 +304,16 @@ public class LazyDynaBeanTestCase extends TestCase {
     /**
      * Test Setting an 'Indexed' Property using PropertyUtils
      */
+    @Test
     public void testIndexedPropertyUtils() {
 
         final int index = 3;
         dynaClass.setReturnNull(false);
 
         // Check the property & value doesn't exist
-        assertFalse("Check Indexed Property doesn't exist", dynaClass.isDynaProperty(testProperty));
-        assertNull("Check Indexed Property is null", bean.get(testProperty));
-        assertNull("Check Indexed value is null", bean.get(testProperty, index));
+        assertFalse(dynaClass.isDynaProperty(testProperty), "Check Indexed Property doesn't exist");
+        assertNull(bean.get(testProperty), "Check Indexed Property is null");
+        assertNull(bean.get(testProperty, index), "Check Indexed value is null");
 
         // Use PropertyUtils to set the indexed value
         try {
@@ -285,16 +323,17 @@ public class LazyDynaBeanTestCase extends TestCase {
         }
 
         // Check property value correctly set
-        assertEquals("Check Indexed Bean Value is correct", testString1, bean.get(testProperty, index));
+        assertEquals(testString1, bean.get(testProperty, index), "Check Indexed Bean Value is correct");
 
     }
 
     /**
      * Test setting mapped property for type which is not Map
      */
+    @Test
     public void testMappedInvalidType() {
         dynaClass.add(testProperty, String.class);
-        assertFalse("Check Property is not mapped", dynaClass.getDynaProperty(testProperty).isMapped());
+        assertFalse(dynaClass.getDynaProperty(testProperty).isMapped(), "Check Property is not mapped");
         try {
             bean.set(testProperty, testKey, testInteger1);
             fail("set(property, key, value) should have thrown IllegalArgumentException");
@@ -306,42 +345,49 @@ public class LazyDynaBeanTestCase extends TestCase {
     /**
      * Test Getting/Setting a 'Mapped' Property - default HashMap property
      */
+    @Test
     public void testMappedPropertyDefault() {
 
         // Check the property & value doesn't exist
-        assertNull("Check Mapped Property doesn't exist", dynaClass.getDynaProperty(testProperty));
-        assertNull("Check Map is null", bean.get(testProperty));
-        assertNull("Check Mapped Value is null", bean.get(testProperty, testKey));
+        assertNull(dynaClass.getDynaProperty(testProperty), "Check Mapped Property doesn't exist");
+        assertNull(bean.get(testProperty), "Check Map is null");
+        assertNull(bean.get(testProperty, testKey), "Check Mapped Value is null");
 
         // Set a new mapped property - should add new HashMap property and set the mapped value
         bean.set(testProperty, testKey, testInteger1);
-        assertEquals("Check Mapped Property exists", HashMap.class, bean.get(testProperty).getClass());
-        assertEquals("Check First Mapped Value is correct(a)", testInteger1, bean.get(testProperty, testKey));
-        assertEquals("Check First Mapped Value is correct(b)", testInteger1, ((HashMap<?, ?>) bean.get(testProperty)).get(testKey));
+        assertEquals(HashMap.class, bean.get(testProperty).getClass(), "Check Mapped Property exists");
+        assertEquals(testInteger1, bean.get(testProperty, testKey),
+                                "Check First Mapped Value is correct(a)");
+        assertEquals(testInteger1, ((HashMap<?, ?>) bean.get(testProperty)).get(testKey),
+                                "Check First Mapped Value is correct(b)");
 
         // Set the property again - should set the new value
         bean.set(testProperty, testKey, testInteger2);
-        assertEquals("Check Second Mapped Value is correct(a)", testInteger2, bean.get(testProperty, testKey));
-        assertEquals("Check Second Mapped Value is correct(b)", testInteger2, ((HashMap<?, ?>) bean.get(testProperty)).get(testKey));
+        assertEquals(testInteger2, bean.get(testProperty, testKey),
+                                "Check Second Mapped Value is correct(a)");
+        assertEquals(testInteger2, ((HashMap<?, ?>) bean.get(testProperty)).get(testKey),
+                                "Check Second Mapped Value is correct(b)");
     }
 
     /**
      * Test Setting a Mapped Property when MutableDynaClass is set to restricted
      */
+    @Test
     public void testMappedPropertyRestricted() {
 
         // Set the MutableDyanClass to 'restricted' (i.e. no new properties cab be added
         dynaClass.setRestricted(true);
-        assertTrue("Check MutableDynaClass is restricted", dynaClass.isRestricted());
+        assertTrue(dynaClass.isRestricted(), "Check MutableDynaClass is restricted");
 
         // Check the property & value doesn't exist
-        assertNull("Check Property doesn't exist", dynaClass.getDynaProperty(testProperty));
-        assertNull("Check Value is null", bean.get(testProperty));
+        assertNull(dynaClass.getDynaProperty(testProperty), "Check Property doesn't exist");
+        assertNull(bean.get(testProperty), "Check Value is null");
 
         // Set the property - should fail because property doesn't exist and MutableDynaClass is restricted
         try {
             bean.set(testProperty, testKey, testInteger1);
-            fail("expected IllegalArgumentException trying to add new property to restricted MutableDynaClass");
+            fail(
+                    "expected IllegalArgumentException trying to add new property to restricted MutableDynaClass");
         } catch (final IllegalArgumentException expected) {
             // expected result
         }
@@ -351,41 +397,48 @@ public class LazyDynaBeanTestCase extends TestCase {
     /**
      * Test Getting/Setting a 'Mapped' Property - use TreeMap property
      */
+    @Test
     public void testMappedPropertyTreeMap() {
 
         // Check the property & value doesn't exist
-        assertNull("Check Mapped Property doesn't exist", dynaClass.getDynaProperty(testProperty));
+        assertNull(dynaClass.getDynaProperty(testProperty), "Check Mapped Property doesn't exist");
 
         // Add a 'TreeMap' property to the DynaClass
         dynaClass.add(testProperty, TreeMap.class);
-        assertTrue("Check Property is mapped", dynaClass.getDynaProperty(testProperty).isMapped());
-        assertEquals("Check Property is correct type", TreeMap.class, dynaClass.getDynaProperty(testProperty).getType());
-        assertEquals("Check Mapped Property exists", TreeMap.class, bean.get(testProperty).getClass());
+        assertTrue(dynaClass.getDynaProperty(testProperty).isMapped(), "Check Property is mapped");
+        assertEquals(TreeMap.class, dynaClass.getDynaProperty(testProperty).getType(),
+                                "Check Property is correct type");
+        assertEquals(TreeMap.class, bean.get(testProperty).getClass(), "Check Mapped Property exists");
 //        assertNull("Check mapped property is null", bean.get(testProperty));
 
         // Set a new mapped property - should instantiate a new TreeMap property and set the mapped value
         bean.set(testProperty, testKey, testInteger1);
-        assertEquals("Check Mapped Property exists", TreeMap.class, bean.get(testProperty).getClass());
-        assertEquals("Check First Mapped Value is correct(a)", testInteger1, bean.get(testProperty, testKey));
-        assertEquals("Check First Mapped Value is correct(b)", testInteger1, ((TreeMap<?, ?>) bean.get(testProperty)).get(testKey));
+        assertEquals(TreeMap.class, bean.get(testProperty).getClass(), "Check Mapped Property exists");
+        assertEquals(testInteger1, bean.get(testProperty, testKey),
+                                "Check First Mapped Value is correct(a)");
+        assertEquals(testInteger1, ((TreeMap<?, ?>) bean.get(testProperty)).get(testKey),
+                                "Check First Mapped Value is correct(b)");
 
         // Set the property again - should set the new value
         bean.set(testProperty, testKey, testInteger2);
-        assertEquals("Check Second Mapped Value is correct(a)", testInteger2, bean.get(testProperty, testKey));
-        assertEquals("Check Second Mapped Value is correct(b)", testInteger2, ((TreeMap<?, ?>) bean.get(testProperty)).get(testKey));
+        assertEquals(testInteger2, bean.get(testProperty, testKey),
+                                "Check Second Mapped Value is correct(a)");
+        assertEquals(testInteger2, ((TreeMap<?, ?>) bean.get(testProperty)).get(testKey),
+                                "Check Second Mapped Value is correct(b)");
     }
 
     /**
      * Test Setting a 'Mapped' Property using PropertyUtils
      */
+    @Test
     public void testMappedPropertyUtils() {
 
         dynaClass.setReturnNull(false);
 
         // Check the property & value doesn't exist
-        assertFalse("Check Mapped Property doesn't exist", dynaClass.isDynaProperty(testProperty));
-        assertNull("Check Map is null", bean.get(testProperty));
-        assertNull("Check Mapped Value is null", bean.get(testProperty, testKey));
+        assertFalse(dynaClass.isDynaProperty(testProperty), "Check Mapped Property doesn't exist");
+        assertNull(bean.get(testProperty), "Check Map is null");
+        assertNull(bean.get(testProperty, testKey), "Check Mapped Value is null");
 
         // Set the mapped property using PropertyUtils
         try {
@@ -395,42 +448,45 @@ public class LazyDynaBeanTestCase extends TestCase {
         }
 
         // Check property value correctly set
-        assertEquals("Check Mapped Bean Value is correct", testString1, bean.get(testProperty, testKey));
+        assertEquals(testString1, bean.get(testProperty, testKey), "Check Mapped Bean Value is correct");
 
     }
 
     /**
      * Test Getting/Setting a 'null' Property
      */
+    @Test
     public void testNullProperty() {
 
         // Check the property & value doesn't exist
-        assertNull("Check Property doesn't exist", dynaClass.getDynaProperty(testProperty));
-        assertNull("Check Value is null", bean.get(testProperty));
+        assertNull(dynaClass.getDynaProperty(testProperty), "Check Property doesn't exist");
+        assertNull(bean.get(testProperty), "Check Value is null");
 
         // Set a new property to null
         bean.set(testProperty, null);
-        assertNull("Check Value is still null", bean.get(testProperty));
+        assertNull(bean.get(testProperty), "Check Value is still null");
 
     }
 
     /**
      * Test Getting/Setting a Simple Property
      */
+    @Test
     public void testSimpleProperty() {
 
         // Check the property & value doesn't exist
-        assertNull("Check Property doesn't exist", dynaClass.getDynaProperty(testProperty));
-        assertNull("Check Value is null", bean.get(testProperty));
+        assertNull(dynaClass.getDynaProperty(testProperty), "Check Property doesn't exist");
+        assertNull(bean.get(testProperty), "Check Value is null");
 
         // Set a new property - should add new property and set value
         bean.set(testProperty, testInteger1);
-        assertEquals("Check First Value is correct", testInteger1, bean.get(testProperty));
-        assertEquals("Check Property type is correct", Integer.class, dynaClass.getDynaProperty(testProperty).getType());
+        assertEquals(testInteger1, bean.get(testProperty), "Check First Value is correct");
+        assertEquals(Integer.class, dynaClass.getDynaProperty(testProperty).getType(),
+                                "Check Property type is correct");
 
         // Set the property again - should set the new value
         bean.set(testProperty, testInteger2);
-        assertEquals("Check Second Value is correct", testInteger2, bean.get(testProperty));
+        assertEquals(testInteger2, bean.get(testProperty), "Check Second Value is correct");
 
         // Set the property again - with a different type, should fail
         try {
@@ -445,15 +501,16 @@ public class LazyDynaBeanTestCase extends TestCase {
     /**
      * Test Setting a Simple Property when MutableDynaClass is set to restricted
      */
+    @Test
     public void testSimplePropertyRestricted() {
 
         // Set the MutableDyanClass to 'restricted' (i.e. no new properties cab be added
         dynaClass.setRestricted(true);
-        assertTrue("Check MutableDynaClass is restricted", dynaClass.isRestricted());
+        assertTrue(dynaClass.isRestricted(), "Check MutableDynaClass is restricted");
 
         // Check the property & value doesn't exist
-        assertNull("Check Property doesn't exist", dynaClass.getDynaProperty(testProperty));
-        assertNull("Check Value is null", bean.get(testProperty));
+        assertNull(dynaClass.getDynaProperty(testProperty), "Check Property doesn't exist");
+        assertNull(bean.get(testProperty), "Check Value is null");
 
         // Set the property - should fail because property doesn't exist and MutableDynaClass is restricted
         try {

--- a/src/test/java/org/apache/commons/beanutils2/LazyDynaClassTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/LazyDynaClassTestCase.java
@@ -16,34 +16,33 @@
  */
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>
  * Test Case for the {@code LazyDynaClass} implementation class.
  * </p>
  */
-public class LazyDynaClassTestCase extends TestCase {
+public class LazyDynaClassTestCase {
 
     protected LazyDynaClass dynaClass;
 
     protected String testProperty = "myProperty";
 
     /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public LazyDynaClassTestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Sets up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         dynaClass = new LazyDynaClass();
     }
@@ -51,7 +50,7 @@ public class LazyDynaClassTestCase extends TestCase {
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     public void tearDown() {
         dynaClass = null;
     }
@@ -59,26 +58,29 @@ public class LazyDynaClassTestCase extends TestCase {
     /**
      * Test add(name) method
      */
+    @Test
     public void testAddProperty1() {
         dynaClass.add(testProperty);
         final DynaProperty dynaProperty = dynaClass.getDynaProperty(testProperty);
-        assertEquals("name is correct", testProperty, dynaProperty.getName());
-        assertEquals("type is correct", Object.class, dynaProperty.getType());
+        assertEquals(testProperty, dynaProperty.getName(), "name is correct");
+        assertEquals(Object.class, dynaProperty.getType(), "type is correct");
     }
 
     /**
      * Test add(name, type) method
      */
+    @Test
     public void testAddProperty2() {
         dynaClass.add(testProperty, String.class);
         final DynaProperty dynaProperty = dynaClass.getDynaProperty(testProperty);
-        assertEquals("name is correct", testProperty, dynaProperty.getName());
-        assertEquals("type is correct", String.class, dynaProperty.getType());
+        assertEquals(testProperty, dynaProperty.getName(), "name is correct");
+        assertEquals(String.class, dynaProperty.getType(), "type is correct");
     }
 
     /**
      * Test add(name, type, readable, writable) method
      */
+    @Test
     public void testAddProperty3() {
         try {
             dynaClass.add(testProperty, String.class, true, true);
@@ -91,6 +93,7 @@ public class LazyDynaClassTestCase extends TestCase {
     /**
      * Test add(name) method with 'null' name
      */
+    @Test
     public void testAddPropertyNullName1() {
         assertThrows(NullPointerException.class, () -> dynaClass.add((String) null));
     }
@@ -98,6 +101,7 @@ public class LazyDynaClassTestCase extends TestCase {
     /**
      * Test add(name, type) method with 'null' name
      */
+    @Test
     public void testAddPropertyNullName2() {
         assertThrows(NullPointerException.class, () -> dynaClass.add(null, String.class));
     }
@@ -105,6 +109,7 @@ public class LazyDynaClassTestCase extends TestCase {
     /**
      * Test add(name, type, readable, writable) method with 'null' name
      */
+    @Test
     public void testAddPropertyNullName3() {
         try {
             dynaClass.add(null, String.class, true, true);
@@ -117,9 +122,10 @@ public class LazyDynaClassTestCase extends TestCase {
     /**
      * Test add(name) method when restricted is set to 'true'
      */
+    @Test
     public void testAddPropertyRestricted1() {
         dynaClass.setRestricted(true);
-        assertTrue("MutableDynaClass is restricted", dynaClass.isRestricted());
+        assertTrue(dynaClass.isRestricted(), "MutableDynaClass is restricted");
         try {
             dynaClass.add(testProperty);
             fail("add(name) did not throw IllegalStateException");
@@ -131,9 +137,10 @@ public class LazyDynaClassTestCase extends TestCase {
     /**
      * Test add(name, type) method when restricted is set to 'true'
      */
+    @Test
     public void testAddPropertyRestricted2() {
         dynaClass.setRestricted(true);
-        assertTrue("MutableDynaClass is restricted", dynaClass.isRestricted());
+        assertTrue(dynaClass.isRestricted(), "MutableDynaClass is restricted");
         try {
             dynaClass.add(testProperty, String.class);
             fail("add(name, type) did not throw IllegalStateException");
@@ -145,9 +152,10 @@ public class LazyDynaClassTestCase extends TestCase {
     /**
      * Test add(name, type, readable, writable) method when restricted is set to 'true'
      */
+    @Test
     public void testAddPropertyRestricted3() {
         dynaClass.setRestricted(true);
-        assertTrue("MutableDynaClass is restricted", dynaClass.isRestricted());
+        assertTrue(dynaClass.isRestricted(), "MutableDynaClass is restricted");
         try {
             dynaClass.add(testProperty, String.class, true, true);
             fail("add(name, type, readable, writable) did not throw UnsupportedOperationException");
@@ -159,49 +167,54 @@ public class LazyDynaClassTestCase extends TestCase {
     /**
      * Test retrieving a property which doesn't exist (returnNull is 'false')
      */
+    @Test
     public void testGetPropertyDoesntExist1() {
         dynaClass.setReturnNull(false);
-        assertFalse("returnNull is 'false'", dynaClass.isReturnNull());
+        assertFalse(dynaClass.isReturnNull(), "returnNull is 'false'");
         final DynaProperty dynaProperty = dynaClass.getDynaProperty(testProperty);
-        assertEquals("name is correct", testProperty, dynaProperty.getName());
-        assertEquals("type is correct", Object.class, dynaProperty.getType());
-        assertFalse("property doesn't exist", dynaClass.isDynaProperty(testProperty));
+        assertEquals(testProperty, dynaProperty.getName(), "name is correct");
+        assertEquals(Object.class, dynaProperty.getType(), "type is correct");
+        assertFalse(dynaClass.isDynaProperty(testProperty), "property doesn't exist");
     }
 
     /**
      * Test retrieving a property which doesn't exist (returnNull is 'true')
      */
+    @Test
     public void testGetPropertyDoesntExist2() {
         dynaClass.setReturnNull(true);
-        assertTrue("returnNull is 'true'", dynaClass.isReturnNull());
-        assertNull("property is null", dynaClass.getDynaProperty(testProperty));
+        assertTrue(dynaClass.isReturnNull(), "returnNull is 'true'");
+        assertNull(dynaClass.getDynaProperty(testProperty), "property is null");
     }
 
     /**
      * Test removing a property
      */
+    @Test
     public void testRemoveProperty() {
         dynaClass.setReturnNull(true);
         dynaClass.add(testProperty);
-        assertTrue("Property exists", dynaClass.isDynaProperty(testProperty));
-        assertNotNull("property is Not null", dynaClass.getDynaProperty(testProperty));
+        assertTrue(dynaClass.isDynaProperty(testProperty), "Property exists");
+        assertNotNull(dynaClass.getDynaProperty(testProperty), "property is Not null");
         dynaClass.remove(testProperty);
-        assertFalse("Property doesn't exist", dynaClass.isDynaProperty(testProperty));
-        assertNull("property is null", dynaClass.getDynaProperty(testProperty));
+        assertFalse(dynaClass.isDynaProperty(testProperty), "Property doesn't exist");
+        assertNull(dynaClass.getDynaProperty(testProperty), "property is null");
     }
 
     /**
      * Test removing a property which doesn't exist
      */
+    @Test
     public void testRemovePropertyDoesntExist() {
-        assertFalse("property doesn't exist", dynaClass.isDynaProperty(testProperty));
+        assertFalse(dynaClass.isDynaProperty(testProperty), "property doesn't exist");
         dynaClass.remove(testProperty);
-        assertFalse("property still doesn't exist", dynaClass.isDynaProperty(testProperty));
+        assertFalse(dynaClass.isDynaProperty(testProperty), "property still doesn't exist");
     }
 
     /**
      * Test removing a property, name is null
      */
+    @Test
     public void testRemovePropertyNullName() {
         assertThrows(NullPointerException.class, () -> dynaClass.remove(null));
     }
@@ -209,11 +222,12 @@ public class LazyDynaClassTestCase extends TestCase {
     /**
      * Test removing a property, DynaClass is restricted
      */
+    @Test
     public void testRemovePropertyRestricted() {
         dynaClass.add(testProperty);
-        assertTrue("Property exists", dynaClass.isDynaProperty(testProperty));
+        assertTrue(dynaClass.isDynaProperty(testProperty), "Property exists");
         dynaClass.setRestricted(true);
-        assertTrue("MutableDynaClass is restricted", dynaClass.isRestricted());
+        assertTrue(dynaClass.isRestricted(), "MutableDynaClass is restricted");
         try {
             dynaClass.remove(testProperty);
             fail("remove property when MutableDynaClassis restricted did not throw IllegalStateException");

--- a/src/test/java/org/apache/commons/beanutils2/LazyDynaListTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/LazyDynaListTestCase.java
@@ -16,6 +16,12 @@
  */
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
@@ -26,14 +32,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>
  * Test Case for the {@code LazyDynaList}class.
  * </p>
  */
-public class LazyDynaListTestCase extends TestCase {
+public class LazyDynaListTestCase {
 
     private static final String BASIC_PROP1 = "BasicDynaClass_Property1";
     private static final String BASIC_PROP2 = "BasicDynaClass_Property2";
@@ -47,42 +55,33 @@ public class LazyDynaListTestCase extends TestCase {
     protected DynaClass basicDynaClass = new BasicDynaClass("test", BasicDynaBean.class, properties);
 
     /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public LazyDynaListTestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Test DynaBean Create
      */
     private void dynaBeanTest(final LazyDynaList list, final Class<?> testClass, final DynaClass testDynaClass, final Object wrongBean) {
 
         // Test get(index) created correct DynaBean - Second
         Object dynaBean = list.get(1);
-        assertNotNull("1. DynaBean Not Created", dynaBean);
-        assertEquals("2. Wrong Type", testClass, dynaBean.getClass());
+        assertNotNull(dynaBean, "1. DynaBean Not Created");
+        assertEquals(testClass, dynaBean.getClass(), "2. Wrong Type");
 
         // Test toArray() creates correct Array - Second
         Object array = list.toArray();
-        assertNotNull("3. Array Not Created", array);
-        assertEquals("4. Not DynaBean[]", testClass, array.getClass().getComponentType());
+        assertNotNull(array, "3. Array Not Created");
+        assertEquals(testClass, array.getClass().getComponentType(), "4. Not DynaBean[]");
         DynaBean[] dynaArray = (DynaBean[]) array;
-        assertEquals("5. Array Size Wrong", 2, dynaArray.length);
+        assertEquals(2, dynaArray.length, "5. Array Size Wrong");
 
         // Test get(index) created correct DynaBean - Fourth
         dynaBean = list.get(3);
-        assertNotNull("6. DynaBean Not Created", dynaBean);
-        assertEquals("7. Wrong type", testClass, dynaBean.getClass());
+        assertNotNull(dynaBean, "6. DynaBean Not Created");
+        assertEquals(testClass, dynaBean.getClass(), "7. Wrong type");
 
         // Test toArray() creates correct Array - Fourth
         array = list.toArray();
-        assertNotNull("8. Array Not Created", array);
-        assertEquals("9. Not DynaBean[]", testClass, array.getClass().getComponentType());
+        assertNotNull(array, "8. Array Not Created");
+        assertEquals(testClass, array.getClass().getComponentType(), "9. Not DynaBean[]");
         dynaArray = (DynaBean[]) array;
-        assertEquals("10. Array Size Wrong", 4, dynaArray.length);
+        assertEquals(4, dynaArray.length, "10. Array Size Wrong");
 
         // Test fail if different type added
         try {
@@ -94,7 +93,7 @@ public class LazyDynaListTestCase extends TestCase {
 
         // find a String property to set
         final String testProperty = findStringProperty(testDynaClass);
-        assertNotNull("Test Property Not Found", testProperty);
+        assertNotNull(testProperty, "Test Property Not Found");
         dynaArray = list.toDynaBeanArray();
         for (int i = 0; i < dynaArray.length; i++) {
             dynaArray[i].set(testProperty, "orig_pos" + i);
@@ -121,14 +120,14 @@ public class LazyDynaListTestCase extends TestCase {
 
         // Check array after insert
         dynaArray = list.toDynaBeanArray();
-        assertEquals("11. Array Size Wrong", expectedSize, dynaArray.length);
+        assertEquals(expectedSize, dynaArray.length, "11. Array Size Wrong");
 
         // Check Beans have inserted correctly - by checking the property values
-        assertEquals("12. Wrong Value", "orig_pos0", dynaArray[0].get(testProperty));
-        assertEquals("13. Wrong Value", origValue + "_updated_" + 0, dynaArray[1].get(testProperty));
-        assertEquals("14. Wrong Value", origValue + "_updated_" + 1, dynaArray[2].get(testProperty));
-        assertEquals("15. Wrong Value", origValue + "_updated_" + 2, dynaArray[3].get(testProperty));
-        assertEquals("16. Wrong Value", "orig_pos1", dynaArray[4].get(testProperty));
+        assertEquals("orig_pos0", dynaArray[0].get(testProperty), "12. Wrong Value");
+        assertEquals(origValue + "_updated_" + 0, dynaArray[1].get(testProperty), "13. Wrong Value");
+        assertEquals(origValue + "_updated_" + 1, dynaArray[2].get(testProperty), "14. Wrong Value");
+        assertEquals(origValue + "_updated_" + 2, dynaArray[3].get(testProperty), "15. Wrong Value");
+        assertEquals("orig_pos1", dynaArray[4].get(testProperty), "16. Wrong Value");
 
         // Test Insert - add(index, Object)
         try {
@@ -136,9 +135,9 @@ public class LazyDynaListTestCase extends TestCase {
             extraElement.set(testProperty, "extraOne");
             list.add(2, extraElement);
             dynaArray = list.toDynaBeanArray();
-            assertEquals("17. Wrong Value", origValue + "_updated_" + 0, dynaArray[1].get(testProperty));
-            assertEquals("18. Wrong Value", "extraOne", dynaArray[2].get(testProperty));
-            assertEquals("19. Wrong Value", origValue + "_updated_" + 1, dynaArray[3].get(testProperty));
+            assertEquals(origValue + "_updated_" + 0, dynaArray[1].get(testProperty), "17. Wrong Value");
+            assertEquals("extraOne", dynaArray[2].get(testProperty), "18. Wrong Value");
+            assertEquals(origValue + "_updated_" + 1, dynaArray[3].get(testProperty), "19. Wrong Value");
         } catch (final Exception ex) {
             fail("2. FAILED: " + ex);
         }
@@ -165,37 +164,37 @@ public class LazyDynaListTestCase extends TestCase {
 
         // Test get(index) created correct DynaBean - First
         Object dynaBean = list.get(0);
-        assertNotNull("1. DynaBean Not Created", dynaBean);
-        assertEquals("2. Not LazyDynaMap", LazyDynaMap.class, dynaBean.getClass());
+        assertNotNull(dynaBean, "1. DynaBean Not Created");
+        assertEquals(LazyDynaMap.class, dynaBean.getClass(), "2. Not LazyDynaMap");
 
         // Test get(index) created correct Map - First
         Object map = ((LazyDynaMap) dynaBean).getMap();
-        assertNotNull("3. Map Not Created", map);
-        assertEquals("4. Wrong Map", testClass, map.getClass());
+        assertNotNull(map, "3. Map Not Created");
+        assertEquals(testClass, map.getClass(), "4. Wrong Map");
 
         // Test toArray() creates correct Array - First
         Object array = list.toArray();
-        assertNotNull("5. Array Not Created", array);
-        assertEquals("6. Not Map[]", testClass, array.getClass().getComponentType());
+        assertNotNull(array, "5. Array Not Created");
+        assertEquals(testClass, array.getClass().getComponentType(), "6. Not Map[]");
         Map<?, ?>[] mapArray = (Map[]) array;
-        assertEquals("7. Array Size Wrong", 1, mapArray.length);
+        assertEquals(1, mapArray.length, "7. Array Size Wrong");
 
         // Test get(index) created correct DynaBean - Third
         dynaBean = list.get(2);
-        assertNotNull("8. DynaBean Not Created", dynaBean);
-        assertEquals("9. Not LazyDynaMap", LazyDynaMap.class, dynaBean.getClass());
+        assertNotNull(dynaBean, "8. DynaBean Not Created");
+        assertEquals(LazyDynaMap.class, dynaBean.getClass(), "9. Not LazyDynaMap");
 
         // Test get(index) created correct Map - Third
         map = ((LazyDynaMap) dynaBean).getMap();
-        assertNotNull("10. Map Not Created", map);
-        assertEquals("11. Wrong Map", testClass, map.getClass());
+        assertNotNull(map, "10. Map Not Created");
+        assertEquals(testClass, map.getClass(), "11. Wrong Map");
 
         // Test toArray() creates correct Array - Third
         array = list.toArray();
-        assertNotNull("12. Array Not Created", array);
-        assertEquals("13. Not Map[]", testClass, array.getClass().getComponentType());
+        assertNotNull(array, "12. Array Not Created");
+        assertEquals(testClass, array.getClass().getComponentType(), "13. Not Map[]");
         mapArray = (Map[]) array;
-        assertEquals("14. Array Size Wrong", 3, mapArray.length);
+        assertEquals(3, mapArray.length, "14. Array Size Wrong");
 
         // Test fail if different type added
         try {
@@ -214,37 +213,37 @@ public class LazyDynaListTestCase extends TestCase {
 
         // Test get(index) created correct DynaBean - First
         Object dynaBean = list.get(0);
-        assertNotNull("1. DynaBean Not Created", dynaBean);
-        assertEquals("2. Not WrapDynaBean", WrapDynaBean.class, dynaBean.getClass());
+        assertNotNull(dynaBean, "1. DynaBean Not Created");
+        assertEquals(WrapDynaBean.class, dynaBean.getClass(), "2. Not WrapDynaBean");
 
         // Test get(index) created correct POJO - First
         Object pojoBean = ((WrapDynaBean) dynaBean).getInstance();
-        assertNotNull("3. POJO Not Created", pojoBean);
-        assertEquals("4. Not WrapDynaBean", testClass, pojoBean.getClass());
+        assertNotNull(pojoBean, "3. POJO Not Created");
+        assertEquals(testClass, pojoBean.getClass(), "4. Not WrapDynaBean");
 
         // Test toArray() creates correct Array - First
         Object array = list.toArray();
-        assertNotNull("5. Array Not Created", array);
-        assertEquals("6. Wrong array", testClass, array.getClass().getComponentType());
+        assertNotNull(array, "5. Array Not Created");
+        assertEquals(testClass, array.getClass().getComponentType(), "6. Wrong array");
         Object[] pojoArray = (Object[]) array;
-        assertEquals("7. Array Size Wrong", 1, pojoArray.length);
+        assertEquals(1, pojoArray.length, "7. Array Size Wrong");
 
         // Test get(index) created correct DynaBean - Second
         dynaBean = list.get(1);
-        assertNotNull("8. DynaBean Not Created", dynaBean);
-        assertEquals("9. Not WrapDynaBean", WrapDynaBean.class, dynaBean.getClass());
+        assertNotNull(dynaBean, "8. DynaBean Not Created");
+        assertEquals(WrapDynaBean.class, dynaBean.getClass(), "9. Not WrapDynaBean");
 
         // Test get(index) created correct POJO - Second
         pojoBean = ((WrapDynaBean) dynaBean).getInstance();
-        assertNotNull("10. POJO Not Created", pojoBean);
-        assertEquals("11. Not WrapDynaBean", testClass, pojoBean.getClass());
+        assertNotNull(pojoBean, "10. POJO Not Created");
+        assertEquals(testClass, pojoBean.getClass(), "11. Not WrapDynaBean");
 
         // Test toArray() creates correct Array - Second
         array = list.toArray();
-        assertNotNull("12. Array Not Created", array);
-        assertEquals("13. Wrong array", testClass, array.getClass().getComponentType());
+        assertNotNull(array, "12. Array Not Created");
+        assertEquals(testClass, array.getClass().getComponentType(), "13. Wrong array");
         pojoArray = (Object[]) array;
-        assertEquals("14. Array Size Wrong", 2, pojoArray.length);
+        assertEquals(2, pojoArray.length, "14. Array Size Wrong");
 
         // Test fail if different type added
         try {
@@ -289,14 +288,14 @@ public class LazyDynaListTestCase extends TestCase {
     /**
      * Sets up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
     }
 
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     public void tearDown() {
     }
 
@@ -318,32 +317,32 @@ public class LazyDynaListTestCase extends TestCase {
 
         // Create LazyArrayList from Collection
         LazyDynaList lazyList = new LazyDynaList(testList);
-        assertEquals("1. check size", size, lazyList.size());
+        assertEquals(size, lazyList.size(), "1. check size");
 
         DynaBean[] dynaArray = lazyList.toDynaBeanArray();
         TreeMap<?, ?>[] mapArray = (TreeMap[]) lazyList.toArray();
 
         // Check values
-        assertEquals("2. check size", size, dynaArray.length);
-        assertEquals("3. check size", size, mapArray.length);
+        assertEquals(size, dynaArray.length, "2. check size");
+        assertEquals(size, mapArray.length, "3. check size");
         for (int i = 0; i < size; i++) {
-            assertEquals("4." + i + " DynaBean error ", "val" + i, dynaArray[i].get("prop" + i));
-            assertEquals("5." + i + " Map error ", "val" + i, mapArray[i].get("prop" + i));
+            assertEquals("val" + i, dynaArray[i].get("prop" + i), "4." + i + " DynaBean error ");
+            assertEquals("val" + i, mapArray[i].get("prop" + i), "5." + i + " Map error ");
         }
 
         // Create LazyArrayList from Array
         lazyList = new LazyDynaList(testArray);
-        assertEquals("6. check size", size, lazyList.size());
+        assertEquals(size, lazyList.size(), "6. check size");
 
         dynaArray = lazyList.toDynaBeanArray();
         mapArray = (TreeMap[]) lazyList.toArray();
 
         // Check values
-        assertEquals("7. check size", size, dynaArray.length);
-        assertEquals("8. check size", size, mapArray.length);
+        assertEquals(size, dynaArray.length, "7. check size");
+        assertEquals(size, mapArray.length, "8. check size");
         for (int i = 0; i < size; i++) {
-            assertEquals("9." + i + " DynaBean error ", "val" + i, dynaArray[i].get("prop" + i));
-            assertEquals("10." + i + " Map error ", "val" + i, mapArray[i].get("prop" + i));
+            assertEquals("val" + i, dynaArray[i].get("prop" + i), "9." + i + " DynaBean error ");
+            assertEquals("val" + i, mapArray[i].get("prop" + i), "10." + i + " Map error ");
         }
 
     }
@@ -351,6 +350,7 @@ public class LazyDynaListTestCase extends TestCase {
     /**
      * Test DynaBean Create
      */
+    @Test
     public void testDynaBeanDynaClass() {
 
         // Create LazyArrayList for DynaBeans
@@ -363,6 +363,7 @@ public class LazyDynaListTestCase extends TestCase {
     /**
      * Test DynaBean Create
      */
+    @Test
     public void testDynaBeanType() {
 
         // Create LazyArrayList for DynaBeans
@@ -378,6 +379,7 @@ public class LazyDynaListTestCase extends TestCase {
     /**
      * Test Map Create
      */
+    @Test
     public void testMapDynaClass() {
 
         // Create LazyArrayList for TreeMap's
@@ -391,6 +393,7 @@ public class LazyDynaListTestCase extends TestCase {
     /**
      * Test Map Create
      */
+    @Test
     public void testMapType() {
 
         // Create LazyArrayList for HashMap's
@@ -404,6 +407,7 @@ public class LazyDynaListTestCase extends TestCase {
     /**
      * Test adding a map to List with no type set.
      */
+    @Test
     public void testNullType() {
         final LazyDynaList lazyList = new LazyDynaList();
         lazyList.add(new HashMap<>());
@@ -412,6 +416,7 @@ public class LazyDynaListTestCase extends TestCase {
     /**
      * Test Pojo Create
      */
+    @Test
     public void testPojoDynaClass() {
 
         // Create LazyArrayList for POJO's
@@ -425,6 +430,7 @@ public class LazyDynaListTestCase extends TestCase {
     /**
      * Test Pojo Create
      */
+    @Test
     public void testPojoType() {
 
         // Create LazyArrayList for POJO's
@@ -438,6 +444,7 @@ public class LazyDynaListTestCase extends TestCase {
     /**
      * Test DynaBean serialization.
      */
+    @Test
     public void testSerializationDynaBean() {
 
         // Create LazyArrayList for DynaBeans
@@ -445,9 +452,9 @@ public class LazyDynaListTestCase extends TestCase {
         BasicDynaBean bean = (BasicDynaBean) target.get(0);
 
         // Set a Property
-        assertNull("pre-set check", bean.get(BASIC_PROP1));
+        assertNull(bean.get(BASIC_PROP1), "pre-set check");
         bean.set(BASIC_PROP1, "value1");
-        assertEquals("post-set check", "value1", bean.get(BASIC_PROP1));
+        assertEquals("value1", bean.get(BASIC_PROP1), "post-set check");
 
         // Serialize/Deserialize
         final LazyDynaList result = (LazyDynaList) serializeDeserialize(target, "DynaBean");
@@ -456,13 +463,14 @@ public class LazyDynaListTestCase extends TestCase {
 
         // Confirm property value
         bean = (BasicDynaBean) result.get(0);
-        assertEquals("post-serialize check", "value1", bean.get(BASIC_PROP1));
+        assertEquals("value1", bean.get(BASIC_PROP1), "post-serialize check");
 
     }
 
     /**
      * Test DynaBean serialization.
      */
+    @Test
     public void testSerializationLazyDynaBean() {
 
         // Create LazyArrayList for DynaBeans
@@ -470,9 +478,9 @@ public class LazyDynaListTestCase extends TestCase {
         LazyDynaBean bean = (LazyDynaBean) target.get(0);
 
         // Set a Property
-        assertNull("pre-set check", bean.get(BASIC_PROP1));
+        assertNull(bean.get(BASIC_PROP1), "pre-set check");
         bean.set(BASIC_PROP1, "value1");
-        assertEquals("post-set check", "value1", bean.get(BASIC_PROP1));
+        assertEquals("value1", bean.get(BASIC_PROP1), "post-set check");
 
         // Serialize/Deserialize
         final LazyDynaList result = (LazyDynaList) serializeDeserialize(target, "DynaBean");
@@ -481,13 +489,14 @@ public class LazyDynaListTestCase extends TestCase {
 
         // Confirm property value
         bean = (LazyDynaBean) result.get(0);
-        assertEquals("post-serialize check", "value1", bean.get(BASIC_PROP1));
+        assertEquals("value1", bean.get(BASIC_PROP1), "post-serialize check");
 
     }
 
     /**
      * Test Map serialization.
      */
+    @Test
     public void testSerializationMap() {
 
         // Create LazyArrayList for DynaBeans
@@ -495,9 +504,9 @@ public class LazyDynaListTestCase extends TestCase {
         LazyDynaMap bean = (LazyDynaMap) target.get(0);
 
         // Set a Property
-        assertNull("pre-set check", bean.get(BASIC_PROP1));
+        assertNull(bean.get(BASIC_PROP1), "pre-set check");
         bean.set(BASIC_PROP1, "value1");
-        assertEquals("post-set check", "value1", bean.get(BASIC_PROP1));
+        assertEquals("value1", bean.get(BASIC_PROP1), "post-set check");
 
         // Serialize/Deserialize
         final LazyDynaList result = (LazyDynaList) serializeDeserialize(target, "Map");
@@ -506,13 +515,14 @@ public class LazyDynaListTestCase extends TestCase {
 
         // Confirm property value
         bean = (LazyDynaMap) result.get(0);
-        assertEquals("post-serialize check", "value1", bean.get(BASIC_PROP1));
+        assertEquals("value1", bean.get(BASIC_PROP1), "post-serialize check");
 
     }
 
     /**
      * Test POJO (WrapDynaBean) serialization.
      */
+    @Test
     public void testSerializationPojo() {
 
         // Create LazyArrayList for DynaBeans
@@ -520,9 +530,9 @@ public class LazyDynaListTestCase extends TestCase {
         WrapDynaBean bean = (WrapDynaBean) target.get(0);
 
         // Set a Property
-        assertEquals("pre-set check", "This is a string", bean.get("stringProperty"));
+        assertEquals("This is a string", bean.get("stringProperty"), "pre-set check");
         bean.set("stringProperty", "value1");
-        assertEquals("post-set check", "value1", bean.get("stringProperty"));
+        assertEquals("value1", bean.get("stringProperty"), "post-set check");
 
         // Serialize/Deserialize
         final LazyDynaList result = (LazyDynaList) serializeDeserialize(target, "POJO");
@@ -534,55 +544,59 @@ public class LazyDynaListTestCase extends TestCase {
 
         // Confirm property value
         bean = (WrapDynaBean) result.get(0);
-        assertEquals("post-serialize check", "value1", bean.get("stringProperty"));
+        assertEquals("value1", bean.get("stringProperty"), "post-serialize check");
 
     }
 
     /**
      * Tests toArray() if the list contains DynaBean objects.
      */
+    @Test
     public void testToArrayDynaBeans() {
         final LazyDynaList list = new LazyDynaList(LazyDynaBean.class);
         final LazyDynaBean elem = new LazyDynaBean();
         list.add(elem);
         final LazyDynaBean[] beans = new LazyDynaBean[1];
-        assertSame("Wrong array", beans, list.toArray(beans));
-        assertSame("Wrong element", elem, beans[0]);
+        assertSame(beans, list.toArray(beans), "Wrong array");
+        assertSame(elem, beans[0], "Wrong element");
     }
 
     /**
      * Tests toArray() if the list contains maps.
      */
+    @Test
     public void testToArrayMapType() {
         final LazyDynaList list = new LazyDynaList(HashMap.class);
         final HashMap<String, Object> elem = new HashMap<>();
         list.add(elem);
         final Map<?, ?>[] array = new Map[1];
-        assertSame("Wrong array", array, list.toArray(array));
-        assertEquals("Wrong element", elem, array[0]);
+        assertSame(array, list.toArray(array), "Wrong array");
+        assertEquals(elem, array[0], "Wrong element");
     }
 
     /**
      * Tests toArray() for other bean elements.
      */
+    @Test
     public void testToArrayOtherType() {
         final LazyDynaList list = new LazyDynaList(TestBean.class);
         final TestBean elem = new TestBean();
         list.add(elem);
         final TestBean[] array = new TestBean[1];
-        assertSame("Wrong array", array, list.toArray(array));
-        assertEquals("Wrong element", elem, array[0]);
+        assertSame(array, list.toArray(array), "Wrong array");
+        assertEquals(elem, array[0], "Wrong element");
     }
 
     /**
      * Tests toArray() if the array's size does not fit the collection size.
      */
+    @Test
     public void testToArrayUnsufficientSize() {
         final LazyDynaList list = new LazyDynaList(LazyDynaBean.class);
         final LazyDynaBean elem = new LazyDynaBean();
         list.add(elem);
         final LazyDynaBean[] array = list.toArray(LazyDynaBean.EMPTY_ARRAY);
-        assertEquals("Wrong array size", 1, array.length);
-        assertEquals("Wrong element", elem, array[0]);
+        assertEquals(1, array.length, "Wrong array size");
+        assertEquals(elem, array[0], "Wrong element");
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/LazyDynaMapTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/LazyDynaMapTestCase.java
@@ -16,6 +16,13 @@
  */
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -24,14 +31,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>
  * Test Case for the {@code LazyDynaMap} implementation class.
  * </p>
  */
-public class LazyDynaMapTestCase extends TestCase {
+public class LazyDynaMapTestCase {
 
     protected LazyDynaMap dynaMap;
     protected String testProperty = "myProperty";
@@ -45,19 +54,11 @@ public class LazyDynaMapTestCase extends TestCase {
 
     protected String testKey = "myKey";
 
-    /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public LazyDynaMapTestCase(final String name) {
-        super(name);
-    }
 
     /**
      * Sets up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         dynaMap = new LazyDynaMap();
         dynaMap.setReturnNull(true);
@@ -66,7 +67,7 @@ public class LazyDynaMapTestCase extends TestCase {
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     public void tearDown() {
         dynaMap = null;
     }
@@ -74,49 +75,56 @@ public class LazyDynaMapTestCase extends TestCase {
     /**
      * General Tests
      */
+    @Test
     public void testGeneral() {
 //        LazyDynaMap bean = new LazyDynaMap("TestBean");
-        assertEquals("Check DynaClass name", "TestBean", new LazyDynaMap("TestBean").getName());
+        assertEquals("TestBean", new LazyDynaMap("TestBean").getName(), "Check DynaClass name");
 
     }
 
     /**
      * Test Getting/Setting an DynaBean[] array
      */
+    @Test
     public void testIndexedDynaBeanArray() {
 
         final int index = 3;
         final Object objectArray = new LazyDynaBean[0];
 
         // Check the property & value doesn't exist
-        assertNull("Check Indexed Property doesn't exist", dynaMap.getDynaProperty(testProperty));
-        assertNull("Check Indexed Property is null", dynaMap.get(testProperty));
+        assertNull(dynaMap.getDynaProperty(testProperty), "Check Indexed Property doesn't exist");
+        assertNull(dynaMap.get(testProperty), "Check Indexed Property is null");
 
         // Add a DynaProperty of type String[]
         dynaMap.add(testProperty, objectArray.getClass());
-        assertEquals("Check Indexed Property exists", objectArray.getClass(), dynaMap.getDynaProperty(testProperty).getType());
-        assertEquals("Check Indexed Property is correct type", objectArray.getClass(), dynaMap.get(testProperty).getClass());
+        assertEquals(objectArray.getClass(), dynaMap.getDynaProperty(testProperty).getType(),
+                                "Check Indexed Property exists");
+        assertEquals(objectArray.getClass(), dynaMap.get(testProperty).getClass(),
+                                "Check Indexed Property is correct type");
 
         // Retrieving from Array should initialize DynaBean
         for (int i = index; i >= 0; i--) {
-            assertEquals("Check Array Components initialized", LazyDynaBean.class, dynaMap.get(testProperty, index).getClass());
+            assertEquals(LazyDynaBean.class, dynaMap.get(testProperty, index).getClass(),
+                                    "Check Array Components initialized");
         }
 
         dynaMap.add(testPropertyB, objectArray.getClass());
         final LazyDynaBean newBean = new LazyDynaBean();
         newBean.set(testPropertyB, testString2);
         dynaMap.set(testPropertyA, index, newBean);
-        assertEquals("Check Indexed Value is correct(a)", testString2, ((DynaBean) dynaMap.get(testPropertyA, index)).get(testPropertyB));
+        assertEquals(testString2, ((DynaBean) dynaMap.get(testPropertyA, index)).get(testPropertyB),
+                                "Check Indexed Value is correct(a)");
 
     }
 
     /**
      * Test setting indexed property for type which is not List or Array
      */
+    @Test
     public void testIndexedInvalidType() {
         final int index = 3;
         dynaMap.set(testProperty, "Test String");
-        assertFalse("Check Property is not indexed", dynaMap.getDynaProperty(testProperty).isIndexed());
+        assertFalse(dynaMap.getDynaProperty(testProperty).isIndexed(), "Check Property is not indexed");
         try {
             dynaMap.set(testProperty, index, testString1);
             fail("set(property, index, value) should have thrown IllegalArgumentException");
@@ -128,145 +136,184 @@ public class LazyDynaMapTestCase extends TestCase {
     /**
      * Test Getting/Setting a List 'Indexed' Property - use alternative List (LinkedList)
      */
+    @Test
     public void testIndexedLinkedList() {
 
         int index = 3;
 
         // Check the property & value doesn't exist
-        assertNull("Check Indexed Property doesn't exist", dynaMap.getDynaProperty(testProperty));
-        assertNull("Check Indexed Property is null", dynaMap.get(testProperty));
+        assertNull(dynaMap.getDynaProperty(testProperty), "Check Indexed Property doesn't exist");
+        assertNull(dynaMap.get(testProperty), "Check Indexed Property is null");
 
         // Add a 'LinkedList' property to the DynaClass - should instantiate a new LinkedList
         dynaMap.add(testProperty, LinkedList.class);
-        assertTrue("Check Property is indexed", dynaMap.getDynaProperty(testProperty).isIndexed());
-        assertEquals("Check Property is correct type", LinkedList.class, dynaMap.getDynaProperty(testProperty).getType());
-        assertEquals("Check Indexed Property now exists", LinkedList.class, dynaMap.get(testProperty).getClass());
+        assertTrue(dynaMap.getDynaProperty(testProperty).isIndexed(), "Check Property is indexed");
+        assertEquals(LinkedList.class, dynaMap.getDynaProperty(testProperty).getType(),
+                                "Check Property is correct type");
+        assertEquals(LinkedList.class, dynaMap.get(testProperty).getClass(),
+                                "Check Indexed Property now exists");
 
         // Set the Indexed property, should grow the list to the correct size
         dynaMap.set(testProperty, index, testString1);
-        assertEquals("Check Property type is correct", LinkedList.class, dynaMap.get(testProperty).getClass());
-        assertEquals("Check First Indexed Value is correct", testString1, dynaMap.get(testProperty, index));
-        assertEquals("Check First Array length is correct", Integer.valueOf(index + 1), Integer.valueOf(((LinkedList<?>) dynaMap.get(testProperty)).size()));
+        assertEquals(LinkedList.class, dynaMap.get(testProperty).getClass(),
+                                "Check Property type is correct");
+        assertEquals(testString1, dynaMap.get(testProperty, index), "Check First Indexed Value is correct");
+        assertEquals(Integer.valueOf(index + 1),
+                                Integer.valueOf(((LinkedList<?>) dynaMap.get(testProperty)).size()),
+                                "Check First Array length is correct");
 
         // Set a second indexed value, should automatically grow the LinkedList and set appropriate indexed value
         index += 2;
         dynaMap.set(testProperty, index, testInteger1);
-        assertEquals("Check Second Indexed Value is correct", testInteger1, dynaMap.get(testProperty, index));
-        assertEquals("Check Second Array length is correct", Integer.valueOf(index + 1), Integer.valueOf(((LinkedList<?>) dynaMap.get(testProperty)).size()));
+        assertEquals(testInteger1, dynaMap.get(testProperty, index),
+                                "Check Second Indexed Value is correct");
+        assertEquals(Integer.valueOf(index + 1),
+                                Integer.valueOf(((LinkedList<?>) dynaMap.get(testProperty)).size()),
+                                "Check Second Array length is correct");
     }
 
     /**
      * Test Getting/Setting an Object array 'Indexed' Property - use String[]
      */
+    @Test
     public void testIndexedObjectArray() {
 
         int index = 3;
         final Object objectArray = new String[0];
 
         // Check the property & value doesn't exist
-        assertNull("Check Indexed Property doesn't exist", dynaMap.getDynaProperty(testProperty));
-        assertNull("Check Indexed Property is null", dynaMap.get(testProperty));
+        assertNull(dynaMap.getDynaProperty(testProperty), "Check Indexed Property doesn't exist");
+        assertNull(dynaMap.get(testProperty), "Check Indexed Property is null");
 
         // Add a DynaProperty of type String[]
         dynaMap.add(testProperty, objectArray.getClass());
-        assertEquals("Check Indexed Property exists", objectArray.getClass(), dynaMap.getDynaProperty(testProperty).getType());
-        assertTrue("Check Indexed Property exists", dynaMap.get(testProperty).getClass().isInstance(objectArray));
+        assertEquals(objectArray.getClass(), dynaMap.getDynaProperty(testProperty).getType(),
+                                "Check Indexed Property exists");
+        assertTrue(dynaMap.get(testProperty).getClass().isInstance(objectArray),
+                              "Check Indexed Property exists");
 
         // Set an indexed value
         dynaMap.set(testProperty, index, testString1);
-        assertNotNull("Check Indexed Property is not null", dynaMap.get(testProperty));
-        assertEquals("Check Indexed Property is correct type", objectArray.getClass(), dynaMap.get(testProperty).getClass());
-        assertEquals("Check First Indexed Value is correct(a)", testString1, dynaMap.get(testProperty, index));
-        assertEquals("Check First Indexed Value is correct(b)", testString1, ((String[]) dynaMap.get(testProperty))[index]);
-        assertEquals("Check Array length is correct", Integer.valueOf(index + 1), Integer.valueOf(((String[]) dynaMap.get(testProperty)).length));
+        assertNotNull(dynaMap.get(testProperty), "Check Indexed Property is not null");
+        assertEquals(objectArray.getClass(), dynaMap.get(testProperty).getClass(),
+                                "Check Indexed Property is correct type");
+        assertEquals(testString1, dynaMap.get(testProperty, index),
+                                "Check First Indexed Value is correct(a)");
+        assertEquals(testString1, ((String[]) dynaMap.get(testProperty))[index],
+                                "Check First Indexed Value is correct(b)");
+        assertEquals(Integer.valueOf(index + 1),
+                                Integer.valueOf(((String[]) dynaMap.get(testProperty)).length),
+                                "Check Array length is correct");
 
         // Set a second indexed value, should automatically grow the String[] and set appropriate indexed value
         index += 2;
         dynaMap.set(testProperty, index, testString2);
-        assertEquals("Check Second Indexed Value is correct(a)", testString2, dynaMap.get(testProperty, index));
-        assertEquals("Check Second Indexed Value is correct(b)", testString2, ((String[]) dynaMap.get(testProperty))[index]);
-        assertEquals("Check Second Array length is correct", Integer.valueOf(index + 1), Integer.valueOf(((String[]) dynaMap.get(testProperty)).length));
+        assertEquals(testString2, dynaMap.get(testProperty, index),
+                                "Check Second Indexed Value is correct(a)");
+        assertEquals(testString2, ((String[]) dynaMap.get(testProperty))[index],
+                                "Check Second Indexed Value is correct(b)");
+        assertEquals(Integer.valueOf(index + 1),
+                                Integer.valueOf(((String[]) dynaMap.get(testProperty)).length),
+                                "Check Second Array length is correct");
     }
 
     /**
      * Test Getting/Setting a primitive array 'Indexed' Property - use int[]
      */
+    @Test
     public void testIndexedPrimitiveArray() {
 
         int index = 3;
         final int[] primitiveArray = {};
 
         // Check the property & value doesn't exist
-        assertNull("Check Indexed Property doesn't exist", dynaMap.getDynaProperty(testProperty));
-        assertNull("Check Indexed Property is null", dynaMap.get(testProperty));
+        assertNull(dynaMap.getDynaProperty(testProperty), "Check Indexed Property doesn't exist");
+        assertNull(dynaMap.get(testProperty), "Check Indexed Property is null");
 
         // Add a DynaProperty of type int[]
         dynaMap.add(testProperty, primitiveArray.getClass());
-        assertEquals("Check Indexed Property exists", primitiveArray.getClass(), dynaMap.getDynaProperty(testProperty).getType());
-        assertTrue("Check Indexed Property exists", dynaMap.get(testProperty).getClass().isInstance(primitiveArray));
+        assertEquals(primitiveArray.getClass(), dynaMap.getDynaProperty(testProperty).getType(),
+                                "Check Indexed Property exists");
+        assertTrue(dynaMap.get(testProperty).getClass().isInstance(primitiveArray),
+                              "Check Indexed Property exists");
 
         // Set an indexed value
         dynaMap.set(testProperty, index, testInteger1);
-        assertNotNull("Check Indexed Property is not null", dynaMap.get(testProperty));
-        assertEquals("Check Indexed Property is correct type", primitiveArray.getClass(), dynaMap.get(testProperty).getClass());
-        assertEquals("Check First Indexed Value is correct(a)", testInteger1, dynaMap.get(testProperty, index));
-        assertEquals("Check First Indexed Value is correct(b)", testInteger1, Integer.valueOf(((int[]) dynaMap.get(testProperty))[index]));
-        assertEquals("Check Array length is correct", Integer.valueOf(index + 1), Integer.valueOf(((int[]) dynaMap.get(testProperty)).length));
+        assertNotNull(dynaMap.get(testProperty), "Check Indexed Property is not null");
+        assertEquals(primitiveArray.getClass(), dynaMap.get(testProperty).getClass(),
+                                "Check Indexed Property is correct type");
+        assertEquals(testInteger1, dynaMap.get(testProperty, index),
+                                "Check First Indexed Value is correct(a)");
+        assertEquals(testInteger1, Integer.valueOf(((int[]) dynaMap.get(testProperty))[index]),
+                                "Check First Indexed Value is correct(b)");
+        assertEquals(Integer.valueOf(index + 1), Integer.valueOf(((int[]) dynaMap.get(testProperty)).length),
+                                "Check Array length is correct");
 
         // Set a second indexed value, should automatically grow the int[] and set appropriate indexed value
         index += 2;
         dynaMap.set(testProperty, index, testInteger2);
-        assertEquals("Check Second Indexed Value is correct(a)", testInteger2, dynaMap.get(testProperty, index));
-        assertEquals("Check Second Indexed Value is correct(b)", testInteger2, Integer.valueOf(((int[]) dynaMap.get(testProperty))[index]));
-        assertEquals("Check Second Array length is correct", Integer.valueOf(index + 1), Integer.valueOf(((int[]) dynaMap.get(testProperty)).length));
+        assertEquals(testInteger2, dynaMap.get(testProperty, index),
+                                "Check Second Indexed Value is correct(a)");
+        assertEquals(testInteger2, Integer.valueOf(((int[]) dynaMap.get(testProperty))[index]),
+                                "Check Second Indexed Value is correct(b)");
+        assertEquals(Integer.valueOf(index + 1), Integer.valueOf(((int[]) dynaMap.get(testProperty)).length),
+                                "Check Second Array length is correct");
 
     }
 
     /**
      * Test Getting/Setting an 'Indexed' Property - default ArrayList property
      */
+    @Test
     public void testIndexedPropertyDefault() {
 
         int index = 3;
 
         // Check the property & value doesn't exist
-        assertNull("Check Indexed Property doesn't exist", dynaMap.getDynaProperty(testProperty));
-        assertNull("Check Indexed Property is null", dynaMap.get(testProperty));
-        assertNull("Check Indexed value is null", dynaMap.get(testProperty, index));
+        assertNull(dynaMap.getDynaProperty(testProperty), "Check Indexed Property doesn't exist");
+        assertNull(dynaMap.get(testProperty), "Check Indexed Property is null");
+        assertNull(dynaMap.get(testProperty, index), "Check Indexed value is null");
 
         // Set the property, should create new ArrayList and set appropriate indexed value
         dynaMap.set(testProperty, index, testInteger1);
-        assertNotNull("Check Indexed Property is not null", dynaMap.get(testProperty));
-        assertEquals("Check Indexed Property is correct type", ArrayList.class, dynaMap.get(testProperty).getClass());
-        assertEquals("Check First Indexed Value is correct", testInteger1, dynaMap.get(testProperty, index));
-        assertEquals("Check First Array length is correct", Integer.valueOf(index + 1), Integer.valueOf(((ArrayList<?>) dynaMap.get(testProperty)).size()));
+        assertNotNull(dynaMap.get(testProperty), "Check Indexed Property is not null");
+        assertEquals(ArrayList.class, dynaMap.get(testProperty).getClass(),
+                                "Check Indexed Property is correct type");
+        assertEquals(testInteger1, dynaMap.get(testProperty, index), "Check First Indexed Value is correct");
+        assertEquals(Integer.valueOf(index + 1),
+                                Integer.valueOf(((ArrayList<?>) dynaMap.get(testProperty)).size()),
+                                "Check First Array length is correct");
 
         // Set a second indexed value, should automatically grow the ArrayList and set appropriate indexed value
         index += 2;
         dynaMap.set(testProperty, index, testString1);
-        assertEquals("Check Second Indexed Value is correct", testString1, dynaMap.get(testProperty, index));
-        assertEquals("Check Second Array length is correct", Integer.valueOf(index + 1), Integer.valueOf(((ArrayList<?>) dynaMap.get(testProperty)).size()));
+        assertEquals(testString1, dynaMap.get(testProperty, index), "Check Second Indexed Value is correct");
+        assertEquals(Integer.valueOf(index + 1),
+                                Integer.valueOf(((ArrayList<?>) dynaMap.get(testProperty)).size()),
+                                "Check Second Array length is correct");
     }
 
     /**
      * Test Setting an Indexed Property when MutableDynaClass is set to restricted
      */
+    @Test
     public void testIndexedPropertyRestricted() {
 
         final int index = 3;
 
         // Set the MutableDyanClass to 'restricted' (i.e. no new properties cab be added
         dynaMap.setRestricted(true);
-        assertTrue("Check MutableDynaClass is restricted", dynaMap.isRestricted());
+        assertTrue(dynaMap.isRestricted(), "Check MutableDynaClass is restricted");
 
         // Check the property & value doesn't exist
-        assertNull("Check Property doesn't exist", dynaMap.getDynaProperty(testProperty));
-        assertNull("Check Value is null", dynaMap.get(testProperty));
+        assertNull(dynaMap.getDynaProperty(testProperty), "Check Property doesn't exist");
+        assertNull(dynaMap.get(testProperty), "Check Value is null");
 
         // Set the property - should fail because property doesn't exist and MutableDynaClass is restricted
         try {
             dynaMap.set(testProperty, index, testInteger1);
-            fail("expected IllegalArgumentException trying to add new property to restricted MutableDynaClass");
+            fail(
+                    "expected IllegalArgumentException trying to add new property to restricted MutableDynaClass");
         } catch (final IllegalArgumentException expected) {
             // expected result
         }
@@ -276,15 +323,16 @@ public class LazyDynaMapTestCase extends TestCase {
     /**
      * Test Setting an 'Indexed' Property using PropertyUtils
      */
+    @Test
     public void testIndexedPropertyUtils() {
 
         final int index = 3;
         dynaMap.setReturnNull(false);
 
         // Check the property & value doesn't exist
-        assertFalse("Check Indexed Property doesn't exist", dynaMap.isDynaProperty(testProperty));
-        assertNull("Check Indexed Property is null", dynaMap.get(testProperty));
-        assertNull("Check Indexed value is null", dynaMap.get(testProperty, index));
+        assertFalse(dynaMap.isDynaProperty(testProperty), "Check Indexed Property doesn't exist");
+        assertNull(dynaMap.get(testProperty), "Check Indexed Property is null");
+        assertNull(dynaMap.get(testProperty, index), "Check Indexed value is null");
 
         // Use PropertyUtils to set the indexed value
         try {
@@ -294,16 +342,17 @@ public class LazyDynaMapTestCase extends TestCase {
         }
 
         // Check property value correctly set
-        assertEquals("Check Indexed Bean Value is correct", testString1, dynaMap.get(testProperty, index));
+        assertEquals(testString1, dynaMap.get(testProperty, index), "Check Indexed Bean Value is correct");
 
     }
 
     /**
      * Test setting mapped property for type which is not Map
      */
+    @Test
     public void testMappedInvalidType() {
         dynaMap.set(testProperty, Integer.valueOf(1));
-        assertFalse("Check Property is not mapped", dynaMap.getDynaProperty(testProperty).isMapped());
+        assertFalse(dynaMap.getDynaProperty(testProperty).isMapped(), "Check Property is not mapped");
         try {
             dynaMap.set(testProperty, testKey, testInteger1);
             fail("set(property, key, value) should have thrown IllegalArgumentException");
@@ -315,42 +364,49 @@ public class LazyDynaMapTestCase extends TestCase {
     /**
      * Test Getting/Setting a 'Mapped' Property - default HashMap property
      */
+    @Test
     public void testMappedPropertyDefault() {
 
         // Check the property & value doesn't exist
-        assertNull("Check Mapped Property doesn't exist", dynaMap.getDynaProperty(testProperty));
-        assertNull("Check Map is null", dynaMap.get(testProperty));
-        assertNull("Check Mapped Value is null", dynaMap.get(testProperty, testKey));
+        assertNull(dynaMap.getDynaProperty(testProperty), "Check Mapped Property doesn't exist");
+        assertNull(dynaMap.get(testProperty), "Check Map is null");
+        assertNull(dynaMap.get(testProperty, testKey), "Check Mapped Value is null");
 
         // Set a new mapped property - should add new HashMap property and set the mapped value
         dynaMap.set(testProperty, testKey, testInteger1);
-        assertEquals("Check Mapped Property exists", HashMap.class, dynaMap.get(testProperty).getClass());
-        assertEquals("Check First Mapped Value is correct(a)", testInteger1, dynaMap.get(testProperty, testKey));
-        assertEquals("Check First Mapped Value is correct(b)", testInteger1, ((HashMap<?, ?>) dynaMap.get(testProperty)).get(testKey));
+        assertEquals(HashMap.class, dynaMap.get(testProperty).getClass(), "Check Mapped Property exists");
+        assertEquals(testInteger1, dynaMap.get(testProperty, testKey),
+                                "Check First Mapped Value is correct(a)");
+        assertEquals(testInteger1, ((HashMap<?, ?>) dynaMap.get(testProperty)).get(testKey),
+                                "Check First Mapped Value is correct(b)");
 
         // Set the property again - should set the new value
         dynaMap.set(testProperty, testKey, testInteger2);
-        assertEquals("Check Second Mapped Value is correct(a)", testInteger2, dynaMap.get(testProperty, testKey));
-        assertEquals("Check Second Mapped Value is correct(b)", testInteger2, ((HashMap<?, ?>) dynaMap.get(testProperty)).get(testKey));
+        assertEquals(testInteger2, dynaMap.get(testProperty, testKey),
+                                "Check Second Mapped Value is correct(a)");
+        assertEquals(testInteger2, ((HashMap<?, ?>) dynaMap.get(testProperty)).get(testKey),
+                                "Check Second Mapped Value is correct(b)");
     }
 
     /**
      * Test Setting a Mapped Property when MutableDynaClass is set to restricted
      */
+    @Test
     public void testMappedPropertyRestricted() {
 
         // Set the MutableDyanClass to 'restricted' (i.e. no new properties cab be added
         dynaMap.setRestricted(true);
-        assertTrue("Check MutableDynaClass is restricted", dynaMap.isRestricted());
+        assertTrue(dynaMap.isRestricted(), "Check MutableDynaClass is restricted");
 
         // Check the property & value doesn't exist
-        assertNull("Check Property doesn't exist", dynaMap.getDynaProperty(testProperty));
-        assertNull("Check Value is null", dynaMap.get(testProperty));
+        assertNull(dynaMap.getDynaProperty(testProperty), "Check Property doesn't exist");
+        assertNull(dynaMap.get(testProperty), "Check Value is null");
 
         // Set the property - should fail because property doesn't exist and MutableDynaClass is restricted
         try {
             dynaMap.set(testProperty, testKey, testInteger1);
-            fail("expected IllegalArgumentException trying to add new property to restricted MutableDynaClass");
+            fail(
+                    "expected IllegalArgumentException trying to add new property to restricted MutableDynaClass");
         } catch (final IllegalArgumentException expected) {
             // expected result
         }
@@ -360,41 +416,49 @@ public class LazyDynaMapTestCase extends TestCase {
     /**
      * Test Getting/Setting a 'Mapped' Property - use TreeMap property
      */
+    @Test
     public void testMappedPropertyTreeMap() {
 
         // Check the property & value doesn't exist
-        assertNull("Check Mapped Property doesn't exist", dynaMap.getDynaProperty(testProperty));
-        assertNull("Check Map is null", dynaMap.get(testProperty));
+        assertNull(dynaMap.getDynaProperty(testProperty), "Check Mapped Property doesn't exist");
+        assertNull(dynaMap.get(testProperty), "Check Map is null");
 
         // Add a 'TreeMap' property to the DynaClass
         dynaMap.add(testProperty, TreeMap.class);
-        assertTrue("Check Property is mapped", dynaMap.getDynaProperty(testProperty).isMapped());
-        assertEquals("Check Property is correct type", TreeMap.class, dynaMap.getDynaProperty(testProperty).getType());
-        assertEquals("Check Mapped Property now exists", TreeMap.class, dynaMap.get(testProperty).getClass());
+        assertTrue(dynaMap.getDynaProperty(testProperty).isMapped(), "Check Property is mapped");
+        assertEquals(TreeMap.class, dynaMap.getDynaProperty(testProperty).getType(),
+                                "Check Property is correct type");
+        assertEquals(TreeMap.class, dynaMap.get(testProperty).getClass(),
+                                "Check Mapped Property now exists");
 
         // Set a new mapped property - should instantiate a new TreeMap property and set the mapped value
         dynaMap.set(testProperty, testKey, testInteger1);
-        assertEquals("Check Mapped Property exists", TreeMap.class, dynaMap.get(testProperty).getClass());
-        assertEquals("Check First Mapped Value is correct(a)", testInteger1, dynaMap.get(testProperty, testKey));
-        assertEquals("Check First Mapped Value is correct(b)", testInteger1, ((TreeMap<?, ?>) dynaMap.get(testProperty)).get(testKey));
+        assertEquals(TreeMap.class, dynaMap.get(testProperty).getClass(), "Check Mapped Property exists");
+        assertEquals(testInteger1, dynaMap.get(testProperty, testKey),
+                                "Check First Mapped Value is correct(a)");
+        assertEquals(testInteger1, ((TreeMap<?, ?>) dynaMap.get(testProperty)).get(testKey),
+                                "Check First Mapped Value is correct(b)");
 
         // Set the property again - should set the new value
         dynaMap.set(testProperty, testKey, testInteger2);
-        assertEquals("Check Second Mapped Value is correct(a)", testInteger2, dynaMap.get(testProperty, testKey));
-        assertEquals("Check Second Mapped Value is correct(b)", testInteger2, ((TreeMap<?, ?>) dynaMap.get(testProperty)).get(testKey));
+        assertEquals(testInteger2, dynaMap.get(testProperty, testKey),
+                                "Check Second Mapped Value is correct(a)");
+        assertEquals(testInteger2, ((TreeMap<?, ?>) dynaMap.get(testProperty)).get(testKey),
+                                "Check Second Mapped Value is correct(b)");
     }
 
     /**
      * Test Setting a 'Mapped' Property using PropertyUtils
      */
+    @Test
     public void testMappedPropertyUtils() {
 
         dynaMap.setReturnNull(false);
 
         // Check the property & value doesn't exist
-        assertFalse("Check Mapped Property doesn't exist", dynaMap.isDynaProperty(testProperty));
-        assertNull("Check Map is null", dynaMap.get(testProperty));
-        assertNull("Check Mapped Value is null", dynaMap.get(testProperty, testKey));
+        assertFalse(dynaMap.isDynaProperty(testProperty), "Check Mapped Property doesn't exist");
+        assertNull(dynaMap.get(testProperty), "Check Map is null");
+        assertNull(dynaMap.get(testProperty, testKey), "Check Mapped Value is null");
 
         // Set the mapped property using PropertyUtils
         try {
@@ -404,13 +468,14 @@ public class LazyDynaMapTestCase extends TestCase {
         }
 
         // Check property value correctly set
-        assertEquals("Check Mapped Bean Value is correct", testString1, dynaMap.get(testProperty, testKey));
+        assertEquals(testString1, dynaMap.get(testProperty, testKey), "Check Mapped Bean Value is correct");
 
     }
 
     /**
      * Test creating using DynaClass.newInstance()
      */
+    @Test
     public void testNewInstance() {
 
         // Create LazyDynaMap using TreeMap
@@ -418,53 +483,56 @@ public class LazyDynaMapTestCase extends TestCase {
         final LazyDynaMap orig = new LazyDynaMap(new TreeMap<>());
         orig.set("indexProp", 0, "indexVal0");
         orig.set("indexProp", 1, "indexVal1");
-        assertEquals("Index prop size", 2, ((List<?>) orig.get("indexProp")).size());
+        assertEquals(2, ((List<?>) orig.get("indexProp")).size(), "Index prop size");
 
         final LazyDynaMap newOne = (LazyDynaMap) orig.newInstance();
         final Map<String, Object> newMap = newOne.getMap();
-        assertEquals("Check Map type", TreeMap.class, newMap.getClass());
+        assertEquals(TreeMap.class, newMap.getClass(), "Check Map type");
 
         final ArrayList<?> indexProp = (ArrayList<?>) newMap.get("indexProp");
-        assertNotNull("Indexed Prop missing", indexProp);
-        assertEquals("Index prop size", 0, indexProp.size());
+        assertNotNull(indexProp, "Indexed Prop missing");
+        assertEquals(0, indexProp.size(), "Index prop size");
     }
 
     /**
      * Test Getting/Setting a Simple Property
      */
+    @Test
     public void testSimpleProperty() {
 
         // Check the property & value doesn't exist
-        assertNull("Check Property doesn't exist", dynaMap.getDynaProperty(testProperty));
-        assertNull("Check Value is null", dynaMap.get(testProperty));
+        assertNull(dynaMap.getDynaProperty(testProperty), "Check Property doesn't exist");
+        assertNull(dynaMap.get(testProperty), "Check Value is null");
 
         // Set a new property - should add new property and set value
         dynaMap.set(testProperty, testInteger1);
-        assertEquals("Check First Value is correct", testInteger1, dynaMap.get(testProperty));
-        assertEquals("Check Property type is correct", Integer.class, dynaMap.getDynaProperty(testProperty).getType());
+        assertEquals(testInteger1, dynaMap.get(testProperty), "Check First Value is correct");
+        assertEquals(Integer.class, dynaMap.getDynaProperty(testProperty).getType(),
+                                "Check Property type is correct");
 
         // Set the property again - should set the new value
         dynaMap.set(testProperty, testInteger2);
-        assertEquals("Check Second Value is correct", testInteger2, dynaMap.get(testProperty));
+        assertEquals(testInteger2, dynaMap.get(testProperty), "Check Second Value is correct");
 
         // Set the property again - with a different type, should succeed
         dynaMap.set(testProperty, testString1);
-        assertEquals("Check Third Value is correct", testString1, dynaMap.get(testProperty));
+        assertEquals(testString1, dynaMap.get(testProperty), "Check Third Value is correct");
 
     }
 
     /**
      * Test Setting a Simple Property when MutableDynaClass is set to restricted
      */
+    @Test
     public void testSimplePropertyRestricted() {
 
         // Set the MutableDyanClass to 'restricted' (i.e. no new properties cab be added
         dynaMap.setRestricted(true);
-        assertTrue("Check MutableDynaClass is restricted", dynaMap.isRestricted());
+        assertTrue(dynaMap.isRestricted(), "Check MutableDynaClass is restricted");
 
         // Check the property & value doesn't exist
-        assertNull("Check Property doesn't exist", dynaMap.getDynaProperty(testProperty));
-        assertNull("Check Value is null", dynaMap.get(testProperty));
+        assertNull(dynaMap.getDynaProperty(testProperty), "Check Property doesn't exist");
+        assertNull(dynaMap.get(testProperty), "Check Value is null");
 
         // Set the property - should fail because property doesn't exist and MutableDynaClass is restricted
         try {

--- a/src/test/java/org/apache/commons/beanutils2/MappedPropertyTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/MappedPropertyTestCase.java
@@ -16,48 +16,47 @@
  */
 package org.apache.commons.beanutils2;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>
  * Test Case for the {@code MappedPropertyDescriptor}.
  * </p>
  */
-public class MappedPropertyTestCase extends TestCase {
-
-    /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public MappedPropertyTestCase(final String name) {
-        super(name);
-    }
+public class MappedPropertyTestCase {
 
     /**
      * Sets up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
     }
 
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     public void tearDown() {
     }
 
     /**
      * Test property with any two args
      */
+    @Test
     public void testAnyArgsProperty() {
         final String property = "anyMapped";
         final Class<?> clazz = MappedPropertyTestBean.class;
         try {
             final MappedPropertyDescriptor desc = new MappedPropertyDescriptor(property, clazz);
-            assertNull("Getter is found", desc.getMappedReadMethod());
-            assertNotNull("Setter is missing", desc.getMappedWriteMethod());
+            assertNull(desc.getMappedReadMethod(), "Getter is found");
+            assertNotNull(desc.getMappedWriteMethod(), "Setter is missing");
         } catch (final Exception ex) {
             fail("Property '" + property + "' Not Found in " + clazz.getName() + ": " + ex);
         }
@@ -66,13 +65,14 @@ public class MappedPropertyTestCase extends TestCase {
     /**
      * Test boolean "is" method name
      */
+    @Test
     public void testBooleanMapped() {
         final String property = "mappedBoolean";
         final Class<?> clazz = MappedPropertyTestBean.class;
         try {
             final MappedPropertyDescriptor desc = new MappedPropertyDescriptor(property, clazz);
-            assertNotNull("Getter is missing", desc.getMappedReadMethod());
-            assertNotNull("Setter is missing", desc.getMappedWriteMethod());
+            assertNotNull(desc.getMappedReadMethod(), "Getter is missing");
+            assertNotNull(desc.getMappedWriteMethod(), "Setter is missing");
         } catch (final Exception ex) {
             fail("Property '" + property + "' Not Found in " + clazz.getName() + ": " + ex);
         }
@@ -81,13 +81,14 @@ public class MappedPropertyTestCase extends TestCase {
     /**
      * Test Interface Inherited mapped property
      */
+    @Test
     public void testChildInterfaceMapped() {
         final String property = "mapproperty";
         final Class<?> clazz = MappedPropertyChildInterface.class;
         try {
             final MappedPropertyDescriptor desc = new MappedPropertyDescriptor(property, clazz);
-            assertNotNull("Getter is missing", desc.getMappedReadMethod());
-            assertNotNull("Setter is missing", desc.getMappedWriteMethod());
+            assertNotNull(desc.getMappedReadMethod(), "Getter is missing");
+            assertNotNull(desc.getMappedWriteMethod(), "Setter is missing");
         } catch (final Exception ex) {
             fail("Property '" + property + "' Not Found in " + clazz.getName() + ": " + ex);
         }
@@ -99,13 +100,14 @@ public class MappedPropertyTestCase extends TestCase {
      * Expect to find the getDifferentTypes() method, but not the setDifferentTypes() method because setDifferentTypes() sets and Integer, while
      * getDifferentTypes() returns a Long.
      */
+    @Test
     public void testDifferentTypes() {
         final String property = "differentTypes";
         final Class<?> clazz = MappedPropertyTestBean.class;
         try {
             final MappedPropertyDescriptor desc = new MappedPropertyDescriptor(property, clazz);
-            assertNotNull("Getter is missing", desc.getMappedReadMethod());
-            assertNull("Setter is found", desc.getMappedWriteMethod());
+            assertNotNull(desc.getMappedReadMethod(), "Getter is missing");
+            assertNull(desc.getMappedWriteMethod(), "Setter is found");
         } catch (final Exception ex) {
             fail("Property '" + property + "' Not Found in " + clazz.getName() + ": " + ex);
         }
@@ -114,13 +116,14 @@ public class MappedPropertyTestCase extends TestCase {
     /**
      * Test valid method name
      */
+    @Test
     public void testFound() {
         final String property = "mapproperty";
         final Class<?> clazz = MappedPropertyTestBean.class;
         try {
             final MappedPropertyDescriptor desc = new MappedPropertyDescriptor(property, clazz);
-            assertNotNull("Getter is missing", desc.getMappedReadMethod());
-            assertNotNull("Setter is missing", desc.getMappedWriteMethod());
+            assertNotNull(desc.getMappedReadMethod(), "Getter is missing");
+            assertNotNull(desc.getMappedWriteMethod(), "Setter is missing");
         } catch (final Exception ex) {
             fail("Property '" + property + "' Not Found in " + clazz.getName() + ": " + ex);
         }
@@ -129,13 +132,14 @@ public class MappedPropertyTestCase extends TestCase {
     /**
      * Test Interface with mapped property
      */
+    @Test
     public void testInterfaceMapped() {
         final String property = "mapproperty";
         final Class<?> clazz = MappedPropertyTestInterface.class;
         try {
             final MappedPropertyDescriptor desc = new MappedPropertyDescriptor(property, clazz);
-            assertNotNull("Getter is missing", desc.getMappedReadMethod());
-            assertNotNull("Setter is missing", desc.getMappedWriteMethod());
+            assertNotNull(desc.getMappedReadMethod(), "Getter is missing");
+            assertNotNull(desc.getMappedWriteMethod(), "Setter is missing");
         } catch (final Exception ex) {
             fail("Property '" + property + "' Not Found in " + clazz.getName() + ": " + ex);
         }
@@ -144,6 +148,7 @@ public class MappedPropertyTestCase extends TestCase {
     /**
      * Test property not found in interface
      */
+    @Test
     public void testInterfaceNotFound() {
         final String property = "XXXXXX";
         final Class<?> clazz = MappedPropertyTestInterface.class;
@@ -157,13 +162,14 @@ public class MappedPropertyTestCase extends TestCase {
     /**
      * Test Mapped Property - Invalid Getter
      */
+    @Test
     public void testInvalidGetter() {
         final String property = "invalidGetter";
         final Class<?> clazz = MappedPropertyTestBean.class;
         try {
             final MappedPropertyDescriptor desc = new MappedPropertyDescriptor(property, clazz);
-            assertNull("Getter is found", desc.getMappedReadMethod());
-            assertNotNull("Setter is missing", desc.getMappedWriteMethod());
+            assertNull(desc.getMappedReadMethod(), "Getter is found");
+            assertNotNull(desc.getMappedWriteMethod(), "Setter is missing");
         } catch (final Exception ex) {
             fail("Property '" + property + "' Not Found in " + clazz.getName() + ": " + ex);
         }
@@ -172,13 +178,14 @@ public class MappedPropertyTestCase extends TestCase {
     /**
      * Test Mapped Property - Invalid Setter
      */
+    @Test
     public void testInvalidSetter() {
         final String property = "invalidSetter";
         final Class<?> clazz = MappedPropertyTestBean.class;
         try {
             final MappedPropertyDescriptor desc = new MappedPropertyDescriptor(property, clazz);
-            assertNotNull("Getter is missing", desc.getMappedReadMethod());
-            assertNull("Setter is found", desc.getMappedWriteMethod());
+            assertNotNull(desc.getMappedReadMethod(), "Getter is missing");
+            assertNull(desc.getMappedWriteMethod(), "Setter is found");
         } catch (final Exception ex) {
             fail("Property '" + property + "' Not Found in " + clazz.getName() + ": " + ex);
         }
@@ -187,13 +194,14 @@ public class MappedPropertyTestCase extends TestCase {
     /**
      * Test Map getter
      */
+    @Test
     public void testMapGetter() {
         final MappedPropertyTestBean bean = new MappedPropertyTestBean();
         try {
             final String testValue = "test value";
             final String testKey = "testKey";
             BeanUtils.setProperty(bean, "myMap(" + testKey + ")", "test value");
-            assertEquals("Map getter", testValue, bean.getMyMap().get(testKey));
+            assertEquals(testValue, bean.getMyMap().get(testKey), "Map getter");
         } catch (final Exception ex) {
             fail("Test set mapped property failed: " + ex);
         }
@@ -202,13 +210,14 @@ public class MappedPropertyTestCase extends TestCase {
     /**
      * Test Mapped Property - Getter only
      */
+    @Test
     public void testMappedGetterOnly() {
         final String property = "mappedGetterOnly";
         final Class<?> clazz = MappedPropertyTestBean.class;
         try {
             final MappedPropertyDescriptor desc = new MappedPropertyDescriptor(property, clazz);
-            assertNotNull("Getter is missing", desc.getMappedReadMethod());
-            assertNull("Setter is found", desc.getMappedWriteMethod());
+            assertNotNull(desc.getMappedReadMethod(), "Getter is missing");
+            assertNull(desc.getMappedWriteMethod(), "Setter is found");
         } catch (final Exception ex) {
             fail("Property '" + property + "' Not Found in " + clazz.getName() + ": " + ex);
         }
@@ -217,13 +226,14 @@ public class MappedPropertyTestCase extends TestCase {
     /**
      * Test Mapped Property - Setter Only
      */
+    @Test
     public void testMappedSetterOnly() {
         final String property = "mappedSetterOnly";
         final Class<?> clazz = MappedPropertyTestBean.class;
         try {
             final MappedPropertyDescriptor desc = new MappedPropertyDescriptor(property, clazz);
-            assertNull("Getter is found", desc.getMappedReadMethod());
-            assertNotNull("Setter is missing", desc.getMappedWriteMethod());
+            assertNull(desc.getMappedReadMethod(), "Getter is found");
+            assertNotNull(desc.getMappedWriteMethod(), "Setter is missing");
         } catch (final Exception ex) {
             fail("Property '" + property + "' Not Found in " + clazz.getName() + ": " + ex);
         }
@@ -232,6 +242,7 @@ public class MappedPropertyTestCase extends TestCase {
     /**
      * Test invalid method name
      */
+    @Test
     public void testNotFound() {
         final String property = "xxxxxxx";
         final Class<?> clazz = MappedPropertyTestBean.class;
@@ -246,13 +257,14 @@ public class MappedPropertyTestCase extends TestCase {
     /**
      * Test property with two primitive args
      */
+    @Test
     public void testPrimitiveArgsProperty() {
         final String property = "mappedPrimitive";
         final Class<?> clazz = MappedPropertyTestBean.class;
         try {
             final MappedPropertyDescriptor desc = new MappedPropertyDescriptor(property, clazz);
-            assertNull("Getter is found", desc.getMappedReadMethod());
-            assertNotNull("Setter is missing", desc.getMappedWriteMethod());
+            assertNull(desc.getMappedReadMethod(), "Getter is found");
+            assertNotNull(desc.getMappedWriteMethod(), "Setter is missing");
         } catch (final Exception ex) {
             fail("Property '" + property + "' Not Found in " + clazz.getName() + ": " + ex);
         }
@@ -261,6 +273,7 @@ public class MappedPropertyTestCase extends TestCase {
     /**
      * Test 'protected' mapped property
      */
+    @Test
     public void testProtected() {
         final String property = "protectedProperty";
         final Class<?> clazz = MappedPropertyTestBean.class;
@@ -275,6 +288,7 @@ public class MappedPropertyTestCase extends TestCase {
     /**
      * Test 'protected' method in parent
      */
+    @Test
     public void testProtectedParentMethod() {
         final String property = "protectedMapped";
         final Class<?> clazz = MappedPropertyChildBean.class;
@@ -288,13 +302,14 @@ public class MappedPropertyTestCase extends TestCase {
     /**
      * Test 'public' method in parent
      */
+    @Test
     public void testPublicParentMethod() {
         final String property = "mapproperty";
         final Class<?> clazz = MappedPropertyChildBean.class;
         try {
             final MappedPropertyDescriptor desc = new MappedPropertyDescriptor(property, clazz);
-            assertNotNull("Getter is missing", desc.getMappedReadMethod());
-            assertNotNull("Setter is missing", desc.getMappedWriteMethod());
+            assertNotNull(desc.getMappedReadMethod(), "Getter is missing");
+            assertNotNull(desc.getMappedWriteMethod(), "Setter is missing");
         } catch (final Exception ex) {
             fail("Property '" + property + "' Not Found in " + clazz.getName() + ": " + ex);
         }

--- a/src/test/java/org/apache/commons/beanutils2/MethodUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/MethodUtilsTestCase.java
@@ -17,54 +17,53 @@
 package org.apache.commons.beanutils2;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.beanutils2.priv.PrivateBeanFactory;
 import org.apache.commons.beanutils2.priv.PublicSubBean;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>
  * Test case for {@code MethodUtils}
  * </p>
  */
-public class MethodUtilsTestCase extends TestCase {
+public class MethodUtilsTestCase {
 
     private static void assertMethod(final Method method, final String methodName) {
         assertNotNull(method);
-        assertEquals("Method is not named correctly", methodName, method.getName());
-        assertTrue("Method is not public", Modifier.isPublic(method.getModifiers()));
+        assertEquals(methodName, method.getName(), "Method is not named correctly");
+        assertTrue(Modifier.isPublic(method.getModifiers()), "Method is not public");
     }
 
-    /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public MethodUtilsTestCase(final String name) {
-        super(name);
-    }
 
     /**
      * Sets up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     public void setUp() {
     }
 
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     public void tearDown() {
     }
 
     /**
      * Test {@link MethodUtils#clearCache()}.
      */
+    @Test
     public void testClearCache() throws Exception {
         MethodUtils.clearCache(); // make sure it starts empty
         final PublicSubBean bean = new PublicSubBean();
@@ -77,6 +76,7 @@ public class MethodUtilsTestCase extends TestCase {
      * <p>
      * Test {@code getAccessibleMethod}.
      */
+    @Test
     public void testGetAccessibleMethod() {
         // easy bit first - find a public method
         final Method method = MethodUtils.getAccessibleMethod(TestBean.class, "setStringProperty", String.class);
@@ -84,6 +84,7 @@ public class MethodUtilsTestCase extends TestCase {
         assertMethod(method, "setStringProperty");
     }
 
+    @Test
     public void testGetAccessibleMethodFromInterface() {
         Method method;
         // trickier this one - find a method in a direct interface
@@ -92,6 +93,7 @@ public class MethodUtilsTestCase extends TestCase {
         assertMethod(method, "methodBar");
     }
 
+    @Test
     public void testGetAccessibleMethodIndirectInterface() {
         Method method;
         // trickier this one - find a method in a indirect interface
@@ -104,60 +106,70 @@ public class MethodUtilsTestCase extends TestCase {
      * <p>
      * Test {@code invokeExactMethod}.
      */
+    @Test
     public void testInvokeExactMethod() throws Exception {
         final TestBean bean = new TestBean();
         final Object ret = MethodUtils.invokeExactMethod(bean, "setStringProperty", "TEST");
 
         assertNull(ret);
-        assertEquals("Method ONE was invoked", "TEST", bean.getStringProperty());
+        assertEquals("TEST", bean.getStringProperty(), "Method ONE was invoked");
     }
 
+    @Test
     public void testInvokeExactMethodFromInterface() throws Exception {
         final Object ret = MethodUtils.invokeExactMethod(PrivateBeanFactory.create(), "methodBar", "ANOTHER TEST");
 
-        assertEquals("Method TWO wasn't invoked correctly", "ANOTHER TEST", ret);
+        assertEquals("ANOTHER TEST", ret, "Method TWO wasn't invoked correctly");
     }
 
+    @Test
     public void testInvokeExactMethodIndirectInterface() throws Exception {
         final Object ret = MethodUtils.invokeExactMethod(PrivateBeanFactory.createSubclass(), "methodBaz", "YET ANOTHER TEST");
 
-        assertEquals("Method TWO was invoked correctly", "YET ANOTHER TEST", ret);
+        assertEquals("YET ANOTHER TEST", ret, "Method TWO was invoked correctly");
     }
 
+    @Test
     public void testInvokeExactMethodNull() throws Exception {
         final Object object = new Object();
         final Object result = MethodUtils.invokeExactMethod(object, "toString", (Object) null);
         assertEquals(object.toString(), result);
     }
 
+    @Test
     public void testInvokeExactMethodNullArray() throws Exception {
         final Object result = MethodUtils.invokeExactMethod(new AlphaBean("parent"), "getName", null);
         assertEquals("parent", result);
     }
 
+    @Test
     public void testInvokeExactMethodNullArrayNullArray() throws Exception {
         final Object result = MethodUtils.invokeExactMethod(new AlphaBean("parent"), "getName", null, null);
 
         assertEquals("parent", result);
     }
 
+    @Test
     public void testInvokeExactStaticMethodNull() throws Exception {
         final int current = TestBean.currentCounter();
         final Object value = MethodUtils.invokeExactStaticMethod(TestBean.class, "currentCounter", (Object) null);
-        assertEquals("currentCounter value", current, ((Integer) value).intValue());
+        assertEquals(current, ((Integer) value).intValue(), "currentCounter value");
     }
 
     /**
      * <p>
      * Test {@code invokeMethod}.
      */
+    @Test
     public void testInvokeMethod() throws Exception {
         final AbstractParent parent = new AlphaBean("parent");
         final BetaBean childOne = new BetaBean("ChildOne");
 
-        assertEquals("Cannot invoke through abstract class (1)", "ChildOne", MethodUtils.invokeMethod(parent, "testAddChild", childOne));
+        assertEquals("ChildOne", MethodUtils.invokeMethod(parent, "testAddChild", childOne),
+                                "Cannot invoke through abstract class (1)");
     }
 
+    @Test
     public void testInvokeMethodArray() throws Exception {
         final AbstractParent parent = new AlphaBean("parent");
         final AlphaBean childTwo = new AlphaBean("ChildTwo");
@@ -166,64 +178,76 @@ public class MethodUtilsTestCase extends TestCase {
         params[0] = "parameter";
         params[1] = childTwo;
 
-        assertEquals("Cannot invoke through abstract class", "ChildTwo", MethodUtils.invokeMethod(parent, "testAddChild2", params));
+        assertEquals("ChildTwo", MethodUtils.invokeMethod(parent, "testAddChild2", params),
+                                "Cannot invoke through abstract class");
     }
 
+    @Test
     public void testInvokeMethodNull() throws Exception {
         final Object object = new Object();
         final Object result = MethodUtils.invokeMethod(object, "toString", (Object) null);
         assertEquals(object.toString(), result);
     }
 
+    @Test
     public void testInvokeMethodNullArray() throws Exception {
         final Object result = MethodUtils.invokeMethod(new AlphaBean("parent"), "getName", null);
 
         assertEquals("parent", result);
     }
 
+    @Test
     public void testInvokeMethodNullArrayNullArray() throws Exception {
         final Object result = MethodUtils.invokeMethod(new AlphaBean("parent"), "getName", null, null);
 
         assertEquals("parent", result);
     }
 
+    @Test
     public void testInvokeMethodObject() throws Exception {
         final AbstractParent parent = new AlphaBean("parent");
         final Child childTwo = new AlphaBean("ChildTwo");
 
-        assertEquals("Cannot invoke through interface (1)", "ChildTwo", MethodUtils.invokeMethod(parent, "testAddChild", childTwo));
+        assertEquals("ChildTwo", MethodUtils.invokeMethod(parent, "testAddChild", childTwo),
+                                "Cannot invoke through interface (1)");
     }
 
+    @Test
     public void testInvokeMethodPrimitiveBoolean() throws Exception {
         final PrimitiveBean bean = new PrimitiveBean();
         MethodUtils.invokeMethod(bean, "setBoolean", Boolean.FALSE);
-        assertEquals("Call boolean property using invokeMethod", false, bean.getBoolean());
+        assertEquals(false, bean.getBoolean(), "Call boolean property using invokeMethod");
     }
 
+    @Test
     public void testInvokeMethodPrimitiveDouble() throws Exception {
         final PrimitiveBean bean = new PrimitiveBean();
         MethodUtils.invokeMethod(bean, "setDouble", Double.valueOf(25.5d));
-        assertEquals("Set double property using invokeMethod", 25.5d, bean.getDouble(), 0.01d);
+        assertEquals(25.5d, bean.getDouble(), 0.01d, "Set double property using invokeMethod");
     }
 
+    @Test
     public void testInvokeMethodPrimitiveFloat() throws Exception {
         final PrimitiveBean bean = new PrimitiveBean();
         MethodUtils.invokeMethod(bean, "setFloat", Float.valueOf(20.0f));
-        assertEquals("Call float property using invokeMethod", 20.0f, bean.getFloat(), 0.01f);
+        assertEquals(20.0f, bean.getFloat(), 0.01f, "Call float property using invokeMethod");
     }
 
+    @Test
     public void testInvokeMethodPrimitiveInt() throws Exception {
         final PrimitiveBean bean = new PrimitiveBean();
         MethodUtils.invokeMethod(bean, "setInt", Integer.valueOf(12));
-        assertEquals("Set int property using invokeMethod", 12, bean.getInt());
+        assertEquals(12, bean.getInt(), "Set int property using invokeMethod");
     }
 
+    @Test
     public void testInvokeMethodPrimitiveLong() throws Exception {
         final PrimitiveBean bean = new PrimitiveBean();
         MethodUtils.invokeMethod(bean, "setLong", Long.valueOf(10));
-        assertEquals("Call long property using invokeMethod", 10, bean.getLong());
+        assertEquals(10, bean.getLong(), "Call long property using invokeMethod");
     }
 
+    @Test
     public void testInvokeMethodUnknown() throws Exception {
         // test that exception is correctly thrown when a method cannot be found with matching params
         try {
@@ -237,12 +261,14 @@ public class MethodUtilsTestCase extends TestCase {
         }
     }
 
+    @Test
     public void testInvokeStaticMethodNull() throws Exception {
         final int current = TestBean.currentCounter();
         final Object value = MethodUtils.invokeStaticMethod(TestBean.class, "currentCounter", (Object) null);
-        assertEquals("currentCounter value", current, ((Integer) value).intValue());
+        assertEquals(current, ((Integer) value).intValue(), "currentCounter value");
     }
 
+    @Test
     public void testNoCaching() throws Exception {
         // no caching
         MethodUtils.setCacheMethods(false);
@@ -255,6 +281,7 @@ public class MethodUtilsTestCase extends TestCase {
         MethodUtils.setCacheMethods(true);
     }
 
+    @Test
     public void testParentMethod() throws Exception {
         final String a = "A";
 
@@ -267,22 +294,23 @@ public class MethodUtilsTestCase extends TestCase {
         });
     }
 
+    @Test
     public void testPublicSub() throws Exception {
         // make sure that bean does what it should
         final PublicSubBean bean = new PublicSubBean();
-        assertEquals("Start value (foo)", bean.getFoo(), "This is foo");
-        assertEquals("Start value (bar)", bean.getBar(), "This is bar");
+        assertEquals(bean.getFoo(), "This is foo", "Start value (foo)");
+        assertEquals(bean.getBar(), "This is bar", "Start value (bar)");
         bean.setFoo("new foo");
         bean.setBar("new bar");
-        assertEquals("Set value (foo)", bean.getFoo(), "new foo");
-        assertEquals("Set value (bar)", bean.getBar(), "new bar");
+        assertEquals(bean.getFoo(), "new foo", "Set value (foo)");
+        assertEquals(bean.getBar(), "new bar", "Set value (bar)");
 
         // see if we can access public methods in a default access superclass
         // from a public access subclass instance
         MethodUtils.invokeMethod(bean, "setFoo", "alpha");
-        assertEquals("Set value (foo:2)", bean.getFoo(), "alpha");
+        assertEquals(bean.getFoo(), "alpha", "Set value (foo:2)");
         MethodUtils.invokeMethod(bean, "setBar", "beta");
-        assertEquals("Set value (bar:2)", bean.getBar(), "beta");
+        assertEquals(bean.getBar(), "beta", "Set value (bar:2)");
 
         Method method = null;
         try {
@@ -290,32 +318,33 @@ public class MethodUtilsTestCase extends TestCase {
         } catch (final Throwable t) {
             fail("getAccessibleMethod() setFoo threw " + t);
         }
-        assertNotNull("getAccessibleMethod() setFoo is Null", method);
+        assertNotNull(method, "getAccessibleMethod() setFoo is Null");
         try {
             method.invoke(bean, "1111");
         } catch (final Throwable t) {
             fail("Invoking setFoo threw " + t);
         }
-        assertEquals("Set value (foo:3)", "1111", bean.getFoo());
+        assertEquals("1111", bean.getFoo(), "Set value (foo:3)");
 
         try {
             method = MethodUtils.getAccessibleMethod(PublicSubBean.class, "setBar", String.class);
         } catch (final Throwable t) {
             fail("getAccessibleMethod() setBar threw " + t);
         }
-        assertNotNull("getAccessibleMethod() setBar is Null", method);
+        assertNotNull(method, "getAccessibleMethod() setBar is Null");
         try {
             method.invoke(bean, "2222");
         } catch (final Throwable t) {
             fail("Invoking setBar threw " + t);
         }
-        assertEquals("Set value (bar:3)", "2222", bean.getBar());
+        assertEquals("2222", bean.getBar(), "Set value (bar:3)");
 
     }
 
     /**
      * Test {@link MethodUtils#setCacheMethods(boolean)}.
      */
+    @Test
     public void testSetCacheMethods() throws Exception {
         MethodUtils.setCacheMethods(true);
         MethodUtils.clearCache(); // make sure it starts empty
@@ -329,6 +358,7 @@ public class MethodUtilsTestCase extends TestCase {
     /**
      * Simple tests for accessing static methods via invokeMethod().
      */
+    @Test
     public void testSimpleStatic1() {
 
         final TestBean bean = new TestBean();
@@ -339,9 +369,9 @@ public class MethodUtilsTestCase extends TestCase {
 
             // Return initial value of the counter
             value = MethodUtils.invokeMethod(bean, "currentCounter", new Object[0], new Class[0]);
-            assertNotNull("currentCounter exists", value);
-            assertTrue("currentCounter type", value instanceof Integer);
-            assertEquals("currentCounter value", current, ((Integer) value).intValue());
+            assertNotNull(value, "currentCounter exists");
+            assertTrue(value instanceof Integer, "currentCounter type");
+            assertEquals(current, ((Integer) value).intValue(), "currentCounter value");
 
             // Increment via no-arguments version
             MethodUtils.invokeMethod(bean, "incrementCounter", new Object[0], new Class[0]);
@@ -349,9 +379,9 @@ public class MethodUtilsTestCase extends TestCase {
             // Validate updated value
             current++;
             value = MethodUtils.invokeMethod(bean, "currentCounter", new Object[0], new Class[0]);
-            assertNotNull("currentCounter exists", value);
-            assertTrue("currentCounter type", value instanceof Integer);
-            assertEquals("currentCounter value", current, ((Integer) value).intValue());
+            assertNotNull(value, "currentCounter exists");
+            assertTrue(value instanceof Integer, "currentCounter type");
+            assertEquals(current, ((Integer) value).intValue(), "currentCounter value");
 
             // Increment via specified-argument version
             MethodUtils.invokeMethod(bean, "incrementCounter", new Object[] { Integer.valueOf(5) }, new Class[] { Integer.TYPE });
@@ -359,9 +389,9 @@ public class MethodUtilsTestCase extends TestCase {
             // Validate updated value
             current += 5;
             value = MethodUtils.invokeMethod(bean, "currentCounter", new Object[0], new Class[0]);
-            assertNotNull("currentCounter exists", value);
-            assertTrue("currentCounter type", value instanceof Integer);
-            assertEquals("currentCounter value", current, ((Integer) value).intValue());
+            assertNotNull(value, "currentCounter exists");
+            assertTrue(value instanceof Integer, "currentCounter type");
+            assertEquals(current, ((Integer) value).intValue(), "currentCounter value");
 
         } catch (final Exception e) {
             fail("Threw exception" + e);
@@ -372,6 +402,7 @@ public class MethodUtilsTestCase extends TestCase {
     /**
      * Simple tests for accessing static methods via invokeExactMethod().
      */
+    @Test
     public void testSimpleStatic2() {
 
         final TestBean bean = new TestBean();
@@ -382,9 +413,9 @@ public class MethodUtilsTestCase extends TestCase {
 
             // Return initial value of the counter
             value = MethodUtils.invokeExactMethod(bean, "currentCounter", new Object[0], new Class[0]);
-            assertNotNull("currentCounter exists", value);
-            assertTrue("currentCounter type", value instanceof Integer);
-            assertEquals("currentCounter value", current, ((Integer) value).intValue());
+            assertNotNull(value, "currentCounter exists");
+            assertTrue(value instanceof Integer, "currentCounter type");
+            assertEquals(current, ((Integer) value).intValue(), "currentCounter value");
 
             // Increment via no-arguments version
             MethodUtils.invokeExactMethod(bean, "incrementCounter", new Object[0], new Class[0]);
@@ -392,9 +423,9 @@ public class MethodUtilsTestCase extends TestCase {
             // Validate updated value
             current++;
             value = MethodUtils.invokeExactMethod(bean, "currentCounter", new Object[0], new Class[0]);
-            assertNotNull("currentCounter exists", value);
-            assertTrue("currentCounter type", value instanceof Integer);
-            assertEquals("currentCounter value", current, ((Integer) value).intValue());
+            assertNotNull(value, "currentCounter exists");
+            assertTrue(value instanceof Integer, "currentCounter type");
+            assertEquals(current, ((Integer) value).intValue(), "currentCounter value");
 
             // Increment via specified-argument version
             MethodUtils.invokeExactMethod(bean, "incrementCounter", new Object[] { Integer.valueOf(5) }, new Class[] { Integer.TYPE });
@@ -402,9 +433,9 @@ public class MethodUtilsTestCase extends TestCase {
             // Validate updated value
             current += 5;
             value = MethodUtils.invokeExactMethod(bean, "currentCounter", new Object[0], new Class[0]);
-            assertNotNull("currentCounter exists", value);
-            assertTrue("currentCounter type", value instanceof Integer);
-            assertEquals("currentCounter value", current, ((Integer) value).intValue());
+            assertNotNull(value, "currentCounter exists");
+            assertTrue(value instanceof Integer, "currentCounter type");
+            assertEquals(current, ((Integer) value).intValue(), "currentCounter value");
 
         } catch (final Exception e) {
             fail("Threw exception" + e);
@@ -415,6 +446,7 @@ public class MethodUtilsTestCase extends TestCase {
     /**
      * Simple tests for accessing static methods via getAccessibleMethod()
      */
+    @Test
     public void testSimpleStatic3() {
 
         Object value = null;
@@ -424,29 +456,39 @@ public class MethodUtilsTestCase extends TestCase {
 
             // Acquire the methods we need
             final Method currentCounterMethod = MethodUtils.getAccessibleMethod(TestBean.class, "currentCounter", new Class[0]);
-            assertNotNull("currentCounterMethod exists", currentCounterMethod);
-            assertEquals("currentCounterMethod name", "currentCounter", currentCounterMethod.getName());
-            assertEquals("currentCounterMethod args", 0, currentCounterMethod.getParameterTypes().length);
-            assertTrue("currentCounterMethod public", Modifier.isPublic(currentCounterMethod.getModifiers()));
-            assertTrue("currentCounterMethod static", Modifier.isStatic(currentCounterMethod.getModifiers()));
+            assertNotNull(currentCounterMethod, "currentCounterMethod exists");
+            assertEquals("currentCounter", currentCounterMethod.getName(), "currentCounterMethod name");
+            assertEquals(0, currentCounterMethod.getParameterTypes().length, "currentCounterMethod args");
+            assertTrue(Modifier.isPublic(currentCounterMethod.getModifiers()),
+                                  "currentCounterMethod public");
+            assertTrue(Modifier.isStatic(currentCounterMethod.getModifiers()),
+                                  "currentCounterMethod static");
             final Method incrementCounterMethod1 = MethodUtils.getAccessibleMethod(TestBean.class, "incrementCounter", new Class[0]);
-            assertNotNull("incrementCounterMethod1 exists", incrementCounterMethod1);
-            assertEquals("incrementCounterMethod1 name", "incrementCounter", incrementCounterMethod1.getName());
-            assertEquals("incrementCounterMethod1 args", 0, incrementCounterMethod1.getParameterTypes().length);
-            assertTrue("incrementCounterMethod1 public", Modifier.isPublic(incrementCounterMethod1.getModifiers()));
-            assertTrue("incrementCounterMethod1 static", Modifier.isStatic(incrementCounterMethod1.getModifiers()));
+            assertNotNull(incrementCounterMethod1, "incrementCounterMethod1 exists");
+            assertEquals("incrementCounter", incrementCounterMethod1.getName(),
+                                    "incrementCounterMethod1 name");
+            assertEquals(0, incrementCounterMethod1.getParameterTypes().length,
+                                    "incrementCounterMethod1 args");
+            assertTrue(Modifier.isPublic(incrementCounterMethod1.getModifiers()),
+                                  "incrementCounterMethod1 public");
+            assertTrue(Modifier.isStatic(incrementCounterMethod1.getModifiers()),
+                                  "incrementCounterMethod1 static");
             final Method incrementCounterMethod2 = MethodUtils.getAccessibleMethod(TestBean.class, "incrementCounter", new Class[] { Integer.TYPE });
-            assertNotNull("incrementCounterMethod2 exists", incrementCounterMethod2);
-            assertEquals("incrementCounterMethod2 name", "incrementCounter", incrementCounterMethod2.getName());
-            assertEquals("incrementCounterMethod2 args", 1, incrementCounterMethod2.getParameterTypes().length);
-            assertTrue("incrementCounterMethod2 public", Modifier.isPublic(incrementCounterMethod2.getModifiers()));
-            assertTrue("incrementCounterMethod2 static", Modifier.isStatic(incrementCounterMethod2.getModifiers()));
+            assertNotNull(incrementCounterMethod2, "incrementCounterMethod2 exists");
+            assertEquals("incrementCounter", incrementCounterMethod2.getName(),
+                                    "incrementCounterMethod2 name");
+            assertEquals(1, incrementCounterMethod2.getParameterTypes().length,
+                                    "incrementCounterMethod2 args");
+            assertTrue(Modifier.isPublic(incrementCounterMethod2.getModifiers()),
+                                  "incrementCounterMethod2 public");
+            assertTrue(Modifier.isStatic(incrementCounterMethod2.getModifiers()),
+                                  "incrementCounterMethod2 static");
 
             // Return initial value of the counter
             value = currentCounterMethod.invoke(null);
-            assertNotNull("currentCounter exists", value);
-            assertTrue("currentCounter type", value instanceof Integer);
-            assertEquals("currentCounter value", current, ((Integer) value).intValue());
+            assertNotNull(value, "currentCounter exists");
+            assertTrue(value instanceof Integer, "currentCounter type");
+            assertEquals(current, ((Integer) value).intValue(), "currentCounter value");
 
             // Increment via no-arguments version
             incrementCounterMethod1.invoke(null);
@@ -454,9 +496,9 @@ public class MethodUtilsTestCase extends TestCase {
             // Validate updated value
             current++;
             value = currentCounterMethod.invoke(null);
-            assertNotNull("currentCounter exists", value);
-            assertTrue("currentCounter type", value instanceof Integer);
-            assertEquals("currentCounter value", current, ((Integer) value).intValue());
+            assertNotNull(value, "currentCounter exists");
+            assertTrue(value instanceof Integer, "currentCounter type");
+            assertEquals(current, ((Integer) value).intValue(), "currentCounter value");
 
             // Increment via specified-argument version
             incrementCounterMethod2.invoke(null, Integer.valueOf(5));
@@ -464,9 +506,9 @@ public class MethodUtilsTestCase extends TestCase {
             // Validate updated value
             current += 5;
             value = currentCounterMethod.invoke(null);
-            assertNotNull("currentCounter exists", value);
-            assertTrue("currentCounter type", value instanceof Integer);
-            assertEquals("currentCounter value", current, ((Integer) value).intValue());
+            assertNotNull(value, "currentCounter exists");
+            assertTrue(value instanceof Integer, "currentCounter type");
+            assertEquals(current, ((Integer) value).intValue(), "currentCounter value");
 
         } catch (final Exception e) {
             fail("Threw exception" + e);
@@ -474,30 +516,31 @@ public class MethodUtilsTestCase extends TestCase {
 
     }
 
+    @Test
     public void testStaticInvokeMethod() throws Exception {
 
         Object value;
         int current = TestBean.currentCounter();
 
         value = MethodUtils.invokeStaticMethod(TestBean.class, "currentCounter", new Object[0]);
-        assertEquals("currentCounter value", current, ((Integer) value).intValue());
+        assertEquals(current, ((Integer) value).intValue(), "currentCounter value");
 
         MethodUtils.invokeStaticMethod(TestBean.class, "incrementCounter", new Object[0]);
         current++;
 
         value = MethodUtils.invokeStaticMethod(TestBean.class, "currentCounter", new Object[0]);
-        assertEquals("currentCounter value", current, ((Integer) value).intValue());
+        assertEquals(current, ((Integer) value).intValue(), "currentCounter value");
 
         MethodUtils.invokeStaticMethod(TestBean.class, "incrementCounter", new Object[] { Integer.valueOf(8) });
         current += 8;
 
         value = MethodUtils.invokeStaticMethod(TestBean.class, "currentCounter", new Object[0]);
-        assertEquals("currentCounter value", current, ((Integer) value).intValue());
+        assertEquals(current, ((Integer) value).intValue(), "currentCounter value");
 
         MethodUtils.invokeExactStaticMethod(TestBean.class, "incrementCounter", new Object[] { Integer.valueOf(8) }, new Class[] { Number.class });
         current += 16;
 
         value = MethodUtils.invokeStaticMethod(TestBean.class, "currentCounter", new Object[0]);
-        assertEquals("currentCounter value", current, ((Integer) value).intValue());
+        assertEquals(current, ((Integer) value).intValue(), "currentCounter value");
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/PropertyUtilsBenchCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/PropertyUtilsBenchCase.java
@@ -20,13 +20,14 @@ package org.apache.commons.beanutils2;
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit Test Case containing microbenchmarks for PropertyUtils.
  */
-
-public class PropertyUtilsBenchCase extends TestCase {
+public class PropertyUtilsBenchCase {
 
     // Basic loop counter
     private long counter = 100000;
@@ -47,20 +48,9 @@ public class PropertyUtilsBenchCase extends TestCase {
     private PropertyUtilsBean pu;
 
     /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public PropertyUtilsBenchCase(final String name) {
-
-        super(name);
-
-    }
-
-    /**
      * Sets up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
 
         // Set up loop counter (if property specified)
@@ -108,7 +98,7 @@ public class PropertyUtilsBenchCase extends TestCase {
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     public void tearDown() {
 
         dynaClass = null;
@@ -122,6 +112,7 @@ public class PropertyUtilsBenchCase extends TestCase {
     }
 
     // Time copyProperties() from a bean
+    @Test
     public void testCopyPropertiesBean() throws Exception {
 
         long startMillis;
@@ -152,6 +143,7 @@ public class PropertyUtilsBenchCase extends TestCase {
     }
 
     // Time copyProperties() from a DynaBean
+    @Test
     public void testCopyPropertiesDyna() throws Exception {
 
         long startMillis;
@@ -182,6 +174,7 @@ public class PropertyUtilsBenchCase extends TestCase {
     }
 
     // Time copyProperties() from a Map
+    @Test
     public void testCopyPropertiesMap() throws Exception {
 
         long startMillis;

--- a/src/test/java/org/apache/commons/beanutils2/PropertyUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/PropertyUtilsTestCase.java
@@ -17,7 +17,13 @@
 
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
@@ -31,11 +37,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.beanutils2.priv.PrivateBeanFactory;
 import org.apache.commons.beanutils2.priv.PrivateDirect;
 import org.apache.commons.beanutils2.priv.PublicSubBean;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>
@@ -64,8 +71,7 @@ import org.apache.commons.beanutils2.priv.PublicSubBean;
  * <li>setSimpleProperty(Object,String,Object)</li>
  * </ul>
  */
-
-public class PropertyUtilsTestCase extends TestCase {
+public class PropertyUtilsTestCase {
 
     /**
      * The fully qualified class name of our private directly implemented interface.
@@ -146,17 +152,6 @@ public class PropertyUtilsTestCase extends TestCase {
             "stringProperty" };
 
     /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public PropertyUtilsTestCase(final String name) {
-
-        super(name);
-
-    }
-
-    /**
      * Returns a single string containing all the keys in the map, sorted in alphabetical order and separated by ", ".
      * <p>
      * If there are no keys, an empty string is returned.
@@ -177,7 +172,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Sets up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     public void setUp() {
 
         bean = new TestBean();
@@ -198,7 +193,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     public void tearDown() {
 
         bean = null;
@@ -213,6 +208,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Tries to add a null BeanIntrospector.
      */
+    @Test
     public void testAddBeanIntrospectorNull() {
         assertThrows(NullPointerException.class, () -> PropertyUtils.addBeanIntrospector(null));
     }
@@ -220,6 +216,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test copyProperties() when the origin is a {@code Map}.
      */
+    @Test
     public void testCopyPropertiesMap() {
 
         final Map<String, Object> map = new HashMap<>();
@@ -240,37 +237,38 @@ public class PropertyUtilsTestCase extends TestCase {
         }
 
         // Scalar properties
-        assertEquals("booleanProperty", false, bean.getBooleanProperty());
-        assertEquals("doubleProperty", 333.0, bean.getDoubleProperty(), 0.005);
-        assertEquals("floatProperty", (float) 222.0, bean.getFloatProperty(), (float) 0.005);
-        assertEquals("intProperty", 111, bean.getIntProperty());
-        assertEquals("longProperty", 444, bean.getLongProperty());
-        assertEquals("shortProperty", (short) 555, bean.getShortProperty());
-        assertEquals("stringProperty", "New String Property", bean.getStringProperty());
+        assertEquals(false, bean.getBooleanProperty(), "booleanProperty");
+        assertEquals(333.0, bean.getDoubleProperty(), 0.005, "doubleProperty");
+        assertEquals((float) 222.0, bean.getFloatProperty(), (float) 0.005, "floatProperty");
+        assertEquals(111, bean.getIntProperty(), "intProperty");
+        assertEquals(444, bean.getLongProperty(), "longProperty");
+        assertEquals((short) 555, bean.getShortProperty(), "shortProperty");
+        assertEquals("New String Property", bean.getStringProperty(), "stringProperty");
 
         // Indexed Properties
         final String[] dupProperty = bean.getDupProperty();
-        assertNotNull("dupProperty present", dupProperty);
-        assertEquals("dupProperty length", 3, dupProperty.length);
-        assertEquals("dupProperty[0]", "New 0", dupProperty[0]);
-        assertEquals("dupProperty[1]", "New 1", dupProperty[1]);
-        assertEquals("dupProperty[2]", "New 2", dupProperty[2]);
+        assertNotNull(dupProperty, "dupProperty present");
+        assertEquals(3, dupProperty.length, "dupProperty length");
+        assertEquals("New 0", dupProperty[0], "dupProperty[0]");
+        assertEquals("New 1", dupProperty[1], "dupProperty[1]");
+        assertEquals("New 2", dupProperty[2], "dupProperty[2]");
         final int[] intArray = bean.getIntArray();
-        assertNotNull("intArray present", intArray);
-        assertEquals("intArray length", 3, intArray.length);
-        assertEquals("intArray[0]", 0, intArray[0]);
-        assertEquals("intArray[1]", 100, intArray[1]);
-        assertEquals("intArray[2]", 200, intArray[2]);
+        assertNotNull(intArray, "intArray present");
+        assertEquals(3, intArray.length, "intArray length");
+        assertEquals(0, intArray[0], "intArray[0]");
+        assertEquals(100, intArray[1], "intArray[1]");
+        assertEquals(200, intArray[2], "intArray[2]");
 
     }
 
     /**
      * Tests whether the default introspection mechanism can be replaced by a custom BeanIntrospector.
      */
+    @Test
     public void testCustomIntrospection() {
         final PropertyDescriptor[] desc1 = PropertyUtils.getPropertyDescriptors(AlphaBean.class);
         PropertyDescriptor nameDescriptor = findNameDescriptor(desc1);
-        assertNotNull("No write method", nameDescriptor.getWriteMethod());
+        assertNotNull(nameDescriptor.getWriteMethod(), "No write method");
 
         final BeanIntrospector bi = icontext -> {
             final Set<String> names = icontext.propertyNames();
@@ -286,15 +284,16 @@ public class PropertyUtilsTestCase extends TestCase {
         PropertyUtils.clearDescriptors();
         PropertyUtils.addBeanIntrospector(bi);
         final PropertyDescriptor[] desc2 = PropertyUtils.getPropertyDescriptors(AlphaBean.class);
-        assertEquals("Different number of properties", desc1.length, desc2.length);
+        assertEquals(desc1.length, desc2.length, "Different number of properties");
         nameDescriptor = findNameDescriptor(desc2);
-        assertNull("Got a write method", nameDescriptor.getWriteMethod());
+        assertNull(nameDescriptor.getWriteMethod(), "Got a write method");
         PropertyUtils.removeBeanIntrospector(bi);
     }
 
     /**
      * Tests whether exceptions during custom introspection are handled.
      */
+    @Test
     public void testCustomIntrospectionEx() {
         final BeanIntrospector bi = icontext -> {
             throw new IntrospectionException("TestException");
@@ -302,13 +301,14 @@ public class PropertyUtilsTestCase extends TestCase {
         PropertyUtils.clearDescriptors();
         PropertyUtils.addBeanIntrospector(bi);
         final PropertyDescriptor[] desc = PropertyUtils.getPropertyDescriptors(AlphaBean.class);
-        assertNotNull("Introspection did not work", findNameDescriptor(desc));
+        assertNotNull(findNameDescriptor(desc), "Introspection did not work");
         PropertyUtils.removeBeanIntrospector(bi);
     }
 
     /**
      * Test the describe() method.
      */
+    @Test
     public void testDescribe() {
 
         Map<String, Object> map = null;
@@ -320,18 +320,18 @@ public class PropertyUtilsTestCase extends TestCase {
 
         // Verify existence of all the properties that should be present
         for (final String describe : describes) {
-            assertTrue("Property '" + describe + "' is present", map.containsKey(describe));
+            assertTrue(map.containsKey(describe), "Property '" + describe + "' is present");
         }
-        assertTrue("Property 'writeOnlyProperty' is not present", !map.containsKey("writeOnlyProperty"));
+        assertFalse(map.containsKey("writeOnlyProperty"), "Property 'writeOnlyProperty' is not present");
 
         // Verify the values of scalar properties
-        assertEquals("Value of 'booleanProperty'", Boolean.TRUE, map.get("booleanProperty"));
-        assertEquals("Value of 'doubleProperty'", Double.valueOf(321.0), map.get("doubleProperty"));
-        assertEquals("Value of 'floatProperty'", Float.valueOf((float) 123.0), map.get("floatProperty"));
-        assertEquals("Value of 'intProperty'", Integer.valueOf(123), map.get("intProperty"));
-        assertEquals("Value of 'longProperty'", Long.valueOf(321), map.get("longProperty"));
-        assertEquals("Value of 'shortProperty'", Short.valueOf((short) 987), map.get("shortProperty"));
-        assertEquals("Value of 'stringProperty'", "This is a string", (String) map.get("stringProperty"));
+        assertEquals(Boolean.TRUE, map.get("booleanProperty"), "Value of 'booleanProperty'");
+        assertEquals(Double.valueOf(321.0), map.get("doubleProperty"), "Value of 'doubleProperty'");
+        assertEquals(Float.valueOf((float) 123.0), map.get("floatProperty"), "Value of 'floatProperty'");
+        assertEquals(Integer.valueOf(123), map.get("intProperty"), "Value of 'intProperty'");
+        assertEquals(Long.valueOf(321), map.get("longProperty"), "Value of 'longProperty'");
+        assertEquals(Short.valueOf((short) 987), map.get("shortProperty"), "Value of 'shortProperty'");
+        assertEquals("This is a string", (String) map.get("stringProperty"), "Value of 'stringProperty'");
 
     }
 
@@ -339,13 +339,15 @@ public class PropertyUtilsTestCase extends TestCase {
      * Test {@link PropertyUtilsBean}'s invoke method throwing an IllegalArgumentException and check that the "cause" has been properly initialized for JDK 1.4+
      * See BEANUTILS-266 for changes and reason for test
      */
+    @Test
     public void testExceptionFromInvoke() throws Exception {
         try {
             PropertyUtils.setSimpleProperty(bean, "intProperty", "XXX");
         } catch (final IllegalArgumentException t) {
             final Throwable cause = (Throwable) PropertyUtils.getProperty(t, "cause");
-            assertNotNull("Cause not found", cause);
-            assertTrue("Expected cause to be IllegalArgumentException, but was: " + cause.getClass(), cause instanceof IllegalArgumentException);
+            assertNotNull(cause, "Cause not found");
+            assertTrue(cause instanceof IllegalArgumentException,
+                                  "Expected cause to be IllegalArgumentException, but was: " + cause.getClass());
             // JDK 1.6 doesn't have "argument type mismatch" message
             // assertEquals("Check error message", "argument type mismatch", cause.getMessage());
         } catch (final Throwable t) {
@@ -356,6 +358,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Corner cases on getPropertyDescriptor invalid arguments.
      */
+    @Test
     public void testGetDescriptorArguments() {
         assertThrows(NullPointerException.class, () -> PropertyUtils.getPropertyDescriptor(null, "stringProperty"));
         assertThrows(NullPointerException.class, () -> PropertyUtils.getPropertyDescriptor(bean, null));
@@ -368,28 +371,28 @@ public class PropertyUtilsTestCase extends TestCase {
      * @param read  Expected name of the read method (or null)
      * @param write Expected name of the write method (or null)
      */
-    protected void testGetDescriptorBase(final String name, final String read, final String write) {
+    private void testGetDescriptorBase(final String name, final String read, final String write) {
 
         try {
             final PropertyDescriptor pd = PropertyUtils.getPropertyDescriptor(bean, name);
             if (read == null && write == null) {
-                assertNull("Got descriptor", pd);
+                assertNull(pd, "Got descriptor");
                 return;
             }
-            assertNotNull("Got descriptor", pd);
+            assertNotNull(pd, "Got descriptor");
             final Method rm = pd.getReadMethod();
             if (read != null) {
-                assertNotNull("Got read method", rm);
-                assertEquals("Got correct read method", rm.getName(), read);
+                assertNotNull(rm, "Got read method");
+                assertEquals(rm.getName(), read, "Got correct read method");
             } else {
-                assertNull("Got read method", rm);
+                assertNull(rm, "Got read method");
             }
             final Method wm = pd.getWriteMethod();
             if (write != null) {
-                assertNotNull("Got write method", wm);
-                assertEquals("Got correct write method", wm.getName(), write);
+                assertNotNull(wm, "Got write method");
+                assertEquals(wm.getName(), write, "Got correct write method");
             } else {
-                assertNull("Got write method", wm);
+                assertNull(wm, "Got write method");
             }
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
@@ -404,6 +407,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Positive getPropertyDescriptor on property {@code booleanProperty}.
      */
+    @Test
     public void testGetDescriptorBoolean() {
 
         testGetDescriptorBase("booleanProperty", "getBooleanProperty", "setBooleanProperty");
@@ -413,6 +417,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Positive getPropertyDescriptor on property {@code doubleProperty}.
      */
+    @Test
     public void testGetDescriptorDouble() {
 
         testGetDescriptorBase("doubleProperty", "getDoubleProperty", "setDoubleProperty");
@@ -422,6 +427,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Positive getPropertyDescriptor on property {@code floatProperty}.
      */
+    @Test
     public void testGetDescriptorFloat() {
 
         testGetDescriptorBase("floatProperty", "getFloatProperty", "setFloatProperty");
@@ -431,6 +437,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Positive getPropertyDescriptor on property {@code intProperty}.
      */
+    @Test
     public void testGetDescriptorInt() {
 
         testGetDescriptorBase("intProperty", "getIntProperty", "setIntProperty");
@@ -449,19 +456,21 @@ public class PropertyUtilsTestCase extends TestCase {
      * write-only property called <em>&lt;property-name&gt;</em>.
      * </p>
      */
+    @Test
     public void testGetDescriptorInvalidBoolean() throws Exception {
 
         final PropertyDescriptor pd = PropertyUtils.getPropertyDescriptor(bean, "invalidBoolean");
-        assertNotNull("invalidBoolean is a property", pd);
-        assertNotNull("invalidBoolean has a getter method", pd.getReadMethod());
-        assertNull("invalidBoolean has no write method", pd.getWriteMethod());
-        assertTrue("invalidBoolean getter method is isInvalidBoolean or getInvalidBoolean",
-                Arrays.asList("isInvalidBoolean", "getInvalidBoolean").contains(pd.getReadMethod().getName()));
+        assertNotNull(pd, "invalidBoolean is a property");
+        assertNotNull(pd.getReadMethod(), "invalidBoolean has a getter method");
+        assertNull(pd.getWriteMethod(), "invalidBoolean has no write method");
+        assertTrue(Arrays.asList("isInvalidBoolean", "getInvalidBoolean").contains(pd.getReadMethod().getName()),
+                              "invalidBoolean getter method is isInvalidBoolean or getInvalidBoolean");
     }
 
     /**
      * Positive getPropertyDescriptor on property {@code longProperty}.
      */
+    @Test
     public void testGetDescriptorLong() {
 
         testGetDescriptorBase("longProperty", "getLongProperty", "setLongProperty");
@@ -471,6 +480,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getting mapped descriptor with periods in the key.
      */
+    @Test
     public void testGetDescriptorMappedPeriods() {
 
         bean.getMappedIntProperty("xyz"); // initializes mappedIntProperty
@@ -479,19 +489,23 @@ public class PropertyUtilsTestCase extends TestCase {
         final Integer testIntegerValue = Integer.valueOf(1234);
 
         bean.setMappedIntProperty("key.with.a.dot", testIntegerValue.intValue());
-        assertEquals("Can retrieve directly", testIntegerValue, Integer.valueOf(bean.getMappedIntProperty("key.with.a.dot")));
+        assertEquals(testIntegerValue, Integer.valueOf(bean.getMappedIntProperty("key.with.a.dot")),
+                                "Can retrieve directly");
         try {
             desc = PropertyUtils.getPropertyDescriptor(bean, "mappedIntProperty(key.with.a.dot)");
-            assertEquals("Check descriptor type (A)", Integer.TYPE, ((MappedPropertyDescriptor) desc).getMappedPropertyType());
+            assertEquals(Integer.TYPE, ((MappedPropertyDescriptor) desc).getMappedPropertyType(),
+                                    "Check descriptor type (A)");
         } catch (final Exception e) {
             fail("Threw exception (A): " + e);
         }
 
         bean.setMappedObjects("nested.property", new TestBean(testIntegerValue.intValue()));
-        assertEquals("Can retrieve directly", testIntegerValue, Integer.valueOf(((TestBean) bean.getMappedObjects("nested.property")).getIntProperty()));
+        assertEquals(testIntegerValue,
+                                Integer.valueOf(((TestBean) bean.getMappedObjects("nested.property")).getIntProperty()),
+                                "Can retrieve directly");
         try {
             desc = PropertyUtils.getPropertyDescriptor(bean, "mappedObjects(nested.property).intProperty");
-            assertEquals("Check descriptor type (B)", Integer.TYPE, desc.getPropertyType());
+            assertEquals(Integer.TYPE, desc.getPropertyType(), "Check descriptor type (B)");
         } catch (final Exception e) {
             fail("Threw exception (B): " + e);
         }
@@ -500,6 +514,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Positive getPropertyDescriptor on property {@code readOnlyProperty}.
      */
+    @Test
     public void testGetDescriptorReadOnly() {
 
         testGetDescriptorBase("readOnlyProperty", "getReadOnlyProperty", null);
@@ -509,10 +524,11 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Positive test for getPropertyDescriptors(). Each property name listed in {@code properties} should be returned exactly once.
      */
+    @Test
     public void testGetDescriptors() {
 
         final PropertyDescriptor[] pd = PropertyUtils.getPropertyDescriptors(bean);
-        assertNotNull("Got descriptors", pd);
+        assertNotNull(pd, "Got descriptors");
         final int[] count = new int[properties.length];
         for (final PropertyDescriptor element : pd) {
             final String name = element.getName();
@@ -535,6 +551,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Corner cases on getPropertyDescriptors invalid arguments.
      */
+    @Test
     public void testGetDescriptorsArguments() {
         assertThrows(NullPointerException.class, () -> PropertyUtils.getPropertyDescriptors(null));
     }
@@ -542,6 +559,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Positive getPropertyDescriptor on property {@code booleanSecond} that uses an "is" method as the getter.
      */
+    @Test
     public void testGetDescriptorSecond() {
         testGetDescriptorBase("booleanSecond", "isBooleanSecond", "setBooleanSecond");
     }
@@ -549,6 +567,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Positive getPropertyDescriptor on property {@code shortProperty}.
      */
+    @Test
     public void testGetDescriptorShort() {
         testGetDescriptorBase("shortProperty", "getShortProperty", "setShortProperty");
     }
@@ -556,6 +575,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Positive getPropertyDescriptor on property {@code stringProperty}.
      */
+    @Test
     public void testGetDescriptorString() {
         testGetDescriptorBase("stringProperty", "getStringProperty", "setStringProperty");
     }
@@ -563,6 +583,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Negative getPropertyDescriptor on property {@code unknown}.
      */
+    @Test
     public void testGetDescriptorUnknown() {
         testGetDescriptorBase("unknown", null, null);
     }
@@ -570,6 +591,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Positive getPropertyDescriptor on property {@code writeOnlyProperty}.
      */
+    @Test
     public void testGetDescriptorWriteOnly() {
         testGetDescriptorBase("writeOnlyProperty", null, "setWriteOnlyProperty");
     }
@@ -577,6 +599,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Corner cases on getIndexedProperty invalid arguments.
      */
+    @Test
     public void testGetIndexedArguments() {
         // Use explicit index argument
         assertThrows(NullPointerException.class, () -> PropertyUtils.getIndexedProperty(null, "intArray", 0));
@@ -597,19 +620,27 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getting an indexed value out of a multi-dimensional array
      */
+    @Test
     public void testGetIndexedArray() {
         final String[] firstArray = { "FIRST-1", "FIRST-2", "FIRST-3" };
         final String[] secondArray = { "SECOND-1", "SECOND-2", "SECOND-3", "SECOND-4" };
         final String[][] mainArray = { firstArray, secondArray };
         final TestBean bean = new TestBean(mainArray);
         try {
-            assertEquals("firstArray[0]", firstArray[0], PropertyUtils.getProperty(bean, "string2dArray[0][0]"));
-            assertEquals("firstArray[1]", firstArray[1], PropertyUtils.getProperty(bean, "string2dArray[0][1]"));
-            assertEquals("firstArray[2]", firstArray[2], PropertyUtils.getProperty(bean, "string2dArray[0][2]"));
-            assertEquals("secondArray[0]", secondArray[0], PropertyUtils.getProperty(bean, "string2dArray[1][0]"));
-            assertEquals("secondArray[1]", secondArray[1], PropertyUtils.getProperty(bean, "string2dArray[1][1]"));
-            assertEquals("secondArray[2]", secondArray[2], PropertyUtils.getProperty(bean, "string2dArray[1][2]"));
-            assertEquals("secondArray[3]", secondArray[3], PropertyUtils.getProperty(bean, "string2dArray[1][3]"));
+            assertEquals(firstArray[0], PropertyUtils.getProperty(bean, "string2dArray[0][0]"),
+                                    "firstArray[0]");
+            assertEquals(firstArray[1], PropertyUtils.getProperty(bean, "string2dArray[0][1]"),
+                                    "firstArray[1]");
+            assertEquals(firstArray[2], PropertyUtils.getProperty(bean, "string2dArray[0][2]"),
+                                    "firstArray[2]");
+            assertEquals(secondArray[0], PropertyUtils.getProperty(bean, "string2dArray[1][0]"),
+                                    "secondArray[0]");
+            assertEquals(secondArray[1], PropertyUtils.getProperty(bean, "string2dArray[1][1]"),
+                                    "secondArray[1]");
+            assertEquals(secondArray[2], PropertyUtils.getProperty(bean, "string2dArray[1][2]"),
+                                    "secondArray[2]");
+            assertEquals(secondArray[3], PropertyUtils.getProperty(bean, "string2dArray[1][3]"),
+                                    "secondArray[3]");
         } catch (final Throwable t) {
             fail("Threw " + t + "");
         }
@@ -618,6 +649,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getting an indexed value out of List of Lists
      */
+    @Test
     public void testGetIndexedList() {
         final String[] firstArray = { "FIRST-1", "FIRST-2", "FIRST-3" };
         final String[] secondArray = { "SECOND-1", "SECOND-2", "SECOND-3", "SECOND-4" };
@@ -626,13 +658,20 @@ public class PropertyUtilsTestCase extends TestCase {
         mainList.add(Arrays.asList(secondArray));
         final TestBean bean = new TestBean(mainList);
         try {
-            assertEquals("firstArray[0]", firstArray[0], PropertyUtils.getProperty(bean, "listIndexed[0][0]"));
-            assertEquals("firstArray[1]", firstArray[1], PropertyUtils.getProperty(bean, "listIndexed[0][1]"));
-            assertEquals("firstArray[2]", firstArray[2], PropertyUtils.getProperty(bean, "listIndexed[0][2]"));
-            assertEquals("secondArray[0]", secondArray[0], PropertyUtils.getProperty(bean, "listIndexed[1][0]"));
-            assertEquals("secondArray[1]", secondArray[1], PropertyUtils.getProperty(bean, "listIndexed[1][1]"));
-            assertEquals("secondArray[2]", secondArray[2], PropertyUtils.getProperty(bean, "listIndexed[1][2]"));
-            assertEquals("secondArray[3]", secondArray[3], PropertyUtils.getProperty(bean, "listIndexed[1][3]"));
+            assertEquals(firstArray[0], PropertyUtils.getProperty(bean, "listIndexed[0][0]"),
+                                    "firstArray[0]");
+            assertEquals(firstArray[1], PropertyUtils.getProperty(bean, "listIndexed[0][1]"),
+                                    "firstArray[1]");
+            assertEquals(firstArray[2], PropertyUtils.getProperty(bean, "listIndexed[0][2]"),
+                                    "firstArray[2]");
+            assertEquals(secondArray[0], PropertyUtils.getProperty(bean, "listIndexed[1][0]"),
+                                    "secondArray[0]");
+            assertEquals(secondArray[1], PropertyUtils.getProperty(bean, "listIndexed[1][1]"),
+                                    "secondArray[1]");
+            assertEquals(secondArray[2], PropertyUtils.getProperty(bean, "listIndexed[1][2]"),
+                                    "secondArray[2]");
+            assertEquals(secondArray[3], PropertyUtils.getProperty(bean, "listIndexed[1][3]"),
+                                    "secondArray[3]");
         } catch (final Throwable t) {
             fail("Threw " + t + "");
         }
@@ -641,6 +680,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getting a value out of a mapped Map
      */
+    @Test
     public void testGetIndexedMap() {
         final Map<String, Object> firstMap = new HashMap<>();
         firstMap.put("FIRST-KEY-1", "FIRST-VALUE-1");
@@ -654,10 +694,14 @@ public class PropertyUtilsTestCase extends TestCase {
         mainList.add(secondMap);
         final TestBean bean = new TestBean(mainList);
         try {
-            assertEquals("listIndexed[0](FIRST-KEY-1)", "FIRST-VALUE-1", PropertyUtils.getProperty(bean, "listIndexed[0](FIRST-KEY-1)"));
-            assertEquals("listIndexed[0](FIRST-KEY-2)", "FIRST-VALUE-2", PropertyUtils.getProperty(bean, "listIndexed[0](FIRST-KEY-2)"));
-            assertEquals("listIndexed[1](SECOND-KEY-1)", "SECOND-VALUE-1", PropertyUtils.getProperty(bean, "listIndexed[1](SECOND-KEY-1)"));
-            assertEquals("listIndexed[1](SECOND-KEY-2)", "SECOND-VALUE-2", PropertyUtils.getProperty(bean, "listIndexed[1](SECOND-KEY-2)"));
+            assertEquals("FIRST-VALUE-1", PropertyUtils.getProperty(bean, "listIndexed[0](FIRST-KEY-1)"),
+                                    "listIndexed[0](FIRST-KEY-1)");
+            assertEquals("FIRST-VALUE-2", PropertyUtils.getProperty(bean, "listIndexed[0](FIRST-KEY-2)"),
+                                    "listIndexed[0](FIRST-KEY-2)");
+            assertEquals("SECOND-VALUE-1", PropertyUtils.getProperty(bean, "listIndexed[1](SECOND-KEY-1)"),
+                                    "listIndexed[1](SECOND-KEY-1)");
+            assertEquals("SECOND-VALUE-2", PropertyUtils.getProperty(bean, "listIndexed[1](SECOND-KEY-2)"),
+                                    "listIndexed[1](SECOND-KEY-2)");
         } catch (final Throwable t) {
             fail("Threw " + t + "");
         }
@@ -666,6 +710,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Positive and negative tests on getIndexedProperty valid arguments.
      */
+    @Test
     public void testGetIndexedValues() {
 
         Object value = null;
@@ -676,54 +721,54 @@ public class PropertyUtilsTestCase extends TestCase {
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "dupProperty", i);
-                assertNotNull("dupProperty returned value " + i, value);
-                assertTrue("dupProperty returned String " + i, value instanceof String);
-                assertEquals("dupProperty returned correct " + i, "Dup " + i, (String) value);
+                assertNotNull(value, "dupProperty returned value " + i);
+                assertTrue(value instanceof String, "dupProperty returned String " + i);
+                assertEquals("Dup " + i, (String) value, "dupProperty returned correct " + i);
             } catch (final Throwable t) {
                 fail("dupProperty " + i + " threw " + t);
             }
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "intArray", i);
-                assertNotNull("intArray returned value " + i, value);
-                assertTrue("intArray returned Integer " + i, value instanceof Integer);
-                assertEquals("intArray returned correct " + i, i * 10, ((Integer) value).intValue());
+                assertNotNull(value, "intArray returned value " + i);
+                assertTrue(value instanceof Integer, "intArray returned Integer " + i);
+                assertEquals(i * 10, ((Integer) value).intValue(), "intArray returned correct " + i);
             } catch (final Throwable t) {
                 fail("intArray " + i + " threw " + t);
             }
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "intIndexed", i);
-                assertNotNull("intIndexed returned value " + i, value);
-                assertTrue("intIndexed returned Integer " + i, value instanceof Integer);
-                assertEquals("intIndexed returned correct " + i, i * 10, ((Integer) value).intValue());
+                assertNotNull(value, "intIndexed returned value " + i);
+                assertTrue(value instanceof Integer, "intIndexed returned Integer " + i);
+                assertEquals(i * 10, ((Integer) value).intValue(), "intIndexed returned correct " + i);
             } catch (final Throwable t) {
                 fail("intIndexed " + i + " threw " + t);
             }
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "listIndexed", i);
-                assertNotNull("listIndexed returned value " + i, value);
-                assertTrue("list returned String " + i, value instanceof String);
-                assertEquals("listIndexed returned correct " + i, "String " + i, (String) value);
+                assertNotNull(value, "listIndexed returned value " + i);
+                assertTrue(value instanceof String, "list returned String " + i);
+                assertEquals("String " + i, (String) value, "listIndexed returned correct " + i);
             } catch (final Throwable t) {
                 fail("listIndexed " + i + " threw " + t);
             }
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "stringArray", i);
-                assertNotNull("stringArray returned value " + i, value);
-                assertTrue("stringArray returned String " + i, value instanceof String);
-                assertEquals("stringArray returned correct " + i, "String " + i, (String) value);
+                assertNotNull(value, "stringArray returned value " + i);
+                assertTrue(value instanceof String, "stringArray returned String " + i);
+                assertEquals("String " + i, (String) value, "stringArray returned correct " + i);
             } catch (final Throwable t) {
                 fail("stringArray " + i + " threw " + t);
             }
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "stringIndexed", i);
-                assertNotNull("stringIndexed returned value " + i, value);
-                assertTrue("stringIndexed returned String " + i, value instanceof String);
-                assertEquals("stringIndexed returned correct " + i, "String " + i, (String) value);
+                assertNotNull(value, "stringIndexed returned value " + i);
+                assertTrue(value instanceof String, "stringIndexed returned String " + i);
+                assertEquals("String " + i, (String) value, "stringIndexed returned correct " + i);
             } catch (final Throwable t) {
                 fail("stringIndexed " + i + " threw " + t);
             }
@@ -736,54 +781,54 @@ public class PropertyUtilsTestCase extends TestCase {
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "dupProperty[" + i + "]");
-                assertNotNull("dupProperty returned value " + i, value);
-                assertTrue("dupProperty returned String " + i, value instanceof String);
-                assertEquals("dupProperty returned correct " + i, "Dup " + i, (String) value);
+                assertNotNull(value, "dupProperty returned value " + i);
+                assertTrue(value instanceof String, "dupProperty returned String " + i);
+                assertEquals("Dup " + i, (String) value, "dupProperty returned correct " + i);
             } catch (final Throwable t) {
                 fail("dupProperty " + i + " threw " + t);
             }
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "intArray[" + i + "]");
-                assertNotNull("intArray returned value " + i, value);
-                assertTrue("intArray returned Integer " + i, value instanceof Integer);
-                assertEquals("intArray returned correct " + i, i * 10, ((Integer) value).intValue());
+                assertNotNull(value, "intArray returned value " + i);
+                assertTrue(value instanceof Integer, "intArray returned Integer " + i);
+                assertEquals(i * 10, ((Integer) value).intValue(), "intArray returned correct " + i);
             } catch (final Throwable t) {
                 fail("intArray " + i + " threw " + t);
             }
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "intIndexed[" + i + "]");
-                assertNotNull("intIndexed returned value " + i, value);
-                assertTrue("intIndexed returned Integer " + i, value instanceof Integer);
-                assertEquals("intIndexed returned correct " + i, i * 10, ((Integer) value).intValue());
+                assertNotNull(value, "intIndexed returned value " + i);
+                assertTrue(value instanceof Integer, "intIndexed returned Integer " + i);
+                assertEquals(i * 10, ((Integer) value).intValue(), "intIndexed returned correct " + i);
             } catch (final Throwable t) {
                 fail("intIndexed " + i + " threw " + t);
             }
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "listIndexed[" + i + "]");
-                assertNotNull("listIndexed returned value " + i, value);
-                assertTrue("listIndexed returned String " + i, value instanceof String);
-                assertEquals("listIndexed returned correct " + i, "String " + i, (String) value);
+                assertNotNull(value, "listIndexed returned value " + i);
+                assertTrue(value instanceof String, "listIndexed returned String " + i);
+                assertEquals("String " + i, (String) value, "listIndexed returned correct " + i);
             } catch (final Throwable t) {
                 fail("listIndexed " + i + " threw " + t);
             }
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "stringArray[" + i + "]");
-                assertNotNull("stringArray returned value " + i, value);
-                assertTrue("stringArray returned String " + i, value instanceof String);
-                assertEquals("stringArray returned correct " + i, "String " + i, (String) value);
+                assertNotNull(value, "stringArray returned value " + i);
+                assertTrue(value instanceof String, "stringArray returned String " + i);
+                assertEquals("String " + i, (String) value, "stringArray returned correct " + i);
             } catch (final Throwable t) {
                 fail("stringArray " + i + " threw " + t);
             }
 
             try {
                 value = PropertyUtils.getIndexedProperty(bean, "stringIndexed[" + i + "]");
-                assertNotNull("stringIndexed returned value " + i, value);
-                assertTrue("stringIndexed returned String " + i, value instanceof String);
-                assertEquals("stringIndexed returned correct " + i, "String " + i, (String) value);
+                assertNotNull(value, "stringIndexed returned value " + i);
+                assertTrue(value instanceof String, "stringIndexed returned String " + i);
+                assertEquals("String " + i, (String) value, "stringIndexed returned correct " + i);
             } catch (final Throwable t) {
                 fail("stringIndexed " + i + " threw " + t);
             }
@@ -905,6 +950,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Corner cases on getMappedProperty invalid arguments.
      */
+    @Test
     public void testGetMappedArguments() {
         // Use explicit key argument
         assertThrows(NullPointerException.class, () -> PropertyUtils.getMappedProperty(null, "mappedProperty", "First Key"));
@@ -919,6 +965,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getting an indexed value out of a mapped array
      */
+    @Test
     public void testGetMappedArray() {
         final TestBean bean = new TestBean();
         final String[] array = { "abc", "def", "ghi" };
@@ -935,6 +982,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getting an indexed value out of a mapped List
      */
+    @Test
     public void testGetMappedList() {
         final TestBean bean = new TestBean();
         final List<Object> list = new ArrayList<>();
@@ -954,6 +1002,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getting a value out of a mapped Map
      */
+    @Test
     public void testGetMappedMap() {
         final TestBean bean = new TestBean();
         final Map<String, Object> map = new HashMap<>();
@@ -962,9 +1011,12 @@ public class PropertyUtilsTestCase extends TestCase {
         map.put("sub-key-3", "sub-value-3");
         bean.getMapProperty().put("mappedMap", map);
         try {
-            assertEquals("sub-value-1", PropertyUtils.getProperty(bean, "mapProperty(mappedMap)(sub-key-1)"));
-            assertEquals("sub-value-2", PropertyUtils.getProperty(bean, "mapProperty(mappedMap)(sub-key-2)"));
-            assertEquals("sub-value-3", PropertyUtils.getProperty(bean, "mapProperty(mappedMap)(sub-key-3)"));
+            assertEquals("sub-value-1",
+                                    PropertyUtils.getProperty(bean, "mapProperty(mappedMap)(sub-key-1)"));
+            assertEquals("sub-value-2",
+                                    PropertyUtils.getProperty(bean, "mapProperty(mappedMap)(sub-key-2)"));
+            assertEquals("sub-value-3",
+                                    PropertyUtils.getProperty(bean, "mapProperty(mappedMap)(sub-key-3)"));
         } catch (final Throwable t) {
             fail("Threw " + t + "");
         }
@@ -973,32 +1025,39 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getting mapped values with periods in the key.
      */
+    @Test
     public void testGetMappedPeriods() {
 
         bean.setMappedProperty("key.with.a.dot", "Special Value");
-        assertEquals("Can retrieve directly", "Special Value", bean.getMappedProperty("key.with.a.dot"));
+        assertEquals("Special Value", bean.getMappedProperty("key.with.a.dot"), "Can retrieve directly");
         try {
-            assertEquals("Can retrieve via getMappedProperty", "Special Value", PropertyUtils.getMappedProperty(bean, "mappedProperty", "key.with.a.dot"));
+            assertEquals("Special Value",
+                                    PropertyUtils.getMappedProperty(bean, "mappedProperty", "key.with.a.dot"),
+                                    "Can retrieve via getMappedProperty");
         } catch (final Exception e) {
             fail("Thew exception: " + e);
         }
         try {
-            assertEquals("Can retrieve via getNestedProperty", "Special Value", PropertyUtils.getNestedProperty(bean, "mappedProperty(key.with.a.dot)"));
+            assertEquals("Special Value",
+                                    PropertyUtils.getNestedProperty(bean, "mappedProperty(key.with.a.dot)"),
+                                    "Can retrieve via getNestedProperty");
         } catch (final Exception e) {
             fail("Thew exception: " + e);
         }
 
         bean.setMappedObjects("nested.property", new TestBean());
-        assertNotNull("Can retrieve directly", bean.getMappedObjects("nested.property"));
+        assertNotNull(bean.getMappedObjects("nested.property"), "Can retrieve directly");
         try {
-            assertEquals("Can retrieve nested", "This is a string", PropertyUtils.getNestedProperty(bean, "mappedObjects(nested.property).stringProperty"));
+            assertEquals("This is a string", PropertyUtils.getNestedProperty(bean, "mappedObjects(nested.property).stringProperty"),
+                                    "Can retrieve nested");
         } catch (final Exception e) {
             fail("Thew exception: " + e);
         }
 
         try {
-            assertEquals("Can't retrieved nested with mapped property", "Mapped Value",
-                    PropertyUtils.getNestedProperty(bean, "mappedNested.value(Mapped Key)"));
+            assertEquals("Mapped Value",
+                                    PropertyUtils.getNestedProperty(bean, "mappedNested.value(Mapped Key)"),
+                                    "Can't retrieved nested with mapped property");
         } catch (final Exception e) {
             fail("Thew exception: " + e);
         }
@@ -1007,25 +1066,31 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getting mapped values with slashes in the key. This is different from periods because slashes are not syntactically significant.
      */
+    @Test
     public void testGetMappedSlashes() {
 
         bean.setMappedProperty("key/with/a/slash", "Special Value");
-        assertEquals("Can retrieve directly", "Special Value", bean.getMappedProperty("key/with/a/slash"));
+        assertEquals("Special Value", bean.getMappedProperty("key/with/a/slash"), "Can retrieve directly");
         try {
-            assertEquals("Can retrieve via getMappedProperty", "Special Value", PropertyUtils.getMappedProperty(bean, "mappedProperty", "key/with/a/slash"));
+            assertEquals("Special Value",
+                                    PropertyUtils.getMappedProperty(bean, "mappedProperty", "key/with/a/slash"),
+                                    "Can retrieve via getMappedProperty");
         } catch (final Exception e) {
             fail("Thew exception: " + e);
         }
         try {
-            assertEquals("Can retrieve via getNestedProperty", "Special Value", PropertyUtils.getNestedProperty(bean, "mappedProperty(key/with/a/slash)"));
+            assertEquals("Special Value",
+                                    PropertyUtils.getNestedProperty(bean, "mappedProperty(key/with/a/slash)"),
+                                    "Can retrieve via getNestedProperty");
         } catch (final Exception e) {
             fail("Thew exception: " + e);
         }
 
         bean.setMappedObjects("nested/property", new TestBean());
-        assertNotNull("Can retrieve directly", bean.getMappedObjects("nested/property"));
+        assertNotNull(bean.getMappedObjects("nested/property"), "Can retrieve directly");
         try {
-            assertEquals("Can retrieve nested", "This is a string", PropertyUtils.getNestedProperty(bean, "mappedObjects(nested/property).stringProperty"));
+            assertEquals("This is a string", PropertyUtils.getNestedProperty(bean, "mappedObjects(nested/property).stringProperty"),
+                                    "Can retrieve nested");
         } catch (final Exception e) {
             fail("Thew exception: " + e);
         }
@@ -1035,6 +1100,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Positive and negative tests on getMappedProperty valid arguments.
      */
+    @Test
     public void testGetMappedValues() {
 
         Object value = null;
@@ -1043,21 +1109,21 @@ public class PropertyUtilsTestCase extends TestCase {
 
         try {
             value = PropertyUtils.getMappedProperty(bean, "mappedProperty", "First Key");
-            assertEquals("Can find first value", "First Value", value);
+            assertEquals("First Value", value, "Can find first value");
         } catch (final Throwable t) {
             fail("Finding first value threw " + t);
         }
 
         try {
             value = PropertyUtils.getMappedProperty(bean, "mappedProperty", "Second Key");
-            assertEquals("Can find second value", "Second Value", value);
+            assertEquals("Second Value", value, "Can find second value");
         } catch (final Throwable t) {
             fail("Finding second value threw " + t);
         }
 
         try {
             value = PropertyUtils.getMappedProperty(bean, "mappedProperty", "Third Key");
-            assertNull("Can not find third value", value);
+            assertNull(value, "Can not find third value");
         } catch (final Throwable t) {
             fail("Finding third value threw " + t);
         }
@@ -1066,21 +1132,21 @@ public class PropertyUtilsTestCase extends TestCase {
 
         try {
             value = PropertyUtils.getMappedProperty(bean, "mappedProperty(First Key)");
-            assertEquals("Can find first value", "First Value", value);
+            assertEquals("First Value", value, "Can find first value");
         } catch (final Throwable t) {
             fail("Finding first value threw " + t);
         }
 
         try {
             value = PropertyUtils.getMappedProperty(bean, "mappedProperty(Second Key)");
-            assertEquals("Can find second value", "Second Value", value);
+            assertEquals("Second Value", value, "Can find second value");
         } catch (final Throwable t) {
             fail("Finding second value threw " + t);
         }
 
         try {
             value = PropertyUtils.getMappedProperty(bean, "mappedProperty(Third Key)");
-            assertNull("Can not find third value", value);
+            assertNull(value, "Can not find third value");
         } catch (final Throwable t) {
             fail("Finding third value threw " + t);
         }
@@ -1089,21 +1155,21 @@ public class PropertyUtilsTestCase extends TestCase {
 
         try {
             value = PropertyUtils.getNestedProperty(bean, "mapProperty.First Key");
-            assertEquals("Can find first value", "First Value", value);
+            assertEquals("First Value", value, "Can find first value");
         } catch (final Throwable t) {
             fail("Finding first value threw " + t);
         }
 
         try {
             value = PropertyUtils.getNestedProperty(bean, "mapProperty.Second Key");
-            assertEquals("Can find second value", "Second Value", value);
+            assertEquals("Second Value", value, "Can find second value");
         } catch (final Throwable t) {
             fail("Finding second value threw " + t);
         }
 
         try {
             value = PropertyUtils.getNestedProperty(bean, "mapProperty.Third Key");
-            assertNull("Can not find third value", value);
+            assertNull(value, "Can not find third value");
         } catch (final Throwable t) {
             fail("Finding third value threw " + t);
         }
@@ -1113,6 +1179,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Corner cases on getNestedProperty invalid arguments.
      */
+    @Test
     public void testGetNestedArguments() {
         assertThrows(NullPointerException.class, () -> PropertyUtils.getNestedProperty(null, "stringProperty"));
         assertThrows(NullPointerException.class, () -> PropertyUtils.getNestedProperty(bean, null));
@@ -1121,12 +1188,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getNestedProperty on a boolean property.
      */
+    @Test
     public void testGetNestedBoolean() {
         try {
             final Object value = PropertyUtils.getNestedProperty(bean, "nested.booleanProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Boolean);
-            assertEquals("Got correct value", ((Boolean) value).booleanValue(), bean.getNested().getBooleanProperty());
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Boolean, "Got correct type");
+            assertEquals(((Boolean) value).booleanValue(), bean.getNested().getBooleanProperty(),
+                                    "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1141,13 +1210,15 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getNestedProperty on a double property.
      */
+    @Test
     public void testGetNestedDouble() {
 
         try {
             final Object value = PropertyUtils.getNestedProperty(bean, "nested.doubleProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Double);
-            assertEquals("Got correct value", ((Double) value).doubleValue(), bean.getNested().getDoubleProperty(), 0.005);
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Double, "Got correct type");
+            assertEquals(((Double) value).doubleValue(), bean.getNested().getDoubleProperty(), 0.005,
+                                    "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1163,13 +1234,15 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getNestedProperty on a float property.
      */
+    @Test
     public void testGetNestedFloat() {
 
         try {
             final Object value = PropertyUtils.getNestedProperty(bean, "nested.floatProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Float);
-            assertEquals("Got correct value", ((Float) value).floatValue(), bean.getNested().getFloatProperty(), (float) 0.005);
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Float, "Got correct type");
+            assertEquals(((Float) value).floatValue(), bean.getNested().getFloatProperty(), (float) 0.005,
+                                    "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1185,13 +1258,15 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getNestedProperty on an int property.
      */
+    @Test
     public void testGetNestedInt() {
 
         try {
             final Object value = PropertyUtils.getNestedProperty(bean, "nested.intProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Integer);
-            assertEquals("Got correct value", ((Integer) value).intValue(), bean.getNested().getIntProperty());
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Integer, "Got correct type");
+            assertEquals(((Integer) value).intValue(), bean.getNested().getIntProperty(),
+                                    "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1207,13 +1282,15 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getNestedProperty on a long property.
      */
+    @Test
     public void testGetNestedLong() {
 
         try {
             final Object value = PropertyUtils.getNestedProperty(bean, "nested.longProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Long);
-            assertEquals("Got correct value", ((Long) value).longValue(), bean.getNested().getLongProperty());
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Long, "Got correct type");
+            assertEquals(((Long) value).longValue(), bean.getNested().getLongProperty(),
+                                    "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1229,13 +1306,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getNestedProperty on a read-only String property.
      */
+    @Test
     public void testGetNestedReadOnly() {
 
         try {
             final Object value = PropertyUtils.getNestedProperty(bean, "nested.readOnlyProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof String);
-            assertEquals("Got correct value", (String) value, bean.getReadOnlyProperty());
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof String, "Got correct type");
+            assertEquals((String) value, bean.getReadOnlyProperty(), "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1251,13 +1329,15 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getNestedProperty on a short property.
      */
+    @Test
     public void testGetNestedShort() {
 
         try {
             final Object value = PropertyUtils.getNestedProperty(bean, "nested.shortProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Short);
-            assertEquals("Got correct value", ((Short) value).shortValue(), bean.getNested().getShortProperty());
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Short, "Got correct type");
+            assertEquals(((Short) value).shortValue(), bean.getNested().getShortProperty(),
+                                    "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1273,13 +1353,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getNestedProperty on a String property.
      */
+    @Test
     public void testGetNestedString() {
 
         try {
             final Object value = PropertyUtils.getNestedProperty(bean, "nested.stringProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof String);
-            assertEquals("Got correct value", (String) value, bean.getNested().getStringProperty());
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof String, "Got correct type");
+            assertEquals((String) value, bean.getNested().getStringProperty(), "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1295,6 +1376,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Negative test getNestedProperty on an unknown property.
      */
+    @Test
     public void testGetNestedUnknown() {
 
         try {
@@ -1315,6 +1397,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getNestedProperty on a write-only String property.
      */
+    @Test
     public void testGetNestedWriteOnly() {
 
         try {
@@ -1335,6 +1418,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getPropertyType() on all kinds of properties.
      */
+    @Test
     public void testGetPropertyType() {
 
         Class<?> clazz = null;
@@ -1345,95 +1429,95 @@ public class PropertyUtilsTestCase extends TestCase {
 
             // Scalar and Indexed Properties
             clazz = PropertyUtils.getPropertyType(bean, "booleanProperty");
-            assertEquals("booleanProperty type", Boolean.TYPE, clazz);
+            assertEquals(Boolean.TYPE, clazz, "booleanProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "booleanSecond");
-            assertEquals("booleanSecond type", Boolean.TYPE, clazz);
+            assertEquals(Boolean.TYPE, clazz, "booleanSecond type");
             clazz = PropertyUtils.getPropertyType(bean, "doubleProperty");
-            assertEquals("doubleProperty type", Double.TYPE, clazz);
+            assertEquals(Double.TYPE, clazz, "doubleProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "dupProperty");
-            assertEquals("dupProperty type", String.class, clazz);
+            assertEquals(String.class, clazz, "dupProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "floatProperty");
-            assertEquals("floatProperty type", Float.TYPE, clazz);
+            assertEquals(Float.TYPE, clazz, "floatProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "intArray");
-            assertEquals("intArray type", intArray.getClass(), clazz);
+            assertEquals(intArray.getClass(), clazz, "intArray type");
             clazz = PropertyUtils.getPropertyType(bean, "intIndexed");
-            assertEquals("intIndexed type", Integer.TYPE, clazz);
+            assertEquals(Integer.TYPE, clazz, "intIndexed type");
             clazz = PropertyUtils.getPropertyType(bean, "intProperty");
-            assertEquals("intProperty type", Integer.TYPE, clazz);
+            assertEquals(Integer.TYPE, clazz, "intProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "listIndexed");
-            assertEquals("listIndexed type", List.class, clazz);
+            assertEquals(List.class, clazz, "listIndexed type");
             clazz = PropertyUtils.getPropertyType(bean, "longProperty");
-            assertEquals("longProperty type", Long.TYPE, clazz);
+            assertEquals(Long.TYPE, clazz, "longProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "mappedProperty");
-            assertEquals("mappedProperty type", String.class, clazz);
+            assertEquals(String.class, clazz, "mappedProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "mappedIntProperty");
-            assertEquals("mappedIntProperty type", Integer.TYPE, clazz);
+            assertEquals(Integer.TYPE, clazz, "mappedIntProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "readOnlyProperty");
-            assertEquals("readOnlyProperty type", String.class, clazz);
+            assertEquals(String.class, clazz, "readOnlyProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "shortProperty");
-            assertEquals("shortProperty type", Short.TYPE, clazz);
+            assertEquals(Short.TYPE, clazz, "shortProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "stringArray");
-            assertEquals("stringArray type", stringArray.getClass(), clazz);
+            assertEquals(stringArray.getClass(), clazz, "stringArray type");
             clazz = PropertyUtils.getPropertyType(bean, "stringIndexed");
-            assertEquals("stringIndexed type", String.class, clazz);
+            assertEquals(String.class, clazz, "stringIndexed type");
             clazz = PropertyUtils.getPropertyType(bean, "stringProperty");
-            assertEquals("stringProperty type", String.class, clazz);
+            assertEquals(String.class, clazz, "stringProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "writeOnlyProperty");
-            assertEquals("writeOnlyProperty type", String.class, clazz);
+            assertEquals(String.class, clazz, "writeOnlyProperty type");
 
             // Nested Properties
             clazz = PropertyUtils.getPropertyType(bean, "nested.booleanProperty");
-            assertEquals("booleanProperty type", Boolean.TYPE, clazz);
+            assertEquals(Boolean.TYPE, clazz, "booleanProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "nested.booleanSecond");
-            assertEquals("booleanSecond type", Boolean.TYPE, clazz);
+            assertEquals(Boolean.TYPE, clazz, "booleanSecond type");
             clazz = PropertyUtils.getPropertyType(bean, "nested.doubleProperty");
-            assertEquals("doubleProperty type", Double.TYPE, clazz);
+            assertEquals(Double.TYPE, clazz, "doubleProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "nested.dupProperty");
-            assertEquals("dupProperty type", String.class, clazz);
+            assertEquals(String.class, clazz, "dupProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "nested.floatProperty");
-            assertEquals("floatProperty type", Float.TYPE, clazz);
+            assertEquals(Float.TYPE, clazz, "floatProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "nested.intArray");
-            assertEquals("intArray type", intArray.getClass(), clazz);
+            assertEquals(intArray.getClass(), clazz, "intArray type");
             clazz = PropertyUtils.getPropertyType(bean, "nested.intIndexed");
-            assertEquals("intIndexed type", Integer.TYPE, clazz);
+            assertEquals(Integer.TYPE, clazz, "intIndexed type");
             clazz = PropertyUtils.getPropertyType(bean, "nested.intProperty");
-            assertEquals("intProperty type", Integer.TYPE, clazz);
+            assertEquals(Integer.TYPE, clazz, "intProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "nested.listIndexed");
-            assertEquals("listIndexed type", List.class, clazz);
+            assertEquals(List.class, clazz, "listIndexed type");
             clazz = PropertyUtils.getPropertyType(bean, "nested.longProperty");
-            assertEquals("longProperty type", Long.TYPE, clazz);
+            assertEquals(Long.TYPE, clazz, "longProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "nested.mappedProperty");
-            assertEquals("mappedProperty type", String.class, clazz);
+            assertEquals(String.class, clazz, "mappedProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "nested.mappedIntProperty");
-            assertEquals("mappedIntProperty type", Integer.TYPE, clazz);
+            assertEquals(Integer.TYPE, clazz, "mappedIntProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "nested.readOnlyProperty");
-            assertEquals("readOnlyProperty type", String.class, clazz);
+            assertEquals(String.class, clazz, "readOnlyProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "nested.shortProperty");
-            assertEquals("shortProperty type", Short.TYPE, clazz);
+            assertEquals(Short.TYPE, clazz, "shortProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "nested.stringArray");
-            assertEquals("stringArray type", stringArray.getClass(), clazz);
+            assertEquals(stringArray.getClass(), clazz, "stringArray type");
             clazz = PropertyUtils.getPropertyType(bean, "nested.stringIndexed");
-            assertEquals("stringIndexed type", String.class, clazz);
+            assertEquals(String.class, clazz, "stringIndexed type");
             clazz = PropertyUtils.getPropertyType(bean, "nested.stringProperty");
-            assertEquals("stringProperty type", String.class, clazz);
+            assertEquals(String.class, clazz, "stringProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "nested.writeOnlyProperty");
-            assertEquals("writeOnlyProperty type", String.class, clazz);
+            assertEquals(String.class, clazz, "writeOnlyProperty type");
 
             // Nested DynaBean
             clazz = PropertyUtils.getPropertyType(bean, "nestedDynaBean");
-            assertEquals("nestedDynaBean type", DynaBean.class, clazz);
+            assertEquals(DynaBean.class, clazz, "nestedDynaBean type");
             clazz = PropertyUtils.getPropertyType(bean, "nestedDynaBean.stringProperty");
-            assertEquals("nestedDynaBean.stringProperty type", String.class, clazz);
+            assertEquals(String.class, clazz, "nestedDynaBean.stringProperty type");
             clazz = PropertyUtils.getPropertyType(bean, "nestedDynaBean.nestedBean");
-            assertEquals("nestedDynaBean.nestedBean type", TestBean.class, clazz);
+            assertEquals(TestBean.class, clazz, "nestedDynaBean.nestedBean type");
             clazz = PropertyUtils.getPropertyType(bean, "nestedDynaBean.nestedBean.nestedDynaBean");
-            assertEquals("nestedDynaBean.nestedBean.nestedDynaBean type", DynaBean.class, clazz);
+            assertEquals(DynaBean.class, clazz, "nestedDynaBean.nestedBean.nestedDynaBean type");
             clazz = PropertyUtils.getPropertyType(bean, "nestedDynaBean.nestedBean.nestedDynaBean.stringProperty");
-            assertEquals("nestedDynaBean.nestedBean.nestedDynaBean.stringPropert type", String.class, clazz);
+            assertEquals(String.class, clazz, "nestedDynaBean.nestedBean.nestedDynaBean.stringPropert type");
 
             // test Null
             clazz = PropertyUtils.getPropertyType(bean, "nestedDynaBean.nullDynaBean");
-            assertEquals("nestedDynaBean.nullDynaBean type", DynaBean.class, clazz);
+            assertEquals(DynaBean.class, clazz, "nestedDynaBean.nullDynaBean type");
             try {
                 clazz = PropertyUtils.getPropertyType(bean, "nestedDynaBean.nullDynaBean.foo");
                 fail("Expected NestedNullException for nestedDynaBean.nullDynaBean.foo");
@@ -1450,6 +1534,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test accessing a public sub-bean of a package scope bean
      */
+    @Test
     public void testGetPublicSubBean_of_PackageBean() {
 
         final PublicSubBean bean = new PublicSubBean();
@@ -1463,7 +1548,7 @@ public class PropertyUtilsTestCase extends TestCase {
         } catch (final Throwable t) {
             fail("getProperty(foo) threw " + t);
         }
-        assertEquals("foo property", "foo-start", result);
+        assertEquals("foo-start", result, "foo property");
 
         // Get Bar
         try {
@@ -1471,7 +1556,7 @@ public class PropertyUtilsTestCase extends TestCase {
         } catch (final Throwable t) {
             fail("getProperty(bar) threw " + t);
         }
-        assertEquals("bar property", "bar-start", result);
+        assertEquals("bar-start", result, "bar property");
     }
 
     /**
@@ -1481,7 +1566,7 @@ public class PropertyUtilsTestCase extends TestCase {
      * @param properties Property names to search for
      * @param className  Class name where this method should be defined
      */
-    protected void testGetReadMethod(final Object bean, final String[] properties, final String className) {
+    private void testGetReadMethod(final Object bean, final String[] properties, final String className) {
 
         final PropertyDescriptor[] pd = PropertyUtils.getPropertyDescriptors(bean);
         for (final String propertie : properties) {
@@ -1503,14 +1588,14 @@ public class PropertyUtilsTestCase extends TestCase {
                     break;
                 }
             }
-            assertTrue("PropertyDescriptor for " + propertie, n >= 0);
+            assertTrue(n >= 0, "PropertyDescriptor for " + propertie);
 
             // Locate an accessible property reader method for it
             final Method reader = PropertyUtils.getReadMethod(pd[n]);
-            assertNotNull("Reader for " + propertie, reader);
+            assertNotNull(reader, "Reader for " + propertie);
             final Class<?> clazz = reader.getDeclaringClass();
-            assertNotNull("Declaring class for " + propertie, clazz);
-            assertEquals("Correct declaring class for " + propertie, clazz.getName(), className);
+            assertNotNull(clazz, "Declaring class for " + propertie);
+            assertEquals(clazz.getName(), className, "Correct declaring class for " + propertie);
 
             // Actually call the reader method we received
             try {
@@ -1526,6 +1611,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getting accessible property reader methods for a specified list of properties of our standard test bean.
      */
+    @Test
     public void testGetReadMethodBasic() {
 
         testGetReadMethod(bean, properties, TEST_BEAN_CLASS);
@@ -1535,6 +1621,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getting accessible property reader methods for a specified list of properties of a package private subclass of our standard test bean.
      */
+    @Test
     public void testGetReadMethodPackageSubclass() {
 
         testGetReadMethod(beanPackageSubclass, properties, TEST_BEAN_CLASS);
@@ -1544,6 +1631,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getting accessible property reader methods for a specified list of properties that are declared either directly or via implemented interfaces.
      */
+    @Test
     public void testGetReadMethodPublicInterface() {
 
         // Properties "bar" and "baz" are visible via implemented interfaces
@@ -1567,9 +1655,9 @@ public class PropertyUtilsTestCase extends TestCase {
                 break;
             }
         }
-        assertTrue("Found foo descriptor", n >= 0);
+        assertTrue(n >= 0, "Found foo descriptor");
         final Method reader = pd[n].getReadMethod();
-        assertNotNull("Found foo read method", reader);
+        assertNotNull(reader, "Found foo read method");
         try {
             reader.invoke(beanPrivate, (Object[]) new Class<?>[0]);
             fail("Foo reader did throw IllegalAccessException");
@@ -1584,6 +1672,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getting accessible property reader methods for a specified list of properties of a public subclass of our standard test bean.
      */
+    @Test
     public void testGetReadMethodPublicSubclass() {
 
         testGetReadMethod(beanPublicSubclass, properties, TEST_BEAN_CLASS);
@@ -1591,33 +1680,36 @@ public class PropertyUtilsTestCase extends TestCase {
     }
 
     /** Text case for setting properties on inner classes */
+    @Test
     public void testGetSetInnerBean() throws Exception {
         final BeanWithInnerBean bean = new BeanWithInnerBean();
 
         PropertyUtils.setProperty(bean, "innerBean.fish(loiterTimer)", "5");
         String out = (String) PropertyUtils.getProperty(bean.getInnerBean(), "fish(loiterTimer)");
-        assertEquals("(1) Inner class property set/get property failed.", "5", out);
+        assertEquals("5", out, "(1) Inner class property set/get property failed.");
 
         out = (String) PropertyUtils.getProperty(bean, "innerBean.fish(loiterTimer)");
 
-        assertEquals("(2) Inner class property set/get property failed.", "5", out);
+        assertEquals("5", out, "(2) Inner class property set/get property failed.");
     }
 
     /** Text case for setting properties on parent */
+    @Test
     public void testGetSetParentBean() throws Exception {
 
         final SonOfAlphaBean bean = new SonOfAlphaBean("Roger");
 
         final String out = (String) PropertyUtils.getProperty(bean, "name");
-        assertEquals("(1) Get/Set On Parent.", "Roger", out);
+        assertEquals("Roger", out, "(1) Get/Set On Parent.");
 
         PropertyUtils.setProperty(bean, "name", "abcd");
-        assertEquals("(2) Get/Set On Parent.", "abcd", bean.getName());
+        assertEquals("abcd", bean.getName(), "(2) Get/Set On Parent.");
     }
 
     /**
      * Corner cases on getSimpleProperty invalid arguments.
      */
+    @Test
     public void testGetSimpleArguments() {
         assertThrows(NullPointerException.class, () -> PropertyUtils.getSimpleProperty(null, "stringProperty"));
         assertThrows(NullPointerException.class, () -> PropertyUtils.getSimpleProperty(bean, null));
@@ -1626,13 +1718,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getSimpleProperty on a boolean property.
      */
+    @Test
     public void testGetSimpleBoolean() {
 
         try {
             final Object value = PropertyUtils.getSimpleProperty(bean, "booleanProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Boolean);
-            assertEquals("Got correct value", ((Boolean) value).booleanValue(), bean.getBooleanProperty());
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Boolean, "Got correct type");
+            assertEquals(((Boolean) value).booleanValue(), bean.getBooleanProperty(), "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1648,13 +1741,15 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getSimpleProperty on a double property.
      */
+    @Test
     public void testGetSimpleDouble() {
 
         try {
             final Object value = PropertyUtils.getSimpleProperty(bean, "doubleProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Double);
-            assertEquals("Got correct value", ((Double) value).doubleValue(), bean.getDoubleProperty(), 0.005);
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Double, "Got correct type");
+            assertEquals(((Double) value).doubleValue(), bean.getDoubleProperty(), 0.005,
+                                    "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1670,13 +1765,15 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getSimpleProperty on a float property.
      */
+    @Test
     public void testGetSimpleFloat() {
 
         try {
             final Object value = PropertyUtils.getSimpleProperty(bean, "floatProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Float);
-            assertEquals("Got correct value", ((Float) value).floatValue(), bean.getFloatProperty(), (float) 0.005);
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Float, "Got correct type");
+            assertEquals(((Float) value).floatValue(), bean.getFloatProperty(), (float) 0.005,
+                                    "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1692,6 +1789,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Negative test getSimpleProperty on an indexed property.
      */
+    @Test
     public void testGetSimpleIndexed() {
 
         try {
@@ -1712,13 +1810,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getSimpleProperty on an int property.
      */
+    @Test
     public void testGetSimpleInt() {
 
         try {
             final Object value = PropertyUtils.getSimpleProperty(bean, "intProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Integer);
-            assertEquals("Got correct value", ((Integer) value).intValue(), bean.getIntProperty());
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Integer, "Got correct type");
+            assertEquals(((Integer) value).intValue(), bean.getIntProperty(), "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1734,13 +1833,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getSimpleProperty on a long property.
      */
+    @Test
     public void testGetSimpleLong() {
 
         try {
             final Object value = PropertyUtils.getSimpleProperty(bean, "longProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Long);
-            assertEquals("Got correct value", ((Long) value).longValue(), bean.getLongProperty());
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Long, "Got correct type");
+            assertEquals(((Long) value).longValue(), bean.getLongProperty(), "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1756,6 +1856,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Negative test getSimpleProperty on a nested property.
      */
+    @Test
     public void testGetSimpleNested() {
 
         try {
@@ -1776,13 +1877,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getSimpleProperty on a read-only String property.
      */
+    @Test
     public void testGetSimpleReadOnly() {
 
         try {
             final Object value = PropertyUtils.getSimpleProperty(bean, "readOnlyProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof String);
-            assertEquals("Got correct value", (String) value, bean.getReadOnlyProperty());
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof String, "Got correct type");
+            assertEquals((String) value, bean.getReadOnlyProperty(), "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1798,13 +1900,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getSimpleProperty on a short property.
      */
+    @Test
     public void testGetSimpleShort() {
 
         try {
             final Object value = PropertyUtils.getSimpleProperty(bean, "shortProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof Short);
-            assertEquals("Got correct value", ((Short) value).shortValue(), bean.getShortProperty());
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof Short, "Got correct type");
+            assertEquals(((Short) value).shortValue(), bean.getShortProperty(), "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1820,13 +1923,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getSimpleProperty on a String property.
      */
+    @Test
     public void testGetSimpleString() {
 
         try {
             final Object value = PropertyUtils.getSimpleProperty(bean, "stringProperty");
-            assertNotNull("Got a value", value);
-            assertTrue("Got correct type", value instanceof String);
-            assertEquals("Got correct value", (String) value, bean.getStringProperty());
+            assertNotNull(value, "Got a value");
+            assertTrue(value instanceof String, "Got correct type");
+            assertEquals((String) value, bean.getStringProperty(), "Got correct value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -1842,6 +1946,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Negative test getSimpleProperty on an unknown property.
      */
+    @Test
     public void testGetSimpleUnknown() {
 
         try {
@@ -1863,6 +1968,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getSimpleProperty on a write-only String property.
      */
+    @Test
     public void testGetSimpleWriteOnly() {
 
         try {
@@ -1876,7 +1982,9 @@ public class PropertyUtilsTestCase extends TestCase {
             fail("InvocationTargetException");
         } catch (final NoSuchMethodException e) {
             // Correct result for this test
-            assertEquals("Property 'writeOnlyProperty' has no getter method in class '" + bean.getClass() + "'", e.getMessage());
+            assertEquals(
+                    "Property 'writeOnlyProperty' has no getter method in class '" + bean.getClass() + "'",
+                    e.getMessage());
         }
 
     }
@@ -1888,7 +1996,7 @@ public class PropertyUtilsTestCase extends TestCase {
      * @param properties Property names to search for
      * @param className  Class name where this method should be defined
      */
-    protected void testGetWriteMethod(final Object bean, final String[] properties, final String className) {
+    private void testGetWriteMethod(final Object bean, final String[] properties, final String className) {
 
         final PropertyDescriptor[] pd = PropertyUtils.getPropertyDescriptors(bean);
         for (final String property : properties) {
@@ -1916,14 +2024,14 @@ public class PropertyUtilsTestCase extends TestCase {
                     break;
                 }
             }
-            assertTrue("PropertyDescriptor for " + property, n >= 0);
+            assertTrue(n >= 0, "PropertyDescriptor for " + property);
 
             // Locate an accessible property reader method for it
             final Method writer = PropertyUtils.getWriteMethod(pd[n]);
-            assertNotNull("Writer for " + property, writer);
+            assertNotNull(writer, "Writer for " + property);
             final Class<?> clazz = writer.getDeclaringClass();
-            assertNotNull("Declaring class for " + property, clazz);
-            assertEquals("Correct declaring class for " + property, clazz.getName(), className);
+            assertNotNull(clazz, "Declaring class for " + property);
+            assertEquals(clazz.getName(), className, "Correct declaring class for " + property);
 
         }
 
@@ -1932,6 +2040,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getting accessible property writer methods for a specified list of properties of our standard test bean.
      */
+    @Test
     public void testGetWriteMethodBasic() {
 
         testGetWriteMethod(bean, properties, TEST_BEAN_CLASS);
@@ -1941,6 +2050,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getting accessible property writer methods for a specified list of properties of a package private subclass of our standard test bean.
      */
+    @Test
     public void testGetWriteMethodPackageSubclass() {
 
         testGetWriteMethod(beanPackageSubclass, properties, TEST_BEAN_CLASS);
@@ -1950,6 +2060,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test getting accessible property writer methods for a specified list of properties of a public subclass of our standard test bean.
      */
+    @Test
     public void testGetWriteMethodPublicSubclass() {
 
         testGetWriteMethod(beanPublicSubclass, properties, TEST_BEAN_CLASS);
@@ -1959,72 +2070,83 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test isReadable() method.
      */
+    @Test
     public void testIsReadable() {
         String property = null;
         try {
             property = "stringProperty";
-            assertTrue("Property " + property + " isReadable expected TRUE", PropertyUtils.isReadable(bean, property));
+            assertTrue(PropertyUtils.isReadable(bean, property),
+                                  "Property " + property + " isReadable expected TRUE");
         } catch (final Throwable t) {
             fail("Property " + property + " isReadable Threw exception: " + t);
         }
         try {
             property = "stringIndexed";
-            assertTrue("Property " + property + " isReadable expected TRUE", PropertyUtils.isReadable(bean, property));
+            assertTrue(PropertyUtils.isReadable(bean, property),
+                                  "Property " + property + " isReadable expected TRUE");
         } catch (final Throwable t) {
             fail("Property " + property + " isReadable Threw exception: " + t);
         }
         try {
             property = "mappedProperty";
-            assertTrue("Property " + property + " isReadable expected TRUE", PropertyUtils.isReadable(bean, property));
+            assertTrue(PropertyUtils.isReadable(bean, property),
+                                  "Property " + property + " isReadable expected TRUE");
         } catch (final Throwable t) {
             fail("Property " + property + " isReadable Threw exception: " + t);
         }
 
         try {
             property = "nestedDynaBean";
-            assertTrue("Property " + property + " isReadable expected TRUE", PropertyUtils.isReadable(bean, property));
+            assertTrue(PropertyUtils.isReadable(bean, property),
+                                  "Property " + property + " isReadable expected TRUE");
         } catch (final Throwable t) {
             fail("Property " + property + " isReadable Threw exception: " + t);
         }
 
         try {
             property = "nestedDynaBean.stringProperty";
-            assertTrue("Property " + property + " isReadable expected TRUE", PropertyUtils.isReadable(bean, property));
+            assertTrue(PropertyUtils.isReadable(bean, property),
+                                  "Property " + property + " isReadable expected TRUE");
         } catch (final Throwable t) {
             fail("Property " + property + " isReadable Threw exception: " + t);
         }
 
         try {
             property = "nestedDynaBean.nestedBean";
-            assertTrue("Property " + property + " isReadable expected TRUE", PropertyUtils.isReadable(bean, property));
+            assertTrue(PropertyUtils.isReadable(bean, property),
+                                  "Property " + property + " isReadable expected TRUE");
         } catch (final Throwable t) {
             fail("Property " + property + " isReadable Threw exception: " + t);
         }
 
         try {
             property = "nestedDynaBean.nestedBean.nestedDynaBean";
-            assertTrue("Property " + property + " isReadable expected TRUE", PropertyUtils.isReadable(bean, property));
+            assertTrue(PropertyUtils.isReadable(bean, property),
+                                  "Property " + property + " isReadable expected TRUE");
         } catch (final Throwable t) {
             fail("Property " + property + " isReadable Threw exception: " + t);
         }
 
         try {
             property = "nestedDynaBean.nestedBean.nestedDynaBean.stringProperty";
-            assertTrue("Property " + property + " isReadable expected TRUE", PropertyUtils.isReadable(bean, property));
+            assertTrue(PropertyUtils.isReadable(bean, property),
+                                  "Property " + property + " isReadable expected TRUE");
         } catch (final Throwable t) {
             fail("Property " + property + " isReadable Threw exception: " + t);
         }
 
         try {
             property = "nestedDynaBean.nullDynaBean";
-            assertTrue("Property " + property + " isReadable expected TRUE", PropertyUtils.isReadable(bean, property));
+            assertTrue(PropertyUtils.isReadable(bean, property),
+                                  "Property " + property + " isReadable expected TRUE");
         } catch (final Throwable t) {
             fail("Property " + property + " isReadable Threw exception: " + t);
         }
 
         try {
             property = "nestedDynaBean.nullDynaBean.foo";
-            assertTrue("Property " + property + " isReadable expected TRUE", PropertyUtils.isReadable(bean, property));
+            assertTrue(PropertyUtils.isReadable(bean, property),
+                                  "Property " + property + " isReadable expected TRUE");
             fail("Property " + property + " isReadable expected NestedNullException");
         } catch (final NestedNullException e) {
             // expected result
@@ -2036,37 +2158,43 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test isWriteable() method.
      */
+    @Test
     public void testIsWriteable() {
         String property = null;
         try {
             property = "stringProperty";
-            assertTrue("Property " + property + " isWriteable expected TRUE", PropertyUtils.isWriteable(bean, property));
+            assertTrue(PropertyUtils.isWriteable(bean, property),
+                                  "Property " + property + " isWriteable expected TRUE");
         } catch (final Throwable t) {
             fail("Property " + property + " isWriteable Threw exception: " + t);
         }
         try {
             property = "stringIndexed";
-            assertTrue("Property " + property + " isWriteable expected TRUE", PropertyUtils.isWriteable(bean, property));
+            assertTrue(PropertyUtils.isWriteable(bean, property),
+                                  "Property " + property + " isWriteable expected TRUE");
         } catch (final Throwable t) {
             fail("Property " + property + " isWriteable Threw exception: " + t);
         }
         try {
             property = "mappedProperty";
-            assertTrue("Property " + property + " isWriteable expected TRUE", PropertyUtils.isWriteable(bean, property));
+            assertTrue(PropertyUtils.isWriteable(bean, property),
+                                  "Property " + property + " isWriteable expected TRUE");
         } catch (final Throwable t) {
             fail("Property " + property + " isWriteable Threw exception: " + t);
         }
 
         try {
             property = "nestedDynaBean";
-            assertTrue("Property " + property + " isWriteable expected TRUE", PropertyUtils.isWriteable(bean, property));
+            assertTrue(PropertyUtils.isWriteable(bean, property),
+                                  "Property " + property + " isWriteable expected TRUE");
         } catch (final Throwable t) {
             fail("Property " + property + " isWriteable Threw exception: " + t);
         }
 
         try {
             property = "nestedDynaBean.stringProperty";
-            assertTrue("Property " + property + " isWriteable expected TRUE", PropertyUtils.isWriteable(bean, property));
+            assertTrue(PropertyUtils.isWriteable(bean, property),
+                                  "Property " + property + " isWriteable expected TRUE");
         } catch (final Throwable t) {
             t.printStackTrace();
             fail("Property " + property + " isWriteable Threw exception: " + t);
@@ -2074,35 +2202,40 @@ public class PropertyUtilsTestCase extends TestCase {
 
         try {
             property = "nestedDynaBean.nestedBean";
-            assertTrue("Property " + property + " isWriteable expected TRUE", PropertyUtils.isWriteable(bean, property));
+            assertTrue(PropertyUtils.isWriteable(bean, property),
+                                  "Property " + property + " isWriteable expected TRUE");
         } catch (final Throwable t) {
             fail("Property " + property + " isWriteable Threw exception: " + t);
         }
 
         try {
             property = "nestedDynaBean.nestedBean.nestedDynaBean";
-            assertTrue("Property " + property + " isWriteable expected TRUE", PropertyUtils.isWriteable(bean, property));
+            assertTrue(PropertyUtils.isWriteable(bean, property),
+                                  "Property " + property + " isWriteable expected TRUE");
         } catch (final Throwable t) {
             fail("Property " + property + " isWriteable Threw exception: " + t);
         }
 
         try {
             property = "nestedDynaBean.nestedBean.nestedDynaBean.stringProperty";
-            assertTrue("Property " + property + " isWriteable expected TRUE", PropertyUtils.isWriteable(bean, property));
+            assertTrue(PropertyUtils.isWriteable(bean, property),
+                                  "Property " + property + " isWriteable expected TRUE");
         } catch (final Throwable t) {
             fail("Property " + property + " isWriteable Threw exception: " + t);
         }
 
         try {
             property = "nestedDynaBean.nullDynaBean";
-            assertTrue("Property " + property + " isWriteable expected TRUE", PropertyUtils.isWriteable(bean, property));
+            assertTrue(PropertyUtils.isWriteable(bean, property),
+                                  "Property " + property + " isWriteable expected TRUE");
         } catch (final Throwable t) {
             fail("Property " + property + " isWriteable Threw exception: " + t);
         }
 
         try {
             property = "nestedDynaBean.nullDynaBean.foo";
-            assertTrue("Property " + property + " isWriteable expected TRUE", PropertyUtils.isWriteable(bean, property));
+            assertTrue(PropertyUtils.isWriteable(bean, property),
+                                  "Property " + property + " isWriteable expected TRUE");
             fail("Property " + property + " isWriteable expected NestedNullException");
         } catch (final NestedNullException e) {
             // expected result
@@ -2115,28 +2248,31 @@ public class PropertyUtilsTestCase extends TestCase {
      * This tests to see that it is possible to subclass PropertyUtilsBean and change the behavior of setNestedProperty/getNestedProperty when dealing with
      * objects that implement Map.
      */
+    @Test
     public void testMapExtensionCustom() throws Exception {
         final PropsFirstPropertyUtilsBean utilsBean = new PropsFirstPropertyUtilsBean();
         final ExtendMapBean bean = new ExtendMapBean();
 
         // hardly worth testing this, really :-)
         bean.setUnusuallyNamedProperty("bean value");
-        assertEquals("Set property direct failed", "bean value", bean.getUnusuallyNamedProperty());
+        assertEquals("bean value", bean.getUnusuallyNamedProperty(), "Set property direct failed");
 
         // setSimpleProperty should affect the simple property
         utilsBean.setSimpleProperty(bean, "unusuallyNamedProperty", "new value");
-        assertEquals("Set property on map failed (1)", "new value", bean.getUnusuallyNamedProperty());
+        assertEquals("new value", bean.getUnusuallyNamedProperty(), "Set property on map failed (1)");
 
         // setNestedProperty with setter should affect the simple property
         // getNestedProperty with getter should obtain the simple property
         utilsBean.setProperty(bean, "unusuallyNamedProperty", "next value");
-        assertEquals("Set property on map failed (2)", "next value", bean.getUnusuallyNamedProperty());
-        assertEquals("setNestedProperty on non-simple property failed", "next value", utilsBean.getNestedProperty(bean, "unusuallyNamedProperty"));
+        assertEquals("next value", bean.getUnusuallyNamedProperty(), "Set property on map failed (2)");
+        assertEquals("next value", utilsBean.getNestedProperty(bean, "unusuallyNamedProperty"),
+                                "setNestedProperty on non-simple property failed");
 
         // setting property without setter should update the map
         // getting property without setter should fetch from the map
         utilsBean.setProperty(bean, "mapProperty", "value1");
-        assertEquals("setNestedProperty on non-simple property failed", "value1", utilsBean.getNestedProperty(bean, "mapProperty"));
+        assertEquals("value1", utilsBean.getNestedProperty(bean, "mapProperty"),
+                                "setNestedProperty on non-simple property failed");
 
         final HashMap<String, Object> myMap = new HashMap<>();
         myMap.put("thebean", bean);
@@ -2150,31 +2286,36 @@ public class PropertyUtilsTestCase extends TestCase {
      * Note that this behavior has changed several times over past releases of beanutils, breaking backwards compatibility each time. Here's hoping that the
      * current 1.7.1 release is the last time this behavior changes!
      */
+    @Test
     public void testMapExtensionDefault() throws Exception {
         final ExtendMapBean bean = new ExtendMapBean();
 
         // setting property direct should work, and not affect map
         bean.setUnusuallyNamedProperty("bean value");
-        assertEquals("Set property direct failed", "bean value", bean.getUnusuallyNamedProperty());
-        assertNull("Get on unset map property failed", PropertyUtils.getNestedProperty(bean, "unusuallyNamedProperty"));
+        assertEquals("bean value", bean.getUnusuallyNamedProperty(), "Set property direct failed");
+        assertNull(PropertyUtils.getNestedProperty(bean, "unusuallyNamedProperty"),
+                              "Get on unset map property failed");
 
         // setting simple property should call the setter method only, and not
         // affect the map.
         PropertyUtils.setSimpleProperty(bean, "unusuallyNamedProperty", "new value");
-        assertEquals("Set property on map failed (1)", "new value", bean.getUnusuallyNamedProperty());
-        assertNull("Get on unset map property failed", PropertyUtils.getNestedProperty(bean, "unusuallyNamedProperty"));
+        assertEquals("new value", bean.getUnusuallyNamedProperty(), "Set property on map failed (1)");
+        assertNull(PropertyUtils.getNestedProperty(bean, "unusuallyNamedProperty"),
+                              "Get on unset map property failed");
 
         // setting via setNestedProperty should affect the map only, and not
         // call the setter method.
         PropertyUtils.setProperty(bean, "unusuallyNamedProperty", "next value");
-        assertEquals("setNestedProperty on map not visible to getNestedProperty", "next value",
-                PropertyUtils.getNestedProperty(bean, "unusuallyNamedProperty"));
-        assertEquals("Set nested property on map unexpected affected simple property", "new value", bean.getUnusuallyNamedProperty());
+        assertEquals("next value", PropertyUtils.getNestedProperty(bean, "unusuallyNamedProperty"),
+                                "setNestedProperty on map not visible to getNestedProperty");
+        assertEquals("new value", bean.getUnusuallyNamedProperty(),
+                                "Set nested property on map unexpected affected simple property");
     }
 
     /**
      * Test the mappedPropertyType of MappedPropertyDescriptor.
      */
+    @Test
     public void testMappedPropertyType() throws Exception {
 
         MappedPropertyDescriptor desc;
@@ -2204,6 +2345,7 @@ public class PropertyUtilsTestCase extends TestCase {
      * <p>
      * Here we verify that an exception is thrown if the user makes this mistake.
      */
+    @Test
     public void testNestedPropertyKeyOrIndexOnBeanImplementingMap() throws Exception {
         final HashMap<String, Object> map = new HashMap<>();
         final HashMap<String, Object> submap = new HashMap<>();
@@ -2215,8 +2357,8 @@ public class PropertyUtilsTestCase extends TestCase {
 
         // map.get("submap").put("beta1", betaBean1)
         PropertyUtils.setNestedProperty(map, "submap.beta1", betaBean1);
-        assertEquals("Unexpected keys in map", "submap", keysToString(map));
-        assertEquals("Unexpected keys in submap", "beta1", keysToString(submap));
+        assertEquals("submap", keysToString(map), "Unexpected keys in map");
+        assertEquals("beta1", keysToString(submap), "Unexpected keys in submap");
 
         try {
             // One would expect that the command below would be equivalent to
@@ -2237,7 +2379,8 @@ public class PropertyUtilsTestCase extends TestCase {
             // ok, getting an exception was expected. As it is of a generic
             // type, let's check the message string to make sure it really
             // was caused by the issue we expected.
-            assertTrue("Unexpected exception message", ex.getMessage().contains("Indexed or mapped properties are not supported"));
+            assertTrue(ex.getMessage().contains("Indexed or mapped properties are not supported"),
+                                  "Unexpected exception message");
         }
 
         try {
@@ -2260,10 +2403,11 @@ public class PropertyUtilsTestCase extends TestCase {
             // type, let's check the message string to make sure it really
             // was caused by the issue we expected.
             final int index = ex.getMessage().indexOf("Indexed or mapped properties are not supported");
-            assertTrue("Unexpected exception message", index >= 0);
+            assertTrue(index >= 0, "Unexpected exception message");
         }
     }
 
+    @Test
     public void testNestedWithIndex() throws Exception {
         final NestedTestBean nestedBean = new NestedTestBean("base");
         nestedBean.init();
@@ -2274,62 +2418,68 @@ public class PropertyUtilsTestCase extends TestCase {
         // test first calling properties on indexed beans
 
         value = (NestedTestBean) PropertyUtils.getProperty(nestedBean, "indexedProperty[0]");
-        assertEquals("Cannot get simple index(1)", "Bean@0", value.getName());
-        assertEquals("Bug in NestedTestBean", "NOT SET", value.getTestString());
+        assertEquals("Bean@0", value.getName(), "Cannot get simple index(1)");
+        assertEquals("NOT SET", value.getTestString(), "Bug in NestedTestBean");
 
         value = (NestedTestBean) PropertyUtils.getProperty(nestedBean, "indexedProperty[1]");
-        assertEquals("Cannot get simple index(1)", "Bean@1", value.getName());
-        assertEquals("Bug in NestedTestBean", "NOT SET", value.getTestString());
+        assertEquals("Bean@1", value.getName(), "Cannot get simple index(1)");
+        assertEquals("NOT SET", value.getTestString(), "Bug in NestedTestBean");
 
         String prop = (String) PropertyUtils.getProperty(nestedBean, "indexedProperty[0].testString");
-        assertEquals("Get property on indexes failed (1)", "NOT SET", prop);
+        assertEquals("NOT SET", prop, "Get property on indexes failed (1)");
 
         prop = (String) PropertyUtils.getProperty(nestedBean, "indexedProperty[1].testString");
-        assertEquals("Get property on indexes failed (2)", "NOT SET", prop);
+        assertEquals("NOT SET", prop, "Get property on indexes failed (2)");
 
         PropertyUtils.setProperty(nestedBean, "indexedProperty[0].testString", "Test#1");
-        assertEquals("Cannot set property on indexed bean (1)", "Test#1", nestedBean.getIndexedProperty(0).getTestString());
+        assertEquals("Test#1", nestedBean.getIndexedProperty(0).getTestString(),
+                                "Cannot set property on indexed bean (1)");
 
         PropertyUtils.setProperty(nestedBean, "indexedProperty[1].testString", "Test#2");
-        assertEquals("Cannot set property on indexed bean (2)", "Test#2", nestedBean.getIndexedProperty(1).getTestString());
+        assertEquals("Test#2", nestedBean.getIndexedProperty(1).getTestString(),
+                                "Cannot set property on indexed bean (2)");
 
         // test first calling indexed properties on a simple property
 
         value = (NestedTestBean) PropertyUtils.getProperty(nestedBean, "simpleBeanProperty");
-        assertEquals("Cannot get simple bean", "Simple Property Bean", value.getName());
-        assertEquals("Bug in NestedTestBean", "NOT SET", value.getTestString());
+        assertEquals("Simple Property Bean", value.getName(), "Cannot get simple bean");
+        assertEquals("NOT SET", value.getTestString(), "Bug in NestedTestBean");
 
         value = (NestedTestBean) PropertyUtils.getProperty(nestedBean, "simpleBeanProperty.indexedProperty[3]");
-        assertEquals("Cannot get index property on property", "Bean@3", value.getName());
-        assertEquals("Bug in NestedTestBean", "NOT SET", value.getTestString());
+        assertEquals("Bean@3", value.getName(), "Cannot get index property on property");
+        assertEquals("NOT SET", value.getTestString(), "Bug in NestedTestBean");
 
         PropertyUtils.setProperty(nestedBean, "simpleBeanProperty.indexedProperty[3].testString", "Test#3");
-        assertEquals("Cannot set property on indexed property on property", "Test#3", nestedBean.getSimpleBeanProperty().getIndexedProperty(3).getTestString());
+        assertEquals("Test#3", nestedBean.getSimpleBeanProperty().getIndexedProperty(3).getTestString(),
+                                "Cannot set property on indexed property on property");
     }
 
     /**
      * Tests whether a BeanIntrospector can be removed.
      */
+    @Test
     public void testRemoveBeanIntrospector() {
-        assertTrue("Wrong result", PropertyUtils.removeBeanIntrospector(DefaultBeanIntrospector.INSTANCE));
+        assertTrue(PropertyUtils.removeBeanIntrospector(DefaultBeanIntrospector.INSTANCE), "Wrong result");
         final PropertyDescriptor[] desc = PropertyUtils.getPropertyDescriptors(AlphaBean.class);
-        assertEquals("Got descriptors", 0, desc.length);
+        assertEquals(0, desc.length, "Got descriptors");
         PropertyUtils.addBeanIntrospector(DefaultBeanIntrospector.INSTANCE);
     }
 
     /**
      * Tests whether a reset of the registered BeanIntrospectors can be performed.
      */
+    @Test
     public void testResetBeanIntrospectors() {
-        assertTrue("Wrong result", PropertyUtils.removeBeanIntrospector(DefaultBeanIntrospector.INSTANCE));
+        assertTrue(PropertyUtils.removeBeanIntrospector(DefaultBeanIntrospector.INSTANCE), "Wrong result");
         PropertyUtils.resetBeanIntrospectors();
         final PropertyDescriptor[] desc = PropertyUtils.getPropertyDescriptors(AlphaBean.class);
-        assertTrue("Got no descriptors", desc.length > 0);
+        assertTrue(desc.length > 0, "Got no descriptors");
     }
 
     /**
      * Corner cases on setIndexedProperty invalid arguments.
      */
+    @Test
     public void testSetIndexedArguments() {
         // Use explicit index argument
         assertThrows(NullPointerException.class, () -> PropertyUtils.setIndexedProperty(null, "intArray", 0, Integer.valueOf(1)));
@@ -2350,23 +2500,25 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setting an indexed value out of a multi-dimensional array
      */
+    @Test
     public void testSetIndexedArray() {
         final String[] firstArray = { "FIRST-1", "FIRST-2", "FIRST-3" };
         final String[] secondArray = { "SECOND-1", "SECOND-2", "SECOND-3", "SECOND-4" };
         final String[][] mainArray = { firstArray, secondArray };
         final TestBean bean = new TestBean(mainArray);
-        assertEquals("BEFORE", "SECOND-3", bean.getString2dArray(1)[2]);
+        assertEquals("SECOND-3", bean.getString2dArray(1)[2], "BEFORE");
         try {
             PropertyUtils.setProperty(bean, "string2dArray[1][2]", "SECOND-3-UPDATED");
         } catch (final Throwable t) {
             fail("Threw " + t + "");
         }
-        assertEquals("AFTER", "SECOND-3-UPDATED", bean.getString2dArray(1)[2]);
+        assertEquals("SECOND-3-UPDATED", bean.getString2dArray(1)[2], "AFTER");
     }
 
     /**
      * Test setting an indexed value out of List of Lists
      */
+    @Test
     public void testSetIndexedList() {
         final String[] firstArray = { "FIRST-1", "FIRST-2", "FIRST-3" };
         final String[] secondArray = { "SECOND-1", "SECOND-2", "SECOND-3", "SECOND-4" };
@@ -2374,18 +2526,19 @@ public class PropertyUtilsTestCase extends TestCase {
         mainList.add(Arrays.asList(firstArray));
         mainList.add(Arrays.asList(secondArray));
         final TestBean bean = new TestBean(mainList);
-        assertEquals("BEFORE", "SECOND-4", ((List<?>) bean.getListIndexed().get(1)).get(3));
+        assertEquals("SECOND-4", ((List<?>) bean.getListIndexed().get(1)).get(3), "BEFORE");
         try {
             PropertyUtils.setProperty(bean, "listIndexed[1][3]", "SECOND-4-UPDATED");
         } catch (final Throwable t) {
             fail("Threw " + t + "");
         }
-        assertEquals("AFTER", "SECOND-4-UPDATED", ((List<?>) bean.getListIndexed().get(1)).get(3));
+        assertEquals("SECOND-4-UPDATED", ((List<?>) bean.getListIndexed().get(1)).get(3), "AFTER");
     }
 
     /**
      * Test setting a value out of a mapped Map
      */
+    @Test
     public void testSetIndexedMap() {
         final Map<String, Object> firstMap = new HashMap<>();
         firstMap.put("FIRST-KEY-1", "FIRST-VALUE-1");
@@ -2399,21 +2552,25 @@ public class PropertyUtilsTestCase extends TestCase {
         mainList.add(secondMap);
         final TestBean bean = new TestBean(mainList);
 
-        assertEquals("BEFORE", null, ((Map<?, ?>) bean.getListIndexed().get(0)).get("FIRST-NEW-KEY"));
-        assertEquals("BEFORE", "SECOND-VALUE-1", ((Map<?, ?>) bean.getListIndexed().get(1)).get("SECOND-KEY-1"));
+        assertEquals(null, ((Map<?, ?>) bean.getListIndexed().get(0)).get("FIRST-NEW-KEY"), "BEFORE");
+        assertEquals("SECOND-VALUE-1", ((Map<?, ?>) bean.getListIndexed().get(1)).get("SECOND-KEY-1"),
+                                "BEFORE");
         try {
             PropertyUtils.setProperty(bean, "listIndexed[0](FIRST-NEW-KEY)", "FIRST-NEW-VALUE");
             PropertyUtils.setProperty(bean, "listIndexed[1](SECOND-KEY-1)", "SECOND-VALUE-1-UPDATED");
         } catch (final Throwable t) {
             fail("Threw " + t + "");
         }
-        assertEquals("BEFORE", "FIRST-NEW-VALUE", ((Map<?, ?>) bean.getListIndexed().get(0)).get("FIRST-NEW-KEY"));
-        assertEquals("AFTER", "SECOND-VALUE-1-UPDATED", ((Map<?, ?>) bean.getListIndexed().get(1)).get("SECOND-KEY-1"));
+        assertEquals("FIRST-NEW-VALUE", ((Map<?, ?>) bean.getListIndexed().get(0)).get("FIRST-NEW-KEY"),
+                                "BEFORE");
+        assertEquals("SECOND-VALUE-1-UPDATED", ((Map<?, ?>) bean.getListIndexed().get(1)).get("SECOND-KEY-1"),
+                                "AFTER");
     }
 
     /**
      * Positive and negative tests on setIndexedProperty valid arguments.
      */
+    @Test
     public void testSetIndexedValues() {
 
         Object value = null;
@@ -2423,9 +2580,9 @@ public class PropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "dupProperty", 0, "New 0");
             value = PropertyUtils.getIndexedProperty(bean, "dupProperty", 0);
-            assertNotNull("Returned new value 0", value);
-            assertTrue("Returned String new value 0", value instanceof String);
-            assertEquals("Returned correct new value 0", "New 0", (String) value);
+            assertNotNull(value, "Returned new value 0");
+            assertTrue(value instanceof String, "Returned String new value 0");
+            assertEquals("New 0", (String) value, "Returned correct new value 0");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -2433,9 +2590,9 @@ public class PropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "intArray", 0, Integer.valueOf(1));
             value = PropertyUtils.getIndexedProperty(bean, "intArray", 0);
-            assertNotNull("Returned new value 0", value);
-            assertTrue("Returned Integer new value 0", value instanceof Integer);
-            assertEquals("Returned correct new value 0", 1, ((Integer) value).intValue());
+            assertNotNull(value, "Returned new value 0");
+            assertTrue(value instanceof Integer, "Returned Integer new value 0");
+            assertEquals(1, ((Integer) value).intValue(), "Returned correct new value 0");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -2443,9 +2600,9 @@ public class PropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "intIndexed", 1, Integer.valueOf(11));
             value = PropertyUtils.getIndexedProperty(bean, "intIndexed", 1);
-            assertNotNull("Returned new value 1", value);
-            assertTrue("Returned Integer new value 1", value instanceof Integer);
-            assertEquals("Returned correct new value 1", 11, ((Integer) value).intValue());
+            assertNotNull(value, "Returned new value 1");
+            assertTrue(value instanceof Integer, "Returned Integer new value 1");
+            assertEquals(11, ((Integer) value).intValue(), "Returned correct new value 1");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -2453,9 +2610,9 @@ public class PropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "listIndexed", 2, "New Value 2");
             value = PropertyUtils.getIndexedProperty(bean, "listIndexed", 2);
-            assertNotNull("Returned new value 2", value);
-            assertTrue("Returned String new value 2", value instanceof String);
-            assertEquals("Returned correct new value 2", "New Value 2", (String) value);
+            assertNotNull(value, "Returned new value 2");
+            assertTrue(value instanceof String, "Returned String new value 2");
+            assertEquals("New Value 2", (String) value, "Returned correct new value 2");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -2463,9 +2620,9 @@ public class PropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "stringArray", 2, "New Value 2");
             value = PropertyUtils.getIndexedProperty(bean, "stringArray", 2);
-            assertNotNull("Returned new value 2", value);
-            assertTrue("Returned String new value 2", value instanceof String);
-            assertEquals("Returned correct new value 2", "New Value 2", (String) value);
+            assertNotNull(value, "Returned new value 2");
+            assertTrue(value instanceof String, "Returned String new value 2");
+            assertEquals("New Value 2", (String) value, "Returned correct new value 2");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -2473,9 +2630,9 @@ public class PropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "stringArray", 3, "New Value 3");
             value = PropertyUtils.getIndexedProperty(bean, "stringArray", 3);
-            assertNotNull("Returned new value 3", value);
-            assertTrue("Returned String new value 3", value instanceof String);
-            assertEquals("Returned correct new value 3", "New Value 3", (String) value);
+            assertNotNull(value, "Returned new value 3");
+            assertTrue(value instanceof String, "Returned String new value 3");
+            assertEquals("New Value 3", (String) value, "Returned correct new value 3");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -2485,9 +2642,9 @@ public class PropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "dupProperty[4]", "New 4");
             value = PropertyUtils.getIndexedProperty(bean, "dupProperty[4]");
-            assertNotNull("Returned new value 4", value);
-            assertTrue("Returned String new value 4", value instanceof String);
-            assertEquals("Returned correct new value 4", "New 4", (String) value);
+            assertNotNull(value, "Returned new value 4");
+            assertTrue(value instanceof String, "Returned String new value 4");
+            assertEquals("New 4", (String) value, "Returned correct new value 4");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -2495,9 +2652,9 @@ public class PropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "intArray[4]", Integer.valueOf(1));
             value = PropertyUtils.getIndexedProperty(bean, "intArray[4]");
-            assertNotNull("Returned new value 4", value);
-            assertTrue("Returned Integer new value 4", value instanceof Integer);
-            assertEquals("Returned correct new value 4", 1, ((Integer) value).intValue());
+            assertNotNull(value, "Returned new value 4");
+            assertTrue(value instanceof Integer, "Returned Integer new value 4");
+            assertEquals(1, ((Integer) value).intValue(), "Returned correct new value 4");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -2505,9 +2662,9 @@ public class PropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "intIndexed[3]", Integer.valueOf(11));
             value = PropertyUtils.getIndexedProperty(bean, "intIndexed[3]");
-            assertNotNull("Returned new value 5", value);
-            assertTrue("Returned Integer new value 5", value instanceof Integer);
-            assertEquals("Returned correct new value 5", 11, ((Integer) value).intValue());
+            assertNotNull(value, "Returned new value 5");
+            assertTrue(value instanceof Integer, "Returned Integer new value 5");
+            assertEquals(11, ((Integer) value).intValue(), "Returned correct new value 5");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -2515,9 +2672,9 @@ public class PropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "listIndexed[1]", "New Value 2");
             value = PropertyUtils.getIndexedProperty(bean, "listIndexed[1]");
-            assertNotNull("Returned new value 6", value);
-            assertTrue("Returned String new value 6", value instanceof String);
-            assertEquals("Returned correct new value 6", "New Value 2", (String) value);
+            assertNotNull(value, "Returned new value 6");
+            assertTrue(value instanceof String, "Returned String new value 6");
+            assertEquals("New Value 2", (String) value, "Returned correct new value 6");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -2525,9 +2682,9 @@ public class PropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "stringArray[1]", "New Value 2");
             value = PropertyUtils.getIndexedProperty(bean, "stringArray[2]");
-            assertNotNull("Returned new value 6", value);
-            assertTrue("Returned String new value 6", value instanceof String);
-            assertEquals("Returned correct new value 6", "New Value 2", (String) value);
+            assertNotNull(value, "Returned new value 6");
+            assertTrue(value instanceof String, "Returned String new value 6");
+            assertEquals("New Value 2", (String) value, "Returned correct new value 6");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -2535,9 +2692,9 @@ public class PropertyUtilsTestCase extends TestCase {
         try {
             PropertyUtils.setIndexedProperty(bean, "stringArray[0]", "New Value 3");
             value = PropertyUtils.getIndexedProperty(bean, "stringArray[0]");
-            assertNotNull("Returned new value 7", value);
-            assertTrue("Returned String new value 7", value instanceof String);
-            assertEquals("Returned correct new value 7", "New Value 3", (String) value);
+            assertNotNull(value, "Returned new value 7");
+            assertTrue(value instanceof String, "Returned String new value 7");
+            assertEquals("New Value 3", (String) value, "Returned correct new value 7");
         } catch (final Throwable t) {
             fail("Threw " + t);
         }
@@ -2657,6 +2814,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Corner cases on getMappedProperty invalid arguments.
      */
+    @Test
     public void testSetMappedArguments() {
         // Use explicit key argument
         assertThrows(NullPointerException.class, () -> PropertyUtils.setMappedProperty(null, "mappedProperty", "First Key", "First Value"));
@@ -2671,23 +2829,25 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setting an indexed value out of a mapped array
      */
+    @Test
     public void testSetMappedArray() {
         final TestBean bean = new TestBean();
         final String[] array = { "abc", "def", "ghi" };
         bean.getMapProperty().put("mappedArray", array);
 
-        assertEquals("BEFORE", "def", ((String[]) bean.getMapProperty().get("mappedArray"))[1]);
+        assertEquals("def", ((String[]) bean.getMapProperty().get("mappedArray"))[1], "BEFORE");
         try {
             PropertyUtils.setProperty(bean, "mapProperty(mappedArray)[1]", "DEF-UPDATED");
         } catch (final Throwable t) {
             fail("Threw " + t + "");
         }
-        assertEquals("AFTER", "DEF-UPDATED", ((String[]) bean.getMapProperty().get("mappedArray"))[1]);
+        assertEquals("DEF-UPDATED", ((String[]) bean.getMapProperty().get("mappedArray"))[1], "AFTER");
     }
 
     /**
      * Test setting an indexed value out of a mapped List
      */
+    @Test
     public void testSetMappedList() {
         final TestBean bean = new TestBean();
         final List<Object> list = new ArrayList<>();
@@ -2696,18 +2856,19 @@ public class PropertyUtilsTestCase extends TestCase {
         list.add("qrs");
         bean.getMapProperty().put("mappedList", list);
 
-        assertEquals("BEFORE", "klm", ((List<?>) bean.getMapProperty().get("mappedList")).get(0));
+        assertEquals("klm", ((List<?>) bean.getMapProperty().get("mappedList")).get(0), "BEFORE");
         try {
             PropertyUtils.setProperty(bean, "mapProperty(mappedList)[0]", "KLM-UPDATED");
         } catch (final Throwable t) {
             fail("Threw " + t + "");
         }
-        assertEquals("AFTER", "KLM-UPDATED", ((List<?>) bean.getMapProperty().get("mappedList")).get(0));
+        assertEquals("KLM-UPDATED", ((List<?>) bean.getMapProperty().get("mappedList")).get(0), "AFTER");
     }
 
     /**
      * Test setting a value out of a mapped Map
      */
+    @Test
     public void testSetMappedMap() {
         final TestBean bean = new TestBean();
         final Map<String, Object> map = new HashMap<>();
@@ -2716,37 +2877,42 @@ public class PropertyUtilsTestCase extends TestCase {
         map.put("sub-key-3", "sub-value-3");
         bean.getMapProperty().put("mappedMap", map);
 
-        assertEquals("BEFORE", "sub-value-3", ((Map<?, ?>) bean.getMapProperty().get("mappedMap")).get("sub-key-3"));
+        assertEquals("sub-value-3", ((Map<?, ?>) bean.getMapProperty().get("mappedMap")).get("sub-key-3"),
+                                "BEFORE");
         try {
             PropertyUtils.setProperty(bean, "mapProperty(mappedMap)(sub-key-3)", "SUB-KEY-3-UPDATED");
         } catch (final Throwable t) {
             fail("Threw " + t + "");
         }
-        assertEquals("AFTER", "SUB-KEY-3-UPDATED", ((Map<?, ?>) bean.getMapProperty().get("mappedMap")).get("sub-key-3"));
+        assertEquals("SUB-KEY-3-UPDATED", ((Map<?, ?>) bean.getMapProperty().get("mappedMap")).get("sub-key-3"),
+                                "AFTER");
     }
 
     /**
      * Test setting mapped values with periods in the key.
      */
+    @Test
     public void testSetMappedPeriods() {
 
         // PropertyUtils.setMappedProperty()--------
         bean.setMappedProperty("key.with.a.dot", "Special Value");
-        assertEquals("Can retrieve directly (A)", "Special Value", bean.getMappedProperty("key.with.a.dot"));
+        assertEquals("Special Value", bean.getMappedProperty("key.with.a.dot"), "Can retrieve directly (A)");
 
         try {
             PropertyUtils.setMappedProperty(bean, "mappedProperty", "key.with.a.dot", "Updated Special Value");
-            assertEquals("Check set via setMappedProperty", "Updated Special Value", bean.getMappedProperty("key.with.a.dot"));
+            assertEquals("Updated Special Value", bean.getMappedProperty("key.with.a.dot"),
+                                    "Check set via setMappedProperty");
         } catch (final Exception e) {
             fail("Thew exception: " + e);
         }
 
         // PropertyUtils.setNestedProperty()
         bean.setMappedProperty("key.with.a.dot", "Special Value");
-        assertEquals("Can retrieve directly (B)", "Special Value", bean.getMappedProperty("key.with.a.dot"));
+        assertEquals("Special Value", bean.getMappedProperty("key.with.a.dot"), "Can retrieve directly (B)");
         try {
             PropertyUtils.setNestedProperty(bean, "mappedProperty(key.with.a.dot)", "Updated Special Value");
-            assertEquals("Check set via setNestedProperty (B)", "Updated Special Value", bean.getMappedProperty("key.with.a.dot"));
+            assertEquals("Updated Special Value", bean.getMappedProperty("key.with.a.dot"),
+                                    "Check set via setNestedProperty (B)");
         } catch (final Exception e) {
             fail("Thew exception: " + e);
         }
@@ -2754,10 +2920,11 @@ public class PropertyUtilsTestCase extends TestCase {
         // PropertyUtils.setNestedProperty()
         final TestBean testBean = new TestBean();
         bean.setMappedObjects("nested.property", testBean);
-        assertEquals("Can retrieve directly (C)", "This is a string", testBean.getStringProperty());
+        assertEquals("This is a string", testBean.getStringProperty(), "Can retrieve directly (C)");
         try {
             PropertyUtils.setNestedProperty(bean, "mappedObjects(nested.property).stringProperty", "Updated String Value");
-            assertEquals("Check set via setNestedProperty (C)", "Updated String Value", testBean.getStringProperty());
+            assertEquals("Updated String Value", testBean.getStringProperty(),
+                                    "Check set via setNestedProperty (C)");
         } catch (final Exception e) {
             fail("Thew exception: " + e);
         }
@@ -2765,11 +2932,13 @@ public class PropertyUtilsTestCase extends TestCase {
         // PropertyUtils.setNestedProperty()
         bean.getNested().setMappedProperty("Mapped Key", "Nested Mapped Value");
         try {
-            assertEquals("Can retrieve via getNestedProperty (D)", "Nested Mapped Value",
-                    PropertyUtils.getNestedProperty(bean, "nested.mappedProperty(Mapped Key)"));
+            assertEquals("Nested Mapped Value",
+                                    PropertyUtils.getNestedProperty(bean, "nested.mappedProperty(Mapped Key)"),
+                                    "Can retrieve via getNestedProperty (D)");
             PropertyUtils.setNestedProperty(bean, "nested.mappedProperty(Mapped Key)", "Updated Nested Mapped Value");
-            assertEquals("Check set via setNestedProperty (D)", "Updated Nested Mapped Value",
-                    PropertyUtils.getNestedProperty(bean, "nested.mappedProperty(Mapped Key)"));
+            assertEquals("Updated Nested Mapped Value",
+                                    PropertyUtils.getNestedProperty(bean, "nested.mappedProperty(Mapped Key)"),
+                                    "Check set via setNestedProperty (D)");
         } catch (final Exception e) {
             fail("Thew exception: " + e);
         }
@@ -2778,6 +2947,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Positive and negative tests on setMappedProperty valid arguments.
      */
+    @Test
     public void testSetMappedValues() {
 
         Object value = null;
@@ -2786,7 +2956,7 @@ public class PropertyUtilsTestCase extends TestCase {
 
         try {
             value = PropertyUtils.getMappedProperty(bean, "mappedProperty", "Fourth Key");
-            assertNull("Can not find fourth value", value);
+            assertNull(value, "Can not find fourth value");
         } catch (final Throwable t) {
             fail("Finding fourth value threw " + t);
         }
@@ -2799,7 +2969,7 @@ public class PropertyUtilsTestCase extends TestCase {
 
         try {
             value = PropertyUtils.getMappedProperty(bean, "mappedProperty", "Fourth Key");
-            assertEquals("Can find fourth value", "Fourth Value", value);
+            assertEquals("Fourth Value", value, "Can find fourth value");
         } catch (final Throwable t) {
             fail("Finding fourth value threw " + t);
         }
@@ -2808,7 +2978,7 @@ public class PropertyUtilsTestCase extends TestCase {
 
         try {
             value = PropertyUtils.getMappedProperty(bean, "mappedProperty(Fifth Key)");
-            assertNull("Can not find fifth value", value);
+            assertNull(value, "Can not find fifth value");
         } catch (final Throwable t) {
             fail("Finding fifth value threw " + t);
         }
@@ -2821,7 +2991,7 @@ public class PropertyUtilsTestCase extends TestCase {
 
         try {
             value = PropertyUtils.getMappedProperty(bean, "mappedProperty(Fifth Key)");
-            assertEquals("Can find fifth value", "Fifth Value", value);
+            assertEquals("Fifth Value", value, "Can find fifth value");
         } catch (final Throwable t) {
             fail("Finding fifth value threw " + t);
         }
@@ -2830,7 +3000,7 @@ public class PropertyUtilsTestCase extends TestCase {
 
         try {
             value = PropertyUtils.getNestedProperty(bean, "mapProperty.Sixth Key");
-            assertNull("Can not find sixth value", value);
+            assertNull(value, "Can not find sixth value");
         } catch (final Throwable t) {
             fail("Finding fifth value threw " + t);
         }
@@ -2843,7 +3013,7 @@ public class PropertyUtilsTestCase extends TestCase {
 
         try {
             value = PropertyUtils.getNestedProperty(bean, "mapProperty.Sixth Key");
-            assertEquals("Can find sixth value", "Sixth Value", value);
+            assertEquals("Sixth Value", value, "Can find sixth value");
         } catch (final Throwable t) {
             fail("Finding sixth value threw " + t);
         }
@@ -2853,6 +3023,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Corner cases on setNestedProperty invalid arguments.
      */
+    @Test
     public void testSetNestedArguments() {
         assertThrows(NullPointerException.class, () -> PropertyUtils.setNestedProperty(null, "stringProperty", ""));
         assertThrows(NullPointerException.class, () -> PropertyUtils.setNestedProperty(bean, null, ""));
@@ -2861,13 +3032,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setNextedProperty on a boolean property.
      */
+    @Test
     public void testSetNestedBoolean() {
 
         try {
             final boolean oldValue = bean.getNested().getBooleanProperty();
             final boolean newValue = !oldValue;
             PropertyUtils.setNestedProperty(bean, "nested.booleanProperty", Boolean.valueOf(newValue));
-            assertEquals("Matched new value", newValue, bean.getNested().getBooleanProperty());
+            assertEquals(newValue, bean.getNested().getBooleanProperty(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -2883,13 +3055,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setNestedProperty on a double property.
      */
+    @Test
     public void testSetNestedDouble() {
 
         try {
             final double oldValue = bean.getNested().getDoubleProperty();
             final double newValue = oldValue + 1.0;
             PropertyUtils.setNestedProperty(bean, "nested.doubleProperty", Double.valueOf(newValue));
-            assertEquals("Matched new value", newValue, bean.getNested().getDoubleProperty(), 0.005);
+            assertEquals(newValue, bean.getNested().getDoubleProperty(), 0.005, "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -2905,13 +3078,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setNestedProperty on a float property.
      */
+    @Test
     public void testSetNestedFloat() {
 
         try {
             final float oldValue = bean.getNested().getFloatProperty();
             final float newValue = oldValue + (float) 1.0;
             PropertyUtils.setNestedProperty(bean, "nested.floatProperty", Float.valueOf(newValue));
-            assertEquals("Matched new value", newValue, bean.getNested().getFloatProperty(), (float) 0.005);
+            assertEquals(newValue, bean.getNested().getFloatProperty(), (float) 0.005, "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -2927,13 +3101,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setNestedProperty on a int property.
      */
+    @Test
     public void testSetNestedInt() {
 
         try {
             final int oldValue = bean.getNested().getIntProperty();
             final int newValue = oldValue + 1;
             PropertyUtils.setNestedProperty(bean, "nested.intProperty", Integer.valueOf(newValue));
-            assertEquals("Matched new value", newValue, bean.getNested().getIntProperty());
+            assertEquals(newValue, bean.getNested().getIntProperty(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -2949,13 +3124,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setNestedProperty on a long property.
      */
+    @Test
     public void testSetNestedLong() {
 
         try {
             final long oldValue = bean.getNested().getLongProperty();
             final long newValue = oldValue + 1;
             PropertyUtils.setNestedProperty(bean, "nested.longProperty", Long.valueOf(newValue));
-            assertEquals("Matched new value", newValue, bean.getNested().getLongProperty());
+            assertEquals(newValue, bean.getNested().getLongProperty(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -2971,6 +3147,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setNestedProperty on a read-only String property.
      */
+    @Test
     public void testSetNestedReadOnly() {
 
         try {
@@ -2993,6 +3170,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setNestedProperty on a short property.
      */
+    @Test
     public void testSetNestedShort() {
 
         try {
@@ -3000,7 +3178,7 @@ public class PropertyUtilsTestCase extends TestCase {
             short newValue = oldValue;
             newValue++;
             PropertyUtils.setNestedProperty(bean, "nested.shortProperty", Short.valueOf(newValue));
-            assertEquals("Matched new value", newValue, bean.getNested().getShortProperty());
+            assertEquals(newValue, bean.getNested().getShortProperty(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -3016,13 +3194,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setNestedProperty on a String property.
      */
+    @Test
     public void testSetNestedString() {
 
         try {
             final String oldValue = bean.getNested().getStringProperty();
             final String newValue = oldValue + " Extra Value";
             PropertyUtils.setNestedProperty(bean, "nested.stringProperty", newValue);
-            assertEquals("Matched new value", newValue, bean.getNested().getStringProperty());
+            assertEquals(newValue, bean.getNested().getStringProperty(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -3038,6 +3217,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setNestedProperty on an unknown property name.
      */
+    @Test
     public void testSetNestedUnknown() {
 
         try {
@@ -3059,13 +3239,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setNestedProperty on a write-only String property.
      */
+    @Test
     public void testSetNestedWriteOnly() {
 
         try {
             final String oldValue = bean.getNested().getWriteOnlyPropertyValue();
             final String newValue = oldValue + " Extra Value";
             PropertyUtils.setNestedProperty(bean, "nested.writeOnlyProperty", newValue);
-            assertEquals("Matched new value", newValue, bean.getNested().getWriteOnlyPropertyValue());
+            assertEquals(newValue, bean.getNested().getWriteOnlyPropertyValue(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -3078,28 +3259,31 @@ public class PropertyUtilsTestCase extends TestCase {
 
     }
 
+    @Test
     public void testSetNoGetter() throws Exception {
         final BetaBean bean = new BetaBean("Cedric");
 
         // test standard no getter
         bean.setNoGetterProperty("Sigma");
-        assertEquals("BetaBean test failed", "Sigma", bean.getSecret());
+        assertEquals("Sigma", bean.getSecret(), "BetaBean test failed");
 
-        assertNotNull("Descriptor is null", PropertyUtils.getPropertyDescriptor(bean, "noGetterProperty"));
+        assertNotNull(PropertyUtils.getPropertyDescriptor(bean, "noGetterProperty"), "Descriptor is null");
 
         BeanUtils.setProperty(bean, "noGetterProperty", "Omega");
-        assertEquals("Cannot set no-getter property", "Omega", bean.getSecret());
+        assertEquals("Omega", bean.getSecret(), "Cannot set no-getter property");
 
         // test mapped no getter descriptor
-        assertNotNull("Map Descriptor is null", PropertyUtils.getPropertyDescriptor(bean, "noGetterMappedProperty"));
+        assertNotNull(PropertyUtils.getPropertyDescriptor(bean, "noGetterMappedProperty"),
+                                 "Map Descriptor is null");
 
         PropertyUtils.setMappedProperty(bean, "noGetterMappedProperty", "Epsilon", "Epsilon");
-        assertEquals("Cannot set mapped no-getter property", "MAP:Epsilon", bean.getSecret());
+        assertEquals("MAP:Epsilon", bean.getSecret(), "Cannot set mapped no-getter property");
     }
 
     /**
      * Test accessing a public sub-bean of a package scope bean
      */
+    @Test
     public void testSetPublicSubBean_of_PackageBean() {
 
         final PublicSubBean bean = new PublicSubBean();
@@ -3112,7 +3296,7 @@ public class PropertyUtilsTestCase extends TestCase {
         } catch (final Throwable t) {
             fail("setProperty(foo) threw " + t);
         }
-        assertEquals("foo property", "foo-updated", bean.getFoo());
+        assertEquals("foo-updated", bean.getFoo(), "foo property");
 
         // Set Bar
         try {
@@ -3120,12 +3304,13 @@ public class PropertyUtilsTestCase extends TestCase {
         } catch (final Throwable t) {
             fail("setProperty(bar) threw " + t);
         }
-        assertEquals("bar property", "bar-updated", bean.getBar());
+        assertEquals("bar-updated", bean.getBar(), "bar property");
     }
 
     /**
      * Corner cases on setSimpleProperty invalid arguments.
      */
+    @Test
     public void testSetSimpleArguments() {
         assertThrows(NullPointerException.class, () -> PropertyUtils.setSimpleProperty(null, "stringProperty", ""));
         assertThrows(NullPointerException.class, () -> PropertyUtils.setSimpleProperty(bean, null, ""));
@@ -3134,13 +3319,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setSimpleProperty on a boolean property.
      */
+    @Test
     public void testSetSimpleBoolean() {
 
         try {
             final boolean oldValue = bean.getBooleanProperty();
             final boolean newValue = !oldValue;
             PropertyUtils.setSimpleProperty(bean, "booleanProperty", Boolean.valueOf(newValue));
-            assertEquals("Matched new value", newValue, bean.getBooleanProperty());
+            assertEquals(newValue, bean.getBooleanProperty(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -3156,13 +3342,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setSimpleProperty on a double property.
      */
+    @Test
     public void testSetSimpleDouble() {
 
         try {
             final double oldValue = bean.getDoubleProperty();
             final double newValue = oldValue + 1.0;
             PropertyUtils.setSimpleProperty(bean, "doubleProperty", Double.valueOf(newValue));
-            assertEquals("Matched new value", newValue, bean.getDoubleProperty(), 0.005);
+            assertEquals(newValue, bean.getDoubleProperty(), 0.005, "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -3178,13 +3365,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setSimpleProperty on a float property.
      */
+    @Test
     public void testSetSimpleFloat() {
 
         try {
             final float oldValue = bean.getFloatProperty();
             final float newValue = oldValue + (float) 1.0;
             PropertyUtils.setSimpleProperty(bean, "floatProperty", Float.valueOf(newValue));
-            assertEquals("Matched new value", newValue, bean.getFloatProperty(), (float) 0.005);
+            assertEquals(newValue, bean.getFloatProperty(), (float) 0.005, "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -3200,6 +3388,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Negative test setSimpleProperty on an indexed property.
      */
+    @Test
     public void testSetSimpleIndexed() {
 
         try {
@@ -3220,13 +3409,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setSimpleProperty on a int property.
      */
+    @Test
     public void testSetSimpleInt() {
 
         try {
             final int oldValue = bean.getIntProperty();
             final int newValue = oldValue + 1;
             PropertyUtils.setSimpleProperty(bean, "intProperty", Integer.valueOf(newValue));
-            assertEquals("Matched new value", newValue, bean.getIntProperty());
+            assertEquals(newValue, bean.getIntProperty(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -3242,13 +3432,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setSimpleProperty on a long property.
      */
+    @Test
     public void testSetSimpleLong() {
 
         try {
             final long oldValue = bean.getLongProperty();
             final long newValue = oldValue + 1;
             PropertyUtils.setSimpleProperty(bean, "longProperty", Long.valueOf(newValue));
-            assertEquals("Matched new value", newValue, bean.getLongProperty());
+            assertEquals(newValue, bean.getLongProperty(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -3264,6 +3455,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Negative test setSimpleProperty on a nested property.
      */
+    @Test
     public void testSetSimpleNested() {
 
         try {
@@ -3284,6 +3476,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setSimpleProperty on a read-only String property.
      */
+    @Test
     public void testSetSimpleReadOnly() {
 
         try {
@@ -3299,7 +3492,9 @@ public class PropertyUtilsTestCase extends TestCase {
             fail("InvocationTargetException");
         } catch (final NoSuchMethodException e) {
             // Correct result for this test
-            assertEquals("Property 'readOnlyProperty' has no setter method in class '" + bean.getClass() + "'", e.getMessage());
+            assertEquals(
+                    "Property 'readOnlyProperty' has no setter method in class '" + bean.getClass() + "'",
+                    e.getMessage());
         }
 
     }
@@ -3307,6 +3502,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setSimpleProperty on a short property.
      */
+    @Test
     public void testSetSimpleShort() {
 
         try {
@@ -3314,7 +3510,7 @@ public class PropertyUtilsTestCase extends TestCase {
             short newValue = oldValue;
             newValue++;
             PropertyUtils.setSimpleProperty(bean, "shortProperty", Short.valueOf(newValue));
-            assertEquals("Matched new value", newValue, bean.getShortProperty());
+            assertEquals(newValue, bean.getShortProperty(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -3330,13 +3526,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setSimpleProperty on a String property.
      */
+    @Test
     public void testSetSimpleString() {
 
         try {
             final String oldValue = bean.getStringProperty();
             final String newValue = oldValue + " Extra Value";
             PropertyUtils.setSimpleProperty(bean, "stringProperty", newValue);
-            assertEquals("Matched new value", newValue, bean.getStringProperty());
+            assertEquals(newValue, bean.getStringProperty(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -3352,6 +3549,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setSimpleProperty on an unknown property name.
      */
+    @Test
     public void testSetSimpleUnknown() {
 
         try {
@@ -3374,13 +3572,14 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * Test setSimpleProperty on a write-only String property.
      */
+    @Test
     public void testSetSimpleWriteOnly() {
 
         try {
             final String oldValue = bean.getWriteOnlyPropertyValue();
             final String newValue = oldValue + " Extra Value";
             PropertyUtils.setSimpleProperty(bean, "writeOnlyProperty", newValue);
-            assertEquals("Matched new value", newValue, bean.getWriteOnlyPropertyValue());
+            assertEquals(newValue, bean.getWriteOnlyPropertyValue(), "Matched new value");
         } catch (final IllegalAccessException e) {
             fail("IllegalAccessException");
         } catch (final IllegalArgumentException e) {
@@ -3396,6 +3595,7 @@ public class PropertyUtilsTestCase extends TestCase {
     /**
      * When a bean has a null property which is reference by the standard access language, this should throw a NestedNullException.
      */
+    @Test
     public void testThrowNestedNull() throws Exception {
         final NestedTestBean nestedBean = new NestedTestBean("base");
         // don't init!

--- a/src/test/java/org/apache/commons/beanutils2/SuppressPropertiesBeanIntrospectorTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/SuppressPropertiesBeanIntrospectorTestCase.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
@@ -25,12 +28,12 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for {@code SuppressPropertiesBeanIntrospector}.
  */
-public class SuppressPropertiesBeanIntrospectorTestCase extends TestCase {
+public class SuppressPropertiesBeanIntrospectorTestCase {
 
     /**
      * A test implementation of IntrospectionContext which collects the properties which have been removed.
@@ -87,6 +90,7 @@ public class SuppressPropertiesBeanIntrospectorTestCase extends TestCase {
     /**
      * Tests that the set with properties to be removed cannot be modified.
      */
+    @Test
     public void testGetSuppressedPropertiesModify() {
         final SuppressPropertiesBeanIntrospector introspector = new SuppressPropertiesBeanIntrospector(Arrays.asList("p1", "p2"));
         final Set<String> properties = introspector.getSuppressedProperties();
@@ -101,6 +105,7 @@ public class SuppressPropertiesBeanIntrospectorTestCase extends TestCase {
     /**
      * Tries to create an instance without properties.
      */
+    @Test
     public void testInitNoPropertyNames() {
         assertThrows(NullPointerException.class, () -> new SuppressPropertiesBeanIntrospector(null));
     }
@@ -108,6 +113,7 @@ public class SuppressPropertiesBeanIntrospectorTestCase extends TestCase {
     /**
      * Tests that a defensive copy is created from the collection with properties to be removed.
      */
+    @Test
     public void testPropertyNamesDefensiveCopy() throws IntrospectionException {
         final Collection<String> properties = new HashSet<>();
         properties.add("prop1");
@@ -116,22 +122,25 @@ public class SuppressPropertiesBeanIntrospectorTestCase extends TestCase {
         final IntrospectionContextTestImpl context = new IntrospectionContextTestImpl();
 
         introspector.introspect(context);
-        assertEquals("Wrong number of removed properties", 1, context.getRemovedProperties().size());
-        assertTrue("Wrong removed property", context.getRemovedProperties().contains("prop1"));
+        assertEquals(1, context.getRemovedProperties().size(), "Wrong number of removed properties");
+        assertTrue(context.getRemovedProperties().contains("prop1"), "Wrong removed property");
     }
 
     /**
      * Tests whether the expected properties have been removed during introspection.
      */
+    @Test
     public void testRemovePropertiesDuringIntrospection() throws IntrospectionException {
         final String[] properties = { "test", "other", "oneMore" };
         final SuppressPropertiesBeanIntrospector introspector = new SuppressPropertiesBeanIntrospector(Arrays.asList(properties));
         final IntrospectionContextTestImpl context = new IntrospectionContextTestImpl();
 
         introspector.introspect(context);
-        assertEquals("Wrong number of removed properties", properties.length, context.getRemovedProperties().size());
+        assertEquals(properties.length, context.getRemovedProperties().size(),
+                                "Wrong number of removed properties");
         for (final String property : properties) {
-            assertTrue("Property not removed: " + property, context.getRemovedProperties().contains(property));
+            assertTrue(context.getRemovedProperties().contains(property),
+                                  "Property not removed: " + property);
         }
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/WrapDynaBeanTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/WrapDynaBeanTestCase.java
@@ -17,10 +17,22 @@
 
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>
@@ -28,19 +40,7 @@ import java.io.ObjectOutputStream;
  * provide similar levels of functionality.
  * </p>
  */
-
 public class WrapDynaBeanTestCase extends BasicDynaBeanTestCase {
-
-    /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public WrapDynaBeanTestCase(final String name) {
-
-        super(name);
-
-    }
 
     /**
      * Helper method for testing whether basic access to properties works as expected.
@@ -67,14 +67,14 @@ public class WrapDynaBeanTestCase extends BasicDynaBeanTestCase {
         final String testProperty = "stringProperty";
         final TestBean instance = (TestBean) ((WrapDynaBean) bean).getInstance();
         instance.setStringProperty(testValue);
-        assertEquals("Check String property", testValue, instance.getStringProperty());
+        assertEquals(testValue, instance.getStringProperty(), "Check String property");
 
         // Test Valid Get & Set
         try {
             testValue = "Some new value";
             bean.set(testProperty, testValue);
-            assertEquals("Test Set", testValue, instance.getStringProperty());
-            assertEquals("Test Get", testValue, bean.get(testProperty));
+            assertEquals(testValue, instance.getStringProperty(), "Test Set");
+            assertEquals(testValue, bean.get(testProperty), "Test Get");
         } catch (final IllegalArgumentException t) {
             fail("Get threw exception: " + t);
         }
@@ -114,6 +114,7 @@ public class WrapDynaBeanTestCase extends BasicDynaBeanTestCase {
      * Sets up instance variables required by this test case.
      */
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
 
         bean = new WrapDynaBean(new TestBean());
@@ -124,6 +125,7 @@ public class WrapDynaBeanTestCase extends BasicDynaBeanTestCase {
      * Tear down instance variables required by this test case.
      */
     @Override
+    @AfterEach
     public void tearDown() {
 
         bean = null;
@@ -131,36 +133,40 @@ public class WrapDynaBeanTestCase extends BasicDynaBeanTestCase {
     }
 
     /** Tests getInstance method */
+    @Test
     public void testGetInstance() {
         final AlphaBean alphaBean = new AlphaBean("Now On Air... John Peel");
         final WrapDynaBean dynaBean = new WrapDynaBean(alphaBean);
         final Object wrappedInstance = dynaBean.getInstance();
-        assertTrue("Object type is AlphaBean", wrappedInstance instanceof AlphaBean);
+        assertTrue(wrappedInstance instanceof AlphaBean, "Object type is AlphaBean");
         final AlphaBean wrappedAlphaBean = (AlphaBean) wrappedInstance;
-        assertSame("Same Object", wrappedAlphaBean, alphaBean);
+        assertSame(wrappedAlphaBean, alphaBean, "Same Object");
     }
 
     /**
      * Tests whether caching works for WrapDynaClass objects.
      */
+    @Test
     public void testGetWrapDynaClassFromCache() {
         final WrapDynaClass clazz = WrapDynaClass.createDynaClass(TestBean.class);
-        assertSame("Instance not cached", clazz, WrapDynaClass.createDynaClass(TestBean.class));
+        assertSame(clazz, WrapDynaClass.createDynaClass(TestBean.class), "Instance not cached");
     }
 
     /**
      * Tests whether the PropertyUtilsBean instance associated with a WrapDynaClass is taken into account when accessing an instance from the cache.
      */
+    @Test
     public void testGetWrapDynaClassFromCacheWithPropUtils() {
         final WrapDynaClass clazz = WrapDynaClass.createDynaClass(TestBean.class);
         final PropertyUtilsBean pu = new PropertyUtilsBean();
         final WrapDynaClass clazz2 = WrapDynaClass.createDynaClass(TestBean.class, pu);
-        assertNotSame("Got same instance from cache", clazz, clazz2);
+        assertNotSame(clazz, clazz2, "Got same instance from cache");
     }
 
     /**
      * The {@code set()} method.
      */
+    @Test
     public void testIndexedProperties() {
 
         // Invalid getter
@@ -184,14 +190,14 @@ public class WrapDynaBeanTestCase extends BasicDynaBeanTestCase {
         final String testProperty = "stringIndexed";
         final TestBean instance = (TestBean) ((WrapDynaBean) bean).getInstance();
         instance.setStringIndexed(0, testValue);
-        assertEquals("Check String property", testValue, instance.getStringIndexed(0));
+        assertEquals(testValue, instance.getStringIndexed(0), "Check String property");
 
         // Test Valid Get & Set
         try {
             testValue = "Some new value";
             bean.set(testProperty, 0, testValue);
-            assertEquals("Test Set", testValue, instance.getStringIndexed(0));
-            assertEquals("Test Get", testValue, bean.get(testProperty, 0));
+            assertEquals(testValue, instance.getStringIndexed(0), "Test Set");
+            assertEquals(testValue, bean.get(testProperty, 0), "Test Get");
         } catch (final IllegalArgumentException t) {
             fail("Get threw exception: " + t);
         }
@@ -201,16 +207,18 @@ public class WrapDynaBeanTestCase extends BasicDynaBeanTestCase {
     /**
      * Tests whether a WrapDynaClass can be provided when constructing a bean.
      */
+    @Test
     public void testInitWithDynaClass() {
         final WrapDynaClass clazz = WrapDynaClass.createDynaClass(TestBean.class);
         bean = new WrapDynaBean(new TestBean(), clazz);
-        assertSame("Wrong DynaClass", clazz, bean.getDynaClass());
+        assertSame(clazz, bean.getDynaClass(), "Wrong DynaClass");
         checkSimplePropertyAccess();
     }
 
     /**
      * Tests whether a custom PropertyUtilsBean instance can be used for introspection of bean properties.
      */
+    @Test
     public void testIntrospectionWithCustomPropUtils() {
         final PropertyUtilsBean pu = new PropertyUtilsBean();
         pu.addBeanIntrospector(new FluentPropertyBeanIntrospector());
@@ -218,17 +226,18 @@ public class WrapDynaBeanTestCase extends BasicDynaBeanTestCase {
         final FluentIntrospectionTestBean obj = new FluentIntrospectionTestBean();
         bean = new WrapDynaBean(obj, dynaClass);
         bean.set("fluentProperty", "testvalue");
-        assertEquals("Property not set", "testvalue", obj.getStringProperty());
+        assertEquals("testvalue", obj.getStringProperty(), "Property not set");
     }
 
     /**
      * The {@code contains()} method is not supported by the {@code WrapDynaBean} implementation class.
      */
     @Override
+    @Test
     public void testMappedContains() {
 
         try {
-            assertTrue("Can see first key", bean.contains("mappedProperty", "First Key"));
+            assertTrue(bean.contains("mappedProperty", "First Key"), "Can see first key");
             fail("Should have thrown UnsupportedOperationException");
         } catch (final UnsupportedOperationException t) {
             // Expected result
@@ -237,7 +246,7 @@ public class WrapDynaBeanTestCase extends BasicDynaBeanTestCase {
         }
 
         try {
-            assertTrue("Can not see unknown key", !bean.contains("mappedProperty", "Unknown Key"));
+            assertFalse(bean.contains("mappedProperty", "Unknown Key"), "Can not see unknown key");
             fail("Should have thrown UnsupportedOperationException");
         } catch (final UnsupportedOperationException t) {
             // Expected result
@@ -251,13 +260,14 @@ public class WrapDynaBeanTestCase extends BasicDynaBeanTestCase {
      * The {@code remove()} method is not supported by the {@code WrapDynaBean} implementation class.
      */
     @Override
+    @Test
     public void testMappedRemove() {
 
         try {
-            assertTrue("Can see first key", bean.contains("mappedProperty", "First Key"));
+            assertTrue(bean.contains("mappedProperty", "First Key"), "Can see first key");
             bean.remove("mappedProperty", "First Key");
             fail("Should have thrown UnsupportedOperationException");
-            // assertTrue("Can not see first key",
+            // Assert.assertTrue("Can not see first key",
             // !bean.contains("mappedProperty", "First Key"));
         } catch (final UnsupportedOperationException t) {
             // Expected result
@@ -266,10 +276,10 @@ public class WrapDynaBeanTestCase extends BasicDynaBeanTestCase {
         }
 
         try {
-            assertTrue("Can not see unknown key", !bean.contains("mappedProperty", "Unknown Key"));
+            assertFalse(bean.contains("mappedProperty", "Unknown Key"), "Can not see unknown key");
             bean.remove("mappedProperty", "Unknown Key");
             fail("Should have thrown UnsupportedOperationException");
-            // assertTrue("Can not see unknown key",
+            // Assert.assertTrue("Can not see unknown key",
             // !bean.contains("mappedProperty", "Unknown Key"));
         } catch (final UnsupportedOperationException t) {
             // Expected result
@@ -280,36 +290,39 @@ public class WrapDynaBeanTestCase extends BasicDynaBeanTestCase {
     }
 
     /** Tests the newInstance implementation for WrapDynaClass */
+    @Test
     public void testNewInstance() throws Exception {
         final WrapDynaClass dynaClass = WrapDynaClass.createDynaClass(AlphaBean.class);
         final Object createdInstance = dynaClass.newInstance();
-        assertTrue("Object type is WrapDynaBean", createdInstance instanceof WrapDynaBean);
+        assertInstanceOf(WrapDynaBean.class, createdInstance, "Object type is WrapDynaBean");
         final WrapDynaBean dynaBean = (WrapDynaBean) createdInstance;
-        assertTrue("Object type is AlphaBean", dynaBean.getInstance() instanceof AlphaBean);
+        assertInstanceOf(AlphaBean.class, dynaBean.getInstance(), "Object type is AlphaBean");
     }
 
     /**
      * Serialization and deserialization tests. (WrapDynaBean is now serializable, although WrapDynaClass still is not)
      */
     @Override
+    @Test
     public void testSerialization() {
 
         // Create a bean and set a value
         final WrapDynaBean origBean = new WrapDynaBean(new TestBean());
         final Integer newValue = Integer.valueOf(789);
-        assertEquals("origBean default", Integer.valueOf(123), origBean.get("intProperty"));
+        assertEquals(Integer.valueOf(123), origBean.get("intProperty"), "origBean default");
         origBean.set("intProperty", newValue);
-        assertEquals("origBean new value", newValue, origBean.get("intProperty"));
+        assertEquals(newValue, origBean.get("intProperty"), "origBean new value");
 
         // Serialize/Deserialize & test value
         final WrapDynaBean bean = (WrapDynaBean) serializeDeserialize(origBean, "First Test");
-        assertEquals("bean value", newValue, bean.get("intProperty"));
+        assertEquals(newValue, bean.get("intProperty"), "bean value");
 
     }
 
     /**
      * The {@code set()} method.
      */
+    @Test
     public void testSimpleProperties() {
 
         checkSimplePropertyAccess();

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira157TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira157TestCase.java
@@ -16,23 +16,28 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.Serializable;
 import java.util.Map;
-
-import junit.framework.TestCase;
 
 import org.apache.commons.beanutils2.BeanUtils;
 import org.apache.commons.beanutils2.BeanUtilsBean;
 import org.apache.commons.beanutils2.SuppressPropertiesBeanIntrospector;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Beanutils's describe() method cannot determine reader methods for anonymous class - see Jira issue# BEANUTILS-157.
  *
  * See <a href="https://issues.apache.org/jira/browse/BEANUTILS-157">https://issues.apache.org/jira/browse/BEANUTILS-157<a/>
  */
-public class Jira157TestCase extends TestCase {
+public class Jira157TestCase {
 
     public static class FooBar {
         String getPackageFoo() {
@@ -62,22 +67,12 @@ public class Jira157TestCase extends TestCase {
     private static final Log LOG = LogFactory.getLog(Jira157TestCase.class);
 
     /**
-     * Create a test case with the specified name.
-     *
-     * @param name The name of the test
-     */
-    public Jira157TestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Sets up.
      *
      * @throws Exception
      */
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
 
         final BeanUtilsBean custom = new BeanUtilsBean();
         custom.getPropertyUtils().removeBeanIntrospector(SuppressPropertiesBeanIntrospector.SUPPRESS_CLASS);
@@ -89,9 +84,8 @@ public class Jira157TestCase extends TestCase {
      *
      * @throws Exception
      */
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
     }
 
     /**
@@ -99,6 +93,7 @@ public class Jira157TestCase extends TestCase {
      * <p />
      * See Jira issue# BEANUTILS-157.
      */
+    @Test
     public void testIssue_BEANUTILS_157_BeanUtils_Describe_Bean() {
         final Object bean = new FooBar();
         Map<String, String> result = null;
@@ -108,10 +103,10 @@ public class Jira157TestCase extends TestCase {
             LOG.error("Describe Bean: " + t.getMessage(), t);
             fail("Describe Bean Threw exception: " + t);
         }
-        assertEquals("Check Size", 2, result.size());
-        assertTrue("Class", result.containsKey("class"));
-        assertTrue("publicFoo Key", result.containsKey("publicFoo"));
-        assertEquals("publicFoo Value", "PublicFoo Value", result.get("publicFoo"));
+        assertEquals(2, result.size(), "Check Size");
+        assertTrue(result.containsKey("class"), "Class");
+        assertTrue(result.containsKey("publicFoo"), "publicFoo Key");
+        assertEquals("PublicFoo Value", result.get("publicFoo"), "publicFoo Value");
     }
 
     /**
@@ -119,6 +114,7 @@ public class Jira157TestCase extends TestCase {
      * <p />
      * See Jira issue# BEANUTILS-157.
      */
+    @Test
     public void testIssue_BEANUTILS_157_BeanUtils_Describe_Interface() {
         final Object bean = new XY() {
             @Override
@@ -138,12 +134,12 @@ public class Jira157TestCase extends TestCase {
             LOG.error("Describe Interface: " + t.getMessage(), t);
             fail("Describe Interface Threw exception: " + t);
         }
-        assertEquals("Check Size", 3, result.size());
-        assertTrue("Class", result.containsKey("class"));
-        assertTrue("X Key", result.containsKey("x"));
-        assertTrue("Y Key", result.containsKey("y"));
-        assertEquals("X Value", "x-value", result.get("x"));
-        assertEquals("Y Value", "y-value", result.get("y"));
+        assertEquals(3, result.size(), "Check Size");
+        assertTrue(result.containsKey("class"), "Class");
+        assertTrue(result.containsKey("x"), "X Key");
+        assertTrue(result.containsKey("y"), "Y Key");
+        assertEquals("x-value", result.get("x"), "X Value");
+        assertEquals("y-value", result.get("y"), "Y Value");
     }
 
     /**
@@ -151,6 +147,7 @@ public class Jira157TestCase extends TestCase {
      * <p />
      * See Jira issue# BEANUTILS-157.
      */
+    @Test
     public void testIssue_BEANUTILS_157_BeanUtils_Describe_Serializable() {
         final Object bean = new Serializable() {
             private static final long serialVersionUID = 1L;
@@ -172,7 +169,7 @@ public class Jira157TestCase extends TestCase {
             LOG.error("Describe Serializable: " + t.getMessage(), t);
             fail("Describe Serializable Threw exception: " + t);
         }
-        assertEquals("Check Size", 1, result.size());
-        assertTrue("Class", result.containsKey("class"));
+        assertEquals(1, result.size(), "Check Size");
+        assertTrue(result.containsKey("class"), "Class");
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira273TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira273TestCase.java
@@ -16,39 +16,33 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.commons.beanutils2.PropertyUtils;
 import org.apache.commons.beanutils2.bugs.other.Jira273BeanFactory;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Public methods overridden in anonymous or private subclasses are not recognized by PropertyUtils - see issue# BEANUTILS-273.
  *
  * @see <a href="https://issues.apache.org/jira/browse/BEANUTILS-273">https://issues.apache.org/jira/browse/BEANUTILS-273</a>
  */
-public class Jira273TestCase extends TestCase {
+public class Jira273TestCase {
 
     private static final Log LOG = LogFactory.getLog(Jira273TestCase.class);
-
-    /**
-     * Create a test case with the specified name.
-     *
-     * @param name The name of the test
-     */
-    public Jira273TestCase(final String name) {
-        super(name);
-    }
 
     /**
      * Sets up.
      *
      * @throws Exception
      */
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
     }
 
     /**
@@ -56,14 +50,14 @@ public class Jira273TestCase extends TestCase {
      *
      * @throws Exception
      */
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
     }
 
     /**
      * Test with an anonymous class that inherits a public method of a public class.
      */
+    @Test
     public void testIssue_BEANUTILS_273_AnonymousNotOverridden() {
         final Object bean = Jira273BeanFactory.createAnonymousNotOverridden();
         Object result = null;
@@ -79,6 +73,7 @@ public class Jira273TestCase extends TestCase {
     /**
      * Test with an anonymous class that overrides a public method of a public class.
      */
+    @Test
     public void testIssue_BEANUTILS_273_AnonymousOverridden() {
         final Object bean = Jira273BeanFactory.createAnonymousOverridden();
         Object result = null;
@@ -94,6 +89,7 @@ public class Jira273TestCase extends TestCase {
     /**
      * Test with an private class that inherits a public method of a "grand parent" public class.
      */
+    @Test
     public void testIssue_BEANUTILS_273_PrivatePrivatePublicNotOverridden() {
         final Object bean = Jira273BeanFactory.createPrivatePrivatePublicNotOverridden();
         Object result = null;
@@ -109,6 +105,7 @@ public class Jira273TestCase extends TestCase {
     /**
      * Test with an private class that overrides a public method of a "grand parent" public class.
      */
+    @Test
     public void testIssue_BEANUTILS_273_PrivatePrivatePublicOverridden() {
         final Object bean = Jira273BeanFactory.createPrivatePrivatePublicOverridden();
         Object result = null;
@@ -124,6 +121,7 @@ public class Jira273TestCase extends TestCase {
     /**
      * Test with an private class that inherits a public method of a public class.
      */
+    @Test
     public void testIssue_BEANUTILS_273_PrivatePublicNotOverridden() {
         final Object bean = Jira273BeanFactory.createPrivatePublicNotOverridden();
         Object result = null;
@@ -139,6 +137,7 @@ public class Jira273TestCase extends TestCase {
     /**
      * Test with an private class that overrides a public method of a public class.
      */
+    @Test
     public void testIssue_BEANUTILS_273_PrivatePublicOverridden() {
         final Object bean = Jira273BeanFactory.createPrivatePublicOverridden();
         Object result = null;

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira298TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira298TestCase.java
@@ -16,9 +16,10 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
-import java.lang.reflect.Method;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import junit.framework.TestCase;
+import java.lang.reflect.Method;
 
 import org.apache.commons.beanutils2.MethodUtils;
 import org.apache.commons.beanutils2.PropertyUtils;
@@ -26,31 +27,24 @@ import org.apache.commons.beanutils2.bugs.other.Jira298BeanFactory;
 import org.apache.commons.beanutils2.bugs.other.Jira298BeanFactory.IX;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @see <a href="https://issues.apache.org/jira/browse/BEANUTILS-298">https://issues.apache.org/jira/browse/BEANUTILS-298</a>
  */
-public class Jira298TestCase extends TestCase {
+public class Jira298TestCase {
 
     private static final Log LOG = LogFactory.getLog(Jira298TestCase.class);
-
-    /**
-     * Create a test case with the specified name.
-     *
-     * @param name The name of the test
-     */
-    public Jira298TestCase(final String name) {
-        super(name);
-    }
 
     /**
      * Sets up.
      *
      * @throws Exception
      */
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
     }
 
     /**
@@ -58,14 +52,14 @@ public class Jira298TestCase extends TestCase {
      *
      * @throws Exception
      */
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
     }
 
     /**
      * Test {@link MethodUtils#getAccessibleMethod(Class, Method)}
      */
+    @Test
     public void testIssue_BEANUTILS_298_MethodUtils_getAccessibleMethod() {
         final Object bean = Jira298BeanFactory.createImplX();
         Object result = null;
@@ -82,6 +76,7 @@ public class Jira298TestCase extends TestCase {
     /**
      * Test {@link PropertyUtils#getProperty(Object, String)}
      */
+    @Test
     public void testIssue_BEANUTILS_298_PropertyUtils_getProperty() {
         final Object bean = Jira298BeanFactory.createImplX();
         Object result = null;
@@ -97,6 +92,7 @@ public class Jira298TestCase extends TestCase {
     /**
      * Test {@link PropertyUtils#setProperty(Object, String, Object)}
      */
+    @Test
     public void testIssue_BEANUTILS_298_PropertyUtils_setProperty() {
         final Object bean = Jira298BeanFactory.createImplX();
         assertEquals("BaseX name value", ((IX) bean).getName());

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira339TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira339TestCase.java
@@ -16,21 +16,25 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
-
-import junit.framework.TestCase;
 
 import org.apache.commons.beanutils2.BeanUtils;
 import org.apache.commons.beanutils2.PropertyUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @see <a href="https://issues.apache.org/jira/browse/BEANUTILS-339">https://issues.apache.org/jira/browse/BEANUTILS-339</a>
  */
-public class Jira339TestCase extends TestCase {
+public class Jira339TestCase {
 
     /**
      * Test Bean.
@@ -61,22 +65,12 @@ public class Jira339TestCase extends TestCase {
     private static final Log LOG = LogFactory.getLog(Jira339TestCase.class);
 
     /**
-     * Create a test case with the specified name.
-     *
-     * @param name The name of the test
-     */
-    public Jira339TestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Sets up.
      *
      * @throws Exception
      */
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
     }
 
     /**
@@ -84,14 +78,14 @@ public class Jira339TestCase extends TestCase {
      *
      * @throws Exception
      */
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
     }
 
     /**
      * Test {@link BeanUtils#populate(Object, Map)}
      */
+    @Test
     public void testIssue_BEANUTILS_331_BeanUtilsBean_populate() {
 
         final TestBean bean = new TestBean();
@@ -103,12 +97,13 @@ public class Jira339TestCase extends TestCase {
             LOG.error("Failed: " + t.getMessage(), t);
             fail("Threw exception: " + t);
         }
-        assertNull("TestBean comparator should be null", bean.getComparator());
+        assertNull(bean.getComparator(), "TestBean comparator should be null");
     }
 
     /**
      * Test {@link PropertyUtils#setProperty(Object, String, Object)}
      */
+    @Test
     public void testIssue_BEANUTILS_339_BeanUtilsBean_setProperty() {
 
         final TestBean bean = new TestBean();
@@ -118,6 +113,6 @@ public class Jira339TestCase extends TestCase {
             LOG.error("Failed: " + t.getMessage(), t);
             fail("Threw exception: " + t);
         }
-        assertNull("TestBean comparator should be null", bean.getComparator());
+        assertNull(bean.getComparator(), "TestBean comparator should be null");
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira345TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira345TestCase.java
@@ -16,14 +16,17 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.commons.beanutils2.BeanUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @see <a href="https://issues.apache.org/jira/browse/BEANUTILS-345">https://issues.apache.org/jira/browse/BEANUTILS-345</a>
  */
-public class Jira345TestCase extends TestCase {
+public class Jira345TestCase {
 
     /** Example Bean */
     public static class MyBean {
@@ -50,22 +53,12 @@ public class Jira345TestCase extends TestCase {
     }
 
     /**
-     * Create a test case with the specified name.
-     *
-     * @param name The name of the test
-     */
-    public Jira345TestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Sets up.
      *
      * @throws Exception
      */
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
     }
 
     /**
@@ -73,14 +66,14 @@ public class Jira345TestCase extends TestCase {
      *
      * @throws Exception
      */
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
     }
 
     /**
      * Test {@link BeanUtils} setProperty() with 2D array.
      */
+    @Test
     public void testBeanUtilsSetProperty_2DArray() throws Exception {
         final MyBean myBean = new MyBean();
         BeanUtils.setProperty(myBean, "matr[0][0]", "Sample");
@@ -90,6 +83,7 @@ public class Jira345TestCase extends TestCase {
     /**
      * Test {@link BeanUtils} setProperty() with 3D array.
      */
+    @Test
     public void testBeanUtilsSetProperty_3DArray() throws Exception {
         final MyBean myBean = new MyBean();
         BeanUtils.setProperty(myBean, "matr3D[0][0][0]", "Sample");

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira347TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira347TestCase.java
@@ -16,6 +16,12 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.beans.IntrospectionException;
 import java.lang.ref.SoftReference;
 import java.lang.reflect.Method;
@@ -25,17 +31,16 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Objects;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.beanutils2.MappedPropertyDescriptor;
 import org.apache.commons.beanutils2.memoryleaktests.MemoryLeakTestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for Jira issue# BEANUTILS-347.
  *
  * @see <a href="https://issues.apache.org/jira/browse/BEANUTILS-347">https://issues.apache.org/jira/browse/BEANUTILS-347</a>
  */
-public class Jira347TestCase extends TestCase {
+public class Jira347TestCase {
 
     /**
      * Create a new class loader instance.
@@ -114,6 +119,7 @@ public class Jira347TestCase extends TestCase {
      * the same method is returned or in both cases null. If the constructor of the MappedPropertyDescriptor would recognize the situation (of the first param
      * not being of type String) this would be fine as well.
      */
+    @Test
     public void testMappedPropertyDescriptor_AnyArgsProperty() throws Exception {
         final String className = "org.apache.commons.beanutils2.MappedPropertyTestBean";
         try (final URLClassLoader loader = newClassLoader()) {
@@ -121,10 +127,11 @@ public class Jira347TestCase extends TestCase {
             beanClass.newInstance();
 
             // Sanity checks only
-            assertNotNull("ClassLoader is null", loader);
-            assertNotNull("BeanClass is null", beanClass);
-            assertNotSame("ClassLoaders should be different..", getClass().getClassLoader(), beanClass.getClassLoader());
-            assertSame("BeanClass ClassLoader incorrect", beanClass.getClassLoader(), loader);
+            assertNotNull(loader, "ClassLoader is null");
+            assertNotNull(beanClass, "BeanClass is null");
+            assertNotSame(getClass().getClassLoader(), beanClass.getClassLoader(),
+                                     "ClassLoaders should be different..");
+            assertSame(beanClass.getClassLoader(), loader, "BeanClass ClassLoader incorrect");
 
             // now start the test
             MappedPropertyDescriptor descriptor = null;
@@ -139,7 +146,8 @@ public class Jira347TestCase extends TestCase {
                 forceGarbageCollection();
                 try {
                     final String m2 = getMappedWriteMethod(descriptor);
-                    assertEquals("Method returned post garbage collection differs from Method returned prior to gc", m1, m2);
+                    assertEquals(m1, m2,
+                                            "Method returned post garbage collection differs from Method returned prior to gc");
                 } catch (final RuntimeException e) {
                     fail("getMappedWriteMethod threw an exception after garbage collection " + e);
                 }

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira349TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira349TestCase.java
@@ -16,18 +16,19 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.commons.beanutils2.PropertyUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @see <a href="https://issues.apache.org/jira/browse/BEANUTILS-349">https://issues.apache.org/jira/browse/BEANUTILS-349</a>
  */
-public class Jira349TestCase extends TestCase {
+public class Jira349TestCase {
 
     /**
      * Test Bean with a Boolean object property.
@@ -62,31 +63,12 @@ public class Jira349TestCase extends TestCase {
     private static final Log LOG = LogFactory.getLog(Jira349TestCase.class);
 
     /**
-     * Create a test suite for this test.
-     *
-     * @return a test suite
-     */
-    public static Test suite() {
-        return new TestSuite(Jira349TestCase.class);
-    }
-
-    /**
-     * Create a test case with the specified name.
-     *
-     * @param name The name of the test
-     */
-    public Jira349TestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Sets up.
      *
      * @throws Exception
      */
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
     }
 
     /**
@@ -94,14 +76,14 @@ public class Jira349TestCase extends TestCase {
      *
      * @throws Exception
      */
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
     }
 
     /**
      * Test {@link PropertyUtils#copyProperties(Object, Object)}
      */
+    @Test
     public void testIssue_BEANUTILS_349_PropertyUtils_copyProperties() {
         final PrimitiveBean dest = new PrimitiveBean();
         final ObjectBean origin = new ObjectBean();

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira357TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira357TestCase.java
@@ -16,18 +16,21 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.beans.PropertyDescriptor;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-
 import org.apache.commons.beanutils2.PropertyUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @see <a href="https://issues.apache.org/jira/browse/BEANUTILS-357">https://issues.apache.org/jira/browse/BEANUTILS-357</a>
  */
-public class Jira357TestCase extends TestCase {
+public class Jira357TestCase {
 
     /**
      * Abstract test bean.
@@ -98,24 +101,6 @@ public class Jira357TestCase extends TestCase {
     }
 
     /**
-     * Create a test suite for this test.
-     *
-     * @return a test suite
-     */
-    public static Test suite() {
-        return new TestSuite(Jira357TestCase.class);
-    }
-
-    /**
-     * Create a test case with the specified name.
-     *
-     * @param name The name of the test
-     */
-    public Jira357TestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Test {@link PropertyUtils#getPropertyDescriptors(Class)}
      */
     private void checkReadMethod(final String propertyName, final Class<?> expectedDeclaringClass) throws Exception {
@@ -130,8 +115,9 @@ public class Jira357TestCase extends TestCase {
 
         // Test InnerClassProperty
         final PropertyDescriptor descriptor = findDescriptor(propertyName, descriptors);
-        assertNotNull(propertyName + "descriptor", descriptor);
-        assertEquals(propertyName + " read method declaring class", expectedDeclaringClass, descriptor.getReadMethod().getDeclaringClass());
+        assertNotNull(descriptor, propertyName + "descriptor");
+        assertEquals(expectedDeclaringClass, descriptor.getReadMethod().getDeclaringClass(),
+                                propertyName + " read method declaring class");
     }
 
     /**
@@ -153,9 +139,8 @@ public class Jira357TestCase extends TestCase {
      *
      * @throws Exception
      */
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
     }
 
     /**
@@ -163,14 +148,14 @@ public class Jira357TestCase extends TestCase {
      *
      * @throws Exception
      */
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
     }
 
     /**
      * Test {@link PropertyUtils#getPropertyDescriptors(Class)}
      */
+    @Test
     public void testPropertyUtils_getPropertyDescriptors_Bar() throws Exception {
         checkReadMethod("bar", ConcreteTestBean.class);
     }
@@ -178,6 +163,7 @@ public class Jira357TestCase extends TestCase {
     /**
      * Test {@link PropertyUtils#getPropertyDescriptors(Class)}
      */
+    @Test
     public void testPropertyUtils_getPropertyDescriptors_Foo() throws Exception {
         checkReadMethod("foo", ConcreteTestBean.class);
     }
@@ -185,6 +171,7 @@ public class Jira357TestCase extends TestCase {
     /**
      * Test {@link PropertyUtils#getPropertyDescriptors(Class)}
      */
+    @Test
     public void testPropertyUtils_getPropertyDescriptors_InnerClassProperty() throws Exception {
         checkReadMethod("innerClassProperty", ConcreteTestBean.class);
     }

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira358TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira358TestCase.java
@@ -16,33 +16,26 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.commons.beanutils2.PropertyUtils;
 import org.apache.commons.beanutils2.TestBean;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @see <a href="https://issues.apache.org/jira/browse/BEANUTILS-358">https://issues.apache.org/jira/browse/BEANUTILS-358</a>
  */
-public class Jira358TestCase extends TestCase {
-
-    /**
-     * Create a test case with the specified name.
-     *
-     * @param name The name of the test
-     */
-    public Jira358TestCase(final String name) {
-        super(name);
-    }
+public class Jira358TestCase {
 
     /**
      * Sets up.
      *
      * @throws Exception
      */
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
     }
 
     /**
@@ -50,14 +43,14 @@ public class Jira358TestCase extends TestCase {
      *
      * @throws Exception
      */
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
     }
 
     /**
      * Test {@link PropertyUtils#getIndexedProperty(Object, String, int)}
      */
+    @Test
     public void testPropertyUtils_getIndexedProperty_Array() throws Exception {
 
         final TestBean bean = new TestBean();
@@ -72,6 +65,7 @@ public class Jira358TestCase extends TestCase {
     /**
      * Test {@link PropertyUtils#getIndexedProperty(Object, String, int)}
      */
+    @Test
     public void testPropertyUtils_getIndexedProperty_List() throws Exception {
 
         final TestBean bean = new TestBean();

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira359TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira359TestCase.java
@@ -16,17 +16,20 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.commons.beanutils2.BeanUtils;
 import org.apache.commons.beanutils2.BeanUtilsBean;
 import org.apache.commons.beanutils2.converters.ArrayConverter;
 import org.apache.commons.beanutils2.converters.StringConverter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @see <a href="https://issues.apache.org/jira/browse/BEANUTILS-359">https://issues.apache.org/jira/browse/BEANUTILS-359</a>
  */
-public class Jira359TestCase extends TestCase {
+public class Jira359TestCase {
 
     public static class SimplePojoData {
         private String[] jcrMixinTypes = new String[1];
@@ -44,22 +47,12 @@ public class Jira359TestCase extends TestCase {
     }
 
     /**
-     * Create a test case with the specified name.
-     *
-     * @param name The name of the test
-     */
-    public Jira359TestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Sets up.
      *
      * @throws Exception
      */
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
     }
 
     /**
@@ -81,14 +74,14 @@ public class Jira359TestCase extends TestCase {
      *
      * @throws Exception
      */
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
     }
 
     /**
      * Test {@link BeanUtils} setProperty() String to array with colon value
      */
+    @Test
     public void testBeanUtilsSetProperty_CustomConvertStringToArray_WithColonValue() throws Exception {
         final ArrayConverter converter = new ArrayConverter(String[].class, new StringConverter());
         converter.setAllowedChars(new char[] { '.', '-', ':' });
@@ -99,7 +92,7 @@ public class Jira359TestCase extends TestCase {
         final SimplePojoData simplePojo = new SimplePojoData();
         utils.setProperty(simplePojo, "jcrMixinTypes", "mix:rereferencible,mix:simple");
         showArray("Custom WithColonValue", simplePojo.getJcrMixinTypes());
-        assertEquals("array size", 2, simplePojo.getJcrMixinTypes().length);
+        assertEquals(2, simplePojo.getJcrMixinTypes().length, "array size");
         assertEquals("mix:rereferencible", simplePojo.getJcrMixinTypes()[0]);
         assertEquals("mix:simple", simplePojo.getJcrMixinTypes()[1]);
     }
@@ -107,11 +100,12 @@ public class Jira359TestCase extends TestCase {
     /**
      * Test {@link BeanUtils} setProperty() String to array with colon value
      */
+    @Test
     public void testBeanUtilsSetProperty_DefaultConvertStringToArray_WithColonValue() throws Exception {
         final SimplePojoData simplePojo = new SimplePojoData();
         BeanUtils.setProperty(simplePojo, "jcrMixinTypes", "mix:rereferencible,mix:simple");
         showArray("Default WithColonValue", simplePojo.getJcrMixinTypes());
-        assertEquals("array size", 4, simplePojo.getJcrMixinTypes().length);
+        assertEquals(4, simplePojo.getJcrMixinTypes().length, "array size");
         assertEquals("mix", simplePojo.getJcrMixinTypes()[0]);
         assertEquals("rereferencible", simplePojo.getJcrMixinTypes()[1]);
         assertEquals("mix", simplePojo.getJcrMixinTypes()[2]);
@@ -121,11 +115,12 @@ public class Jira359TestCase extends TestCase {
     /**
      * Test {@link BeanUtils} setProperty() String to array without colon value
      */
+    @Test
     public void testBeanUtilsSetProperty_DefaultConvertStringToArray_WithoutColonValue() throws Exception {
         final SimplePojoData simplePojo = new SimplePojoData();
         BeanUtils.setProperty(simplePojo, "jcrMixinTypes", "mixrereferencible,mixsimple");
         showArray("Default WithoutColonValue", simplePojo.getJcrMixinTypes());
-        assertEquals("array size", 2, simplePojo.getJcrMixinTypes().length);
+        assertEquals(2, simplePojo.getJcrMixinTypes().length, "array size");
         assertEquals("mixrereferencible", simplePojo.getJcrMixinTypes()[0]);
         assertEquals("mixsimple", simplePojo.getJcrMixinTypes()[1]);
     }
@@ -133,11 +128,12 @@ public class Jira359TestCase extends TestCase {
     /**
      * Test {@link BeanUtils} setProperty() String to array without colon value and no comma
      */
+    @Test
     public void testBeanUtilsSetProperty_DefaultConvertStringToArray_WithoutColonValueAndNocoma() throws Exception {
         final SimplePojoData simplePojo = new SimplePojoData();
         BeanUtils.setProperty(simplePojo, "jcrMixinTypes", "mixrereferencible");
         showArray("Default WithoutColonAndNocoma", simplePojo.getJcrMixinTypes());
-        assertEquals("array size", 1, simplePojo.getJcrMixinTypes().length);
+        assertEquals(1, simplePojo.getJcrMixinTypes().length, "array size");
         assertEquals("mixrereferencible", simplePojo.getJcrMixinTypes()[0]);
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira368TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira368TestCase.java
@@ -18,32 +18,23 @@ package org.apache.commons.beanutils2.bugs;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.beanutils2.BeanUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @see <a href="https://issues.apache.org/jira/browse/BEANUTILS-368">https://issues.apache.org/jira/browse/BEANUTILS-368</a>
  */
-public class Jira368TestCase extends TestCase {
-
-    /**
-     * Create a test case with the specified name.
-     *
-     * @param name The name of the test
-     */
-    public Jira368TestCase(final String name) {
-        super(name);
-    }
+public class Jira368TestCase {
 
     /**
      * Sets up.
      *
      * @throws Exception
      */
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
     }
 
     /**
@@ -51,14 +42,14 @@ public class Jira368TestCase extends TestCase {
      *
      * @throws Exception
      */
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
     }
 
     /**
      * Test {@link BeanUtils} setProperty() with Null value
      */
+    @Test
     public void testBeanUtilsSetProperty_NullBean() throws Exception {
         assertThrows(NullPointerException.class, () -> BeanUtils.setProperty(null, "foo", "bar"));
     }

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira369TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira369TestCase.java
@@ -16,14 +16,18 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.commons.beanutils2.BeanUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @see <a href="https://issues.apache.org/jira/browse/BEANUTILS-369">https://issues.apache.org/jira/browse/BEANUTILS-369</a>
  */
-public class Jira369TestCase extends TestCase {
+public class Jira369TestCase {
 
     /**
      * Test Bean
@@ -50,22 +54,12 @@ public class Jira369TestCase extends TestCase {
     }
 
     /**
-     * Create a test case with the specified name.
-     *
-     * @param name The name of the test
-     */
-    public Jira369TestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Sets up.
      *
      * @throws Exception
      */
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
     }
 
     /**
@@ -73,14 +67,14 @@ public class Jira369TestCase extends TestCase {
      *
      * @throws Exception
      */
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
     }
 
     /**
      * Test {@link BeanUtils} getProperty() for property "aRatedCd".
      */
+    @Test
     public void testBeanUtilsGetProperty_aRatedCd() throws Exception {
         final TestBean bean = new TestBean();
         bean.setARatedCd("foo");
@@ -98,6 +92,7 @@ public class Jira369TestCase extends TestCase {
     /**
      * Test {@link BeanUtils} getProperty() for property "ARatedCd".
      */
+    @Test
     public void testBeanUtilsGetProperty_ARatedCd() throws Exception {
         final TestBean bean = new TestBean();
         bean.setARatedCd("foo");
@@ -111,6 +106,7 @@ public class Jira369TestCase extends TestCase {
     /**
      * Test {@link BeanUtils} getProperty() for property "bRatedCd".
      */
+    @Test
     public void testBeanUtilsGetProperty_bRatedCd() throws Exception {
         final TestBean bean = new TestBean();
         bean.setbRatedCd("foo");

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira381TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira381TestCase.java
@@ -16,18 +16,19 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.lang.reflect.Method;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.beanutils2.MethodUtils;
+import org.junit.jupiter.api.Test;
 
 /**
  * MethodUtils's getMatchingAccessibleMethod() does not correctly handle inheritance and method overloading.
  *
  * @see <a href="https://issues.apache.org/jira/browse/BEANUTILS-381">https://issues.apache.org/jira/browse/BEANUTILS-381</a>
  */
-public class Jira381TestCase extends TestCase {
+public class Jira381TestCase {
 
     /**
      * Test object.
@@ -60,19 +61,11 @@ public class Jira381TestCase extends TestCase {
     }
 
     /**
-     * Create a test case with the specified name.
-     *
-     * @param name The name of the test
-     */
-    public Jira381TestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Test with an private class that overrides a public method of a "grand parent" public class.
      * <p />
      * See Jira issue# BEANUTILS-381.
      */
+    @Test
     public void testIssue_BEANUTILS_381_getMatchingAccessibleMethod() {
 
         final Class<?> target = TestServiceBean.class;

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira411TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira411TestCase.java
@@ -16,16 +16,16 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.beanutils2.BeanUtilsBean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * BeanUtilsBean.setProperty throws IllegalArgumentException if getter of nested property returns null
  *
  * @see <a href="https://issues.apache.org/jira/browse/BEANUTILS-411">https://issues.apache.org/jira/browse/BEANUTILS-411</a>
  */
-public class Jira411TestCase extends TestCase {
+public class Jira411TestCase {
 
     public class DummyBean {
 
@@ -43,12 +43,13 @@ public class Jira411TestCase extends TestCase {
 
     private DummyBean testBean;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         instance = new BeanUtilsBean();
         testBean = new DummyBean();
     }
 
+    @Test
     public void testSetProperty() throws Exception {
         instance.setProperty(testBean, "imgLink.x", "1");
     }

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira422bTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira422bTestCase.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.commons.beanutils2.PropertyUtils;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira454TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira454TestCase.java
@@ -16,16 +16,17 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.util.Date;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.beanutils2.BeanUtils;
+import org.junit.jupiter.api.Test;
 
 /**
  * copyProperties() throws a ConversionException : No value specified for 'Date' when the field is a java.util.Date with a null value
  */
-public class Jira454TestCase extends TestCase {
+public class Jira454TestCase {
     public static class TestBean {
         private Date createdAt;
 
@@ -38,10 +39,11 @@ public class Jira454TestCase extends TestCase {
         }
     }
 
+    @Test
     public void testCopyProperties() throws Exception {
         final TestBean bean = new TestBean();
         final TestBean b2 = new TestBean();
         BeanUtils.copyProperties(b2, bean);
-        assertNull("Got a creation date", b2.getCreatedAt());
+        assertNull(b2.getCreatedAt(), "Got a creation date");
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira456TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira456TestCase.java
@@ -16,19 +16,22 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
-import java.beans.PropertyDescriptor;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import junit.framework.TestCase;
+import java.beans.PropertyDescriptor;
 
 import org.apache.commons.beanutils2.FluentIntrospectionTestBean;
 import org.apache.commons.beanutils2.FluentPropertyBeanIntrospector;
 import org.apache.commons.beanutils2.PropertyUtilsBean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Write methods for PropertyDescriptors created during custom introspection are lost. See <a href="https://issues.apache.org/jira/browse/BEANUTILS-456">JIRA
  * issue BEANUTILS-456</a>.
  */
-public class Jira456TestCase extends TestCase {
+public class Jira456TestCase {
     /** Constant for the name of the test property. */
     private static final String TEST_PROP = "fluentGetProperty";
 
@@ -51,9 +54,8 @@ public class Jira456TestCase extends TestCase {
         return bean;
     }
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         pub = new PropertyUtilsBean();
         pub.addBeanIntrospector(new FluentPropertyBeanIntrospector());
     }
@@ -61,18 +63,20 @@ public class Jira456TestCase extends TestCase {
     /**
      * Tests whether a property is recognized as writable even if the reference to its write method was freed.
      */
+    @Test
     public void testPropertyIsWritable() throws Exception {
         final FluentIntrospectionTestBean bean = clearWriteMethodRef();
-        assertTrue("Not writable", pub.isWriteable(bean, TEST_PROP));
+        assertTrue(pub.isWriteable(bean, TEST_PROP), "Not writable");
     }
 
     /**
      * Tests whether a lost write method is automatically recovered and can be invoked.
      */
+    @Test
     public void testWriteMethodRecover() throws Exception {
         final FluentIntrospectionTestBean bean = clearWriteMethodRef();
         final String value = "Test value";
         pub.setProperty(bean, TEST_PROP, value);
-        assertEquals("Property not set", value, bean.getFluentGetProperty());
+        assertEquals(value, bean.getFluentGetProperty(), "Property not set");
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira458TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira458TestCase.java
@@ -16,19 +16,20 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
-import java.util.Locale;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import junit.framework.TestCase;
+import java.util.Locale;
 
 import org.apache.commons.beanutils2.Converter;
 import org.apache.commons.beanutils2.locale.converters.IntegerLocaleConverter;
+import org.junit.jupiter.api.Test;
 
 /**
  * BaseLocaleConverter.checkConversionResult() fails with ConversionException when result is null when it should not.
  *
  * @see <a href="https://issues.apache.org/jira/browse/BEANUTILS-458">https://issues.apache.org/jira/browse/BEANUTILS-458</a>
  */
-public class Jira458TestCase extends TestCase {
+public class Jira458TestCase {
     /**
      * Helper method for testing a conversion with null as default.
      *
@@ -37,12 +38,13 @@ public class Jira458TestCase extends TestCase {
     private void checkConversionWithNullDefault(final String input) {
         // final Converter<Integer> converter = new IntegerLocaleConverter(null, Locale.US);
         final Converter<Integer> converter = IntegerLocaleConverter.builder().setUseDefault(true).setLocale(Locale.US).get();
-        assertNull("Wrong result", converter.convert(Integer.class, input));
+        assertNull(converter.convert(Integer.class, input), "Wrong result");
     }
 
     /**
      * Tests a conversion passing in an empty string.
      */
+    @Test
     public void testConversionWithNullDefaultEmptyString() {
         checkConversionWithNullDefault("");
     }
@@ -50,6 +52,7 @@ public class Jira458TestCase extends TestCase {
     /**
      * Tests a conversion passing in null.
      */
+    @Test
     public void testConversionWithNullDefaultNullInput() {
         checkConversionWithNullDefault(null);
     }

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira463TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira463TestCase.java
@@ -16,21 +16,23 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.commons.beanutils2.AlphaBean;
 import org.apache.commons.beanutils2.BeanUtilsBean;
 import org.apache.commons.beanutils2.SuppressPropertiesBeanIntrospector;
+import org.junit.jupiter.api.Test;
 
 /**
  * Class loader vulnerability in DefaultResolver
  *
  * @see <a href="https://issues.apache.org/jira/browse/BEANUTILS-463">https://issues.apache.org/jira/browse/BEANUTILS-463</a>
  */
-public class Jira463TestCase extends TestCase {
+public class Jira463TestCase {
     /**
      * Tests that with a specialized {@code BeanIntrospector} implementation the class property can be suppressed.
      */
+    @Test
     public void testSuppressClassProperty() throws Exception {
         final BeanUtilsBean bub = new BeanUtilsBean();
         bub.getPropertyUtils().addBeanIntrospector(SuppressPropertiesBeanIntrospector.SUPPRESS_CLASS);

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira465TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira465TestCase.java
@@ -16,20 +16,22 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.beanutils2.BeanUtils;
+import org.junit.jupiter.api.Test;
 
 /**
  * Indexed List Setters no longer work.
  *
  * @see <a href="https://issues.apache.org/jira/browse/BEANUTILS-465">https://issues.apache.org/jira/browse/BEANUTILS-465</a>
  */
-public class Jira465TestCase extends TestCase {
+public class Jira465TestCase {
     public static class ArrayIndexedProp {
         private final Object[] foo = { OLD_VALUE };
 
@@ -100,27 +102,31 @@ public class Jira465TestCase extends TestCase {
         }
     }
 
+    @Test
     public void testArrayIndexedProperty() {
         final ArrayIndexedProp bean = new ArrayIndexedProp();
         changeValue(bean);
-        assertEquals("Wrong value", NEW_VALUE, bean.getFoo(0));
+        assertEquals(NEW_VALUE, bean.getFoo(0), "Wrong value");
     }
 
+    @Test
     public void testArrayProperty() {
         final ArrayProp bean = new ArrayProp();
         changeValue(bean);
-        assertEquals("Wrong value", NEW_VALUE, bean.getFoo()[0]);
+        assertEquals(NEW_VALUE, bean.getFoo()[0], "Wrong value");
     }
 
+    @Test
     public void testListIndexedProperty() {
         final ListIndexedProp bean = new ListIndexedProp();
         changeValue(bean);
-        assertEquals("Wrong value", NEW_VALUE, bean.getFoo(0));
+        assertEquals(NEW_VALUE, bean.getFoo(0), "Wrong value");
     }
 
+    @Test
     public void testListProperty() {
         final ListProp bean = new ListProp();
         changeValue(bean);
-        assertEquals("Wrong value", NEW_VALUE, bean.getFoo().get(0));
+        assertEquals(NEW_VALUE, bean.getFoo().get(0), "Wrong value");
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira520TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira520TestCase.java
@@ -16,32 +16,37 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.commons.beanutils2.AlphaBean;
 import org.apache.commons.beanutils2.BeanUtilsBean;
 import org.apache.commons.beanutils2.SuppressPropertiesBeanIntrospector;
+import org.junit.jupiter.api.Test;
 
 /**
  * Fix CVE: https://nvd.nist.gov/vuln/detail/CVE-2014-0114
  *
  * @see <a href="https://issues.apache.org/jira/browse/BEANUTILS-520">https://issues.apache.org/jira/browse/BEANUTILS-520</a>
  */
-public class Jira520TestCase extends TestCase {
+public class Jira520TestCase {
     /**
      * Allow opt-out to make your app less secure but allow access to "class".
      */
+    @Test
     public void testAllowAccessToClassProperty() throws Exception {
         final BeanUtilsBean bub = new BeanUtilsBean();
         bub.getPropertyUtils().removeBeanIntrospector(SuppressPropertiesBeanIntrospector.SUPPRESS_CLASS);
         final AlphaBean bean = new AlphaBean();
         final String result = bub.getProperty(bean, "class");
-        assertEquals("Class property should have been accessed", "class org.apache.commons.beanutils2.AlphaBean", result);
+        assertEquals("class org.apache.commons.beanutils2.AlphaBean", result,
+                                "Class property should have been accessed");
     }
 
     /**
      * By default opt-in to security that does not allow access to "class".
      */
+    @Test
     public void testSuppressClassPropertyByDefault() throws Exception {
         final BeanUtilsBean bub = new BeanUtilsBean();
         final AlphaBean bean = new AlphaBean();

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira87TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira87TestCase.java
@@ -16,12 +16,16 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.commons.beanutils2.PropertyUtils;
 import org.apache.commons.beanutils2.bugs.other.Jira87BeanFactory;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for Jiar issue# BEANUTILS-87.
@@ -35,27 +39,17 @@ import org.apache.commons.logging.LogFactory;
  *
  * @see <a href="https://issues.apache.org/jira/browse/BEANUTILS-87">https://issues.apache.org/jira/browse/BEANUTILS-87</a>
  */
-public class Jira87TestCase extends TestCase {
+public class Jira87TestCase {
 
     private static final Log LOG = LogFactory.getLog(Jira87TestCase.class);
-
-    /**
-     * Create a test case with the specified name.
-     *
-     * @param name The name of the test
-     */
-    public Jira87TestCase(final String name) {
-        super(name);
-    }
 
     /**
      * Sets up.
      *
      * @throws Exception
      */
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
     }
 
     /**
@@ -63,14 +57,14 @@ public class Jira87TestCase extends TestCase {
      *
      * @throws Exception
      */
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
     }
 
     /**
      * Interface definition with a mapped property
      */
+    @Test
     public void testJira87() {
 
         final Jira87BeanFactory.PublicMappedInterface bean = Jira87BeanFactory.createMappedPropertyBean();

--- a/src/test/java/org/apache/commons/beanutils2/bugs/Jira92TestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/bugs/Jira92TestCase.java
@@ -16,17 +16,16 @@
  */
 package org.apache.commons.beanutils2.bugs;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.beanutils2.PropertyUtils;
 import org.apache.commons.beanutils2.TestBean;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for Jira issue# BEANUTILS-92.
  *
  * @see <a href="https://issues.apache.org/jira/browse/BEANUTILS-92">https://issues.apache.org/jira/browse/BEANUTILS-92</a>
  */
-public class Jira92TestCase extends TestCase {
+public class Jira92TestCase {
 
     /**
      * Test bean which has only indexed setter
@@ -49,6 +48,7 @@ public class Jira92TestCase extends TestCase {
     /**
      * Test copy properties where the target bean only has an indexed setter.
      */
+    @Test
     public void testIssue_BEANUTILS_92_copyProperties_indexed_only_setter() throws Exception {
         PropertyUtils.copyProperties(new Jira92TestBean(), new TestBean());
     }

--- a/src/test/java/org/apache/commons/beanutils2/converters/AbstractDateConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/AbstractDateConverterTest.java
@@ -44,15 +44,6 @@ import org.apache.commons.beanutils2.Converter;
 public abstract class AbstractDateConverterTest<T> extends TestCase {
 
     /**
-     * Constructs a new test case.
-     *
-     * @param name Name of the test
-     */
-    public AbstractDateConverterTest(final String name) {
-        super(name);
-    }
-
-    /**
      * Gets the expected type
      *
      * @return The expected type

--- a/src/test/java/org/apache/commons/beanutils2/converters/AbstractNumberConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/AbstractNumberConverterTest.java
@@ -36,10 +36,6 @@ public abstract class AbstractNumberConverterTest<T extends Number> extends Test
     /** Test Number values */
     protected Number[] numbers = new Number[4];
 
-    public AbstractNumberConverterTest(final String name) {
-        super(name);
-    }
-
     protected abstract Class<T> getExpectedType();
 
     protected abstract NumberConverter<T> makeConverter();
@@ -263,7 +259,7 @@ public abstract class AbstractNumberConverterTest<T extends Number> extends Test
      */
     public void testStringArrayToInteger() {
         final Integer defaultValue = Integer.valueOf(-1);
-        final NumberConverter<Integer> converter = new IntegerConverterTestCase("test").makeConverter(defaultValue);
+        final NumberConverter<Integer> converter = new IntegerConverterTestCase().makeConverter(defaultValue);
 
         // Default Locale
         assertEquals("Valid First", Integer.valueOf(5), converter.convert(Integer.class, new String[] { "5", "4", "3" }));

--- a/src/test/java/org/apache/commons/beanutils2/converters/ArrayConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ArrayConverterTestCase.java
@@ -16,28 +16,25 @@
  */
 package org.apache.commons.beanutils2.converters;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Locale;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Case for the ArrayConverter class.
  */
-public class ArrayConverterTestCase extends TestCase {
-
-    /**
-     * Constructs a new Array Converter test case.
-     *
-     * @param name Test Name
-     */
-    public ArrayConverterTestCase(final String name) {
-        super(name);
-    }
+public class ArrayConverterTestCase {
 
     /**
      * Check that two arrays are the same.
@@ -47,28 +44,28 @@ public class ArrayConverterTestCase extends TestCase {
      * @param result   Result array value
      */
     private void checkArray(final String msg, final Object expected, final Object result) {
-        assertNotNull(msg + " Expected Null", expected);
-        assertNotNull(msg + " Result   Null", result);
-        assertTrue(msg + " Result   not array", result.getClass().isArray());
-        assertTrue(msg + " Expected not array", expected.getClass().isArray());
+        assertNotNull(expected, msg + " Expected Null");
+        assertNotNull(result, msg + " Result   Null");
+        assertTrue(result.getClass().isArray(), msg + " Result   not array");
+        assertTrue(expected.getClass().isArray(), msg + " Expected not array");
         final int resultLth = Array.getLength(result);
-        assertEquals(msg + " Size", Array.getLength(expected), resultLth);
-        assertEquals(msg + " Type", expected.getClass(), result.getClass());
+        assertEquals(Array.getLength(expected), resultLth, msg + " Size");
+        assertEquals(expected.getClass(), result.getClass(), msg + " Type");
         for (int i = 0; i < resultLth; i++) {
             final Object expectElement = Array.get(expected, i);
             final Object resultElement = Array.get(result, i);
-            assertEquals(msg + " Element " + i, expectElement, resultElement);
+            assertEquals(expectElement, resultElement, msg + " Element " + i);
         }
     }
 
     /** Sets Up */
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         // empty
     }
 
     /** Tear Down */
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         // empty
     }
@@ -76,6 +73,7 @@ public class ArrayConverterTestCase extends TestCase {
     /**
      * Test Converting using the IntegerConverter as the component Converter
      */
+    @Test
     public void testComponentIntegerConverter() {
 
         final IntegerConverter intConverter = new IntegerConverter(Integer.valueOf(0));
@@ -162,7 +160,7 @@ public class ArrayConverterTestCase extends TestCase {
         // Long --> String
         try {
             msg = "Long --> String";
-            assertEquals(msg, LONGArray[0] + "", arrayConverter.convert(String.class, LONGArray[0]));
+            assertEquals(LONGArray[0] + "", arrayConverter.convert(String.class, LONGArray[0]), msg);
         } catch (final Exception e) {
             fail(msg + " failed " + e);
         }
@@ -170,7 +168,7 @@ public class ArrayConverterTestCase extends TestCase {
         // LONG[] --> String (first)
         try {
             msg = "LONG[] --> String (first)";
-            assertEquals(msg, LONGArray[0] + "", arrayConverter.convert(String.class, LONGArray));
+            assertEquals(LONGArray[0] + "", arrayConverter.convert(String.class, LONGArray), msg);
         } catch (final Exception e) {
             fail(msg + " failed " + e);
         }
@@ -179,7 +177,7 @@ public class ArrayConverterTestCase extends TestCase {
         try {
             msg = "LONG[] --> String (all)";
             arrayConverter.setOnlyFirstToString(false);
-            assertEquals(msg, stringB, arrayConverter.convert(String.class, LONGArray));
+            assertEquals(stringB, arrayConverter.convert(String.class, LONGArray), msg);
         } catch (final Exception e) {
             fail(msg + " failed " + e);
         }
@@ -187,7 +185,7 @@ public class ArrayConverterTestCase extends TestCase {
         // Collection of Long --> String
         try {
             msg = "Collection of Long --> String";
-            assertEquals(msg, stringB, arrayConverter.convert(String.class, longList));
+            assertEquals(stringB, arrayConverter.convert(String.class, longList), msg);
         } catch (final Exception e) {
             fail(msg + " failed " + e);
         }
@@ -220,17 +218,20 @@ public class ArrayConverterTestCase extends TestCase {
     /**
      * Test Empty String
      */
+    @Test
     public void testEmptyString() {
         final int[] zeroArray = {};
         final IntegerConverter intConverter = new IntegerConverter();
 
         checkArray("Empty String", zeroArray, new ArrayConverter(int[].class, intConverter, -1).convert(int[].class, ""));
-        assertEquals("Default String", null, new ArrayConverter(int[].class, intConverter).convert(String.class, null));
+        assertEquals(null, new ArrayConverter(int[].class, intConverter).convert(String.class, null),
+                                "Default String");
     }
 
     /**
      * Test Errors creating the converter
      */
+    @Test
     public void testErrors() {
         assertThrows(NullPointerException.class, () -> new ArrayConverter(null, new DateConverter()));
         assertThrows(IllegalArgumentException.class, () -> new ArrayConverter(Boolean.class, new DateConverter()));
@@ -240,12 +241,14 @@ public class ArrayConverterTestCase extends TestCase {
     /**
      * Test Converting using the IntegerConverter as the component Converter
      */
+    @Test
     public void testInvalidWithDefault() {
         final int[] zeroArray = {};
         final int[] oneArray = new int[1];
         final IntegerConverter intConverter = new IntegerConverter();
 
-        assertEquals("Null Default", null, new ArrayConverter(int[].class, intConverter, -1).convert(int[].class, null));
+        assertEquals(null, new ArrayConverter(int[].class, intConverter, -1).convert(int[].class, null),
+                                "Null Default");
         checkArray("Zero Length", zeroArray, new ArrayConverter(int[].class, intConverter, 0).convert(int[].class, null));
         checkArray("One Length", oneArray, new ArrayConverter(Integer[].class, intConverter, 1).convert(int[].class, null));
     }
@@ -253,6 +256,7 @@ public class ArrayConverterTestCase extends TestCase {
     /**
      * Test Converting a String[] to integer array (with leading/trailing whitespace)
      */
+    @Test
     public void testStringArrayToNumber() {
 
         // Configure Converter
@@ -306,6 +310,7 @@ public class ArrayConverterTestCase extends TestCase {
     /**
      * Test the Matrix!!!! (parses a String into a 2 dimensional integer array or matrix)
      */
+    @Test
     public void testTheMatrix() {
 
         // Test Date - create the Matrix!!
@@ -337,14 +342,14 @@ public class ArrayConverterTestCase extends TestCase {
             final Object result = matrixConverter.convert(int[][].class, matrixString);
 
             // Check it actually worked OK
-            assertEquals("Check int[][].class", int[][].class, result.getClass());
+            assertEquals(int[][].class, result.getClass(), "Check int[][].class");
             final int[][] matrix = (int[][]) result;
-            assertEquals("Check int[][] length", expected.length, matrix.length);
+            assertEquals(expected.length, matrix.length, "Check int[][] length");
             for (int i = 0; i < expected.length; i++) {
-                assertEquals("Check int[" + i + "] length", expected[i].length, matrix[i].length);
+                assertEquals(expected[i].length, matrix[i].length, "Check int[" + i + "] length");
                 for (int j = 0; j < expected[i].length; j++) {
                     final String label = "Matrix int[" + i + "," + j + "] element";
-                    assertEquals(label, expected[i][j], matrix[i][j]);
+                    assertEquals(expected[i][j], matrix[i][j], label);
                     // System.out.println(label + " = " + matrix[i][j]);
                 }
             }
@@ -356,27 +361,28 @@ public class ArrayConverterTestCase extends TestCase {
     /**
      * Test for BEANUTILS-302 - throwing a NPE when underscore used
      */
+    @Test
     public void testUnderscore_BEANUTILS_302() {
         final String value = "first_value,second_value";
         final ArrayConverter<String[]> converter = new ArrayConverter(String[].class, new StringConverter());
 
         // test underscore not allowed (the default)
         String[] result = converter.convert(String[].class, value);
-        assertNotNull("result.null", result);
-        assertEquals("result.length", 4, result.length);
-        assertEquals("result[0]", "first", result[0]);
-        assertEquals("result[1]", "value", result[1]);
-        assertEquals("result[2]", "second", result[2]);
-        assertEquals("result[3]", "value", result[3]);
+        assertNotNull(result, "result.null");
+        assertEquals(4, result.length, "result.length");
+        assertEquals("first", result[0], "result[0]");
+        assertEquals("value", result[1], "result[1]");
+        assertEquals("second", result[2], "result[2]");
+        assertEquals("value", result[3], "result[3]");
 
         // configure the converter to allow underscore
         converter.setAllowedChars(new char[] { '.', '-', '_' });
 
         // test underscore allowed
         result = converter.convert(String[].class, value);
-        assertNotNull("result.null", result);
-        assertEquals("result.length", 2, result.length);
-        assertEquals("result[0]", "first_value", result[0]);
-        assertEquals("result[1]", "second_value", result[1]);
+        assertNotNull(result, "result.null");
+        assertEquals(2, result.length, "result.length");
+        assertEquals("first_value", result[0], "result[0]");
+        assertEquals("second_value", result[1], "result[1]");
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/converters/BaseLocaleConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/BaseLocaleConverterTestCase.java
@@ -58,10 +58,6 @@ public class BaseLocaleConverterTestCase<T> extends TestCase {
     protected String expectedDecimalValue;
     protected String expectedIntegerValue;
 
-    public BaseLocaleConverterTestCase(final String name) {
-        super(name);
-    }
-
     /**
      * Test Converting an invalid value.
      */

--- a/src/test/java/org/apache/commons/beanutils2/converters/BigDecimalConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/BigDecimalConverterTestCase.java
@@ -39,10 +39,6 @@ public class BigDecimalConverterTestCase extends AbstractNumberConverterTest<Big
 
     private Converter<BigDecimal> converter;
 
-    public BigDecimalConverterTestCase(final String name) {
-        super(name);
-    }
-
     @Override
     protected Class<BigDecimal> getExpectedType() {
         return BigDecimal.class;

--- a/src/test/java/org/apache/commons/beanutils2/converters/BigDecimalLocaleConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/BigDecimalLocaleConverterTestCase.java
@@ -26,10 +26,6 @@ import org.apache.commons.beanutils2.locale.converters.BigDecimalLocaleConverter
  */
 public class BigDecimalLocaleConverterTestCase extends BaseLocaleConverterTestCase<BigDecimal> {
 
-    public BigDecimalLocaleConverterTestCase(final String name) {
-        super(name);
-    }
-
     /**
      * Sets up instance variables required by this test case.
      */

--- a/src/test/java/org/apache/commons/beanutils2/converters/BigIntegerConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/BigIntegerConverterTestCase.java
@@ -28,10 +28,6 @@ public class BigIntegerConverterTestCase extends AbstractNumberConverterTest<Big
 
     private Converter<BigInteger> converter;
 
-    public BigIntegerConverterTestCase(final String name) {
-        super(name);
-    }
-
     @Override
     protected Class<BigInteger> getExpectedType() {
         return BigInteger.class;

--- a/src/test/java/org/apache/commons/beanutils2/converters/BigIntegerLocaleConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/BigIntegerLocaleConverterTestCase.java
@@ -26,10 +26,6 @@ import org.apache.commons.beanutils2.locale.converters.BigIntegerLocaleConverter
  */
 public class BigIntegerLocaleConverterTestCase extends BaseLocaleConverterTestCase<BigInteger> {
 
-    public BigIntegerLocaleConverterTestCase(final String name) {
-        super(name);
-    }
-
     /**
      * Sets up instance variables required by this test case.
      */

--- a/src/test/java/org/apache/commons/beanutils2/converters/BooleanConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/BooleanConverterTestCase.java
@@ -17,22 +17,23 @@
 
 package org.apache.commons.beanutils2.converters;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.commons.beanutils2.ConversionException;
+import org.junit.jupiter.api.Test;
 
 /**
  */
-public class BooleanConverterTestCase extends TestCase {
+public class BooleanConverterTestCase {
 
     public static final String[] STANDARD_TRUES = { "yes", "y", "true", "on", "1" };
 
     public static final String[] STANDARD_FALSES = { "no", "n", "false", "off", "0" };
 
-    public BooleanConverterTestCase(final String name) {
-        super(name);
-    }
-
+    @Test
     public void testAdditionalStrings() {
         final String[] trueStrings = { "sure" };
         final String[] falseStrings = { "nope" };
@@ -53,6 +54,7 @@ public class BooleanConverterTestCase extends TestCase {
         }
     }
 
+    @Test
     public void testCaseInsensitivity() {
         final AbstractConverter<Boolean> converter = new BooleanConverter();
         testConversionValues(converter, new String[] { "Yes", "TRUE" }, new String[] { "NO", "fAlSe" });
@@ -61,6 +63,7 @@ public class BooleanConverterTestCase extends TestCase {
     /**
      * Tests a conversion to another target type. This should not be possible.
      */
+    @Test
     public void testConversionToOtherType() {
         final AbstractConverter<Boolean> converter = new BooleanConverter();
         try {
@@ -81,6 +84,7 @@ public class BooleanConverterTestCase extends TestCase {
         }
     }
 
+    @Test
     public void testDefaultValue() {
         final Boolean defaultValue = Boolean.TRUE;
         final AbstractConverter<Boolean> converter = new BooleanConverter(defaultValue);
@@ -89,6 +93,7 @@ public class BooleanConverterTestCase extends TestCase {
         testConversionValues(converter, STANDARD_TRUES, STANDARD_FALSES);
     }
 
+    @Test
     public void testInvalidString() {
         final AbstractConverter<Boolean> converter = new BooleanConverter();
         try {
@@ -102,11 +107,13 @@ public class BooleanConverterTestCase extends TestCase {
     /**
      * Tests whether a conversion to a primitive boolean is possible.
      */
+    @Test
     public void testPrimitiveTargetClass() {
         final AbstractConverter<Boolean> converter = new BooleanConverter();
-        assertTrue("Wrong result", converter.convert(Boolean.TYPE, STANDARD_TRUES[0]));
+        assertTrue(converter.convert(Boolean.TYPE, STANDARD_TRUES[0]), "Wrong result");
     }
 
+    @Test
     public void testStandardValues() {
         final AbstractConverter<Boolean> converter = new BooleanConverter();
         testConversionValues(converter, STANDARD_TRUES, STANDARD_FALSES);

--- a/src/test/java/org/apache/commons/beanutils2/converters/ByteConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ByteConverterTestCase.java
@@ -26,10 +26,6 @@ public class ByteConverterTestCase extends AbstractNumberConverterTest<Byte> {
 
     private Converter<Byte> converter;
 
-    public ByteConverterTestCase(final String name) {
-        super(name);
-    }
-
     @Override
     protected Class<Byte> getExpectedType() {
         return Byte.class;

--- a/src/test/java/org/apache/commons/beanutils2/converters/ByteLocaleConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ByteLocaleConverterTestCase.java
@@ -24,10 +24,6 @@ import org.apache.commons.beanutils2.locale.converters.ByteLocaleConverter;
  */
 public class ByteLocaleConverterTestCase extends BaseLocaleConverterTestCase<Byte> {
 
-    public ByteLocaleConverterTestCase(final String name) {
-        super(name);
-    }
-
     /**
      * Sets up instance variables required by this test case.
      */

--- a/src/test/java/org/apache/commons/beanutils2/converters/CalendarConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/CalendarConverterTestCase.java
@@ -24,15 +24,6 @@ import java.util.Calendar;
 public class CalendarConverterTestCase extends AbstractDateConverterTest<Calendar> {
 
     /**
-     * Constructs a new Calendar test case.
-     *
-     * @param name Test Name
-     */
-    public CalendarConverterTestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Gets the expected type
      *
      * @return The expected type

--- a/src/test/java/org/apache/commons/beanutils2/converters/CharacterConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/CharacterConverterTestCase.java
@@ -16,56 +16,56 @@
  */
 package org.apache.commons.beanutils2.converters;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Case for the CharacterConverter class.
  */
-public class CharacterConverterTestCase extends TestCase {
-
-    /**
-     * Constructs a new Character Converter test case.
-     *
-     * @param name Test Name
-     */
-    public CharacterConverterTestCase(final String name) {
-        super(name);
-    }
+public class CharacterConverterTestCase {
 
     /** Sets Up */
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
     }
 
     /** Tear Down */
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
     }
 
     /**
      * Tests whether the primitive char class can be passed as target type.
      */
+    @Test
     public void testConvertToChar() {
         final Converter<Character> converter = new CharacterConverter();
-        assertEquals("Wrong result", Character.valueOf('F'), converter.convert(Character.TYPE, "FOO"));
+        assertEquals(Character.valueOf('F'), converter.convert(Character.TYPE, "FOO"), "Wrong result");
     }
 
     /**
      * Test Conversion to Character
      */
+    @Test
     public void testConvertToCharacter() {
         final Converter<Character> converter = new CharacterConverter();
-        assertEquals("Character Test", Character.valueOf('N'), converter.convert(Character.class, Character.valueOf('N')));
-        assertEquals("String Test", Character.valueOf('F'), converter.convert(Character.class, "FOO"));
-        assertEquals("Integer Test", Character.valueOf('3'), converter.convert(Character.class, Integer.valueOf(321)));
+        assertEquals(Character.valueOf('N'), converter.convert(Character.class, Character.valueOf('N')),
+                                "Character Test");
+        assertEquals(Character.valueOf('F'), converter.convert(Character.class, "FOO"), "String Test");
+        assertEquals(Character.valueOf('3'), converter.convert(Character.class, Integer.valueOf(321)),
+                                "Integer Test");
     }
 
     /**
      * Tests a conversion to character for null input if no default value is provided.
      */
+    @Test
     public void testConvertToCharacterNullNoDefault() {
         final Converter<Character> converter = new CharacterConverter();
         try {
@@ -79,6 +79,7 @@ public class CharacterConverterTestCase extends TestCase {
     /**
      * Test Conversion to String
      */
+    @Test
     @SuppressWarnings("unchecked") // testing raw conversion
     public void testConvertToString() {
 
@@ -86,15 +87,16 @@ public class CharacterConverterTestCase extends TestCase {
         @SuppressWarnings("rawtypes")
         final Converter raw = converter;
 
-        assertEquals("Character Test", "N", raw.convert(String.class, Character.valueOf('N')));
-        assertEquals("String Test", "F", raw.convert(String.class, "FOO"));
-        assertEquals("Integer Test", "3", raw.convert(String.class, Integer.valueOf(321)));
-        assertEquals("Null Test", null, raw.convert(String.class, null));
+        assertEquals("N", raw.convert(String.class, Character.valueOf('N')), "Character Test");
+        assertEquals("F", raw.convert(String.class, "FOO"), "String Test");
+        assertEquals("3", raw.convert(String.class, Integer.valueOf(321)), "Integer Test");
+        assertEquals(null, raw.convert(String.class, null), "Null Test");
     }
 
     /**
      * Tries a conversion to an unsupported type.
      */
+    @Test
     @SuppressWarnings("unchecked") // tests failure so allow mismatch
     public void testConvertToUnsupportedType() {
         @SuppressWarnings("rawtypes") // tests failure so allow mismatch
@@ -110,8 +112,9 @@ public class CharacterConverterTestCase extends TestCase {
     /**
      * Test Conversion to Character (with default)
      */
+    @Test
     public void testDefault() {
         final CharacterConverter converter = new CharacterConverter('C');
-        assertEquals("Default Test", Character.valueOf('C'), converter.convert(Character.class, null));
+        assertEquals(Character.valueOf('C'), converter.convert(Character.class, null), "Default Test");
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/converters/ClassConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ClassConverterTestCase.java
@@ -16,43 +16,40 @@
  */
 package org.apache.commons.beanutils2.converters;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Case for the ClassConverter class.
  */
-public class ClassConverterTestCase extends TestCase {
-
-    /**
-     * Constructs a new Class Converter test case.
-     *
-     * @param name Test Name
-     */
-    public ClassConverterTestCase(final String name) {
-        super(name);
-    }
+public class ClassConverterTestCase {
 
     /** Sets Up */
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
     }
 
     /** Tear Down */
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
     }
 
     /**
      * Test Array Conversion
      */
+    @Test
     public void testArray() {
         final Converter<Class<?>> converter = new ClassConverter();
 
         // Test Array Class to String
-        assertEquals("Array to String", "[Ljava.lang.Boolean;", converter.convert(String.class, Boolean[].class));
+        assertEquals("[Ljava.lang.Boolean;", converter.convert(String.class, Boolean[].class),
+                                "Array to String");
 
         // *** N.B. for some reason the following works on m1, but not m2
         // Test String to Array Class
@@ -62,12 +59,14 @@ public class ClassConverterTestCase extends TestCase {
     /**
      * Test Conversion to Class
      */
+    @Test
     public void testConvertToClass() {
         final Converter<Class<?>> converter = new ClassConverter();
 
-        assertEquals("Class Test", Integer.class, converter.convert(Class.class, Integer.class));
-        assertEquals("String Test", Integer.class, converter.convert(Class.class, "java.lang.Integer"));
-        assertEquals("StringBuilder Test", Integer.class, converter.convert(Class.class, new StringBuilder("java.lang.Integer")));
+        assertEquals(Integer.class, converter.convert(Class.class, Integer.class), "Class Test");
+        assertEquals(Integer.class, converter.convert(Class.class, "java.lang.Integer"), "String Test");
+        assertEquals(Integer.class, converter.convert(Class.class, new StringBuilder("java.lang.Integer")),
+                                "StringBuilder Test");
 
         // Invalid Test
         try {
@@ -89,40 +88,44 @@ public class ClassConverterTestCase extends TestCase {
     /**
      * Test Invalid Conversion with default
      */
+    @Test
     public void testConvertToClassDefault() {
 
         final Converter<Class<?>> converter = new ClassConverter(Object.class);
 
-        assertEquals("Invalid Test", Object.class, converter.convert(Class.class, Integer.valueOf(6)));
-        assertEquals("Null Test", Object.class, converter.convert(Class.class, null));
+        assertEquals(Object.class, converter.convert(Class.class, Integer.valueOf(6)), "Invalid Test");
+        assertEquals(Object.class, converter.convert(Class.class, null), "Null Test");
     }
 
     /**
      * Test Invalid Conversion with default "null"
      */
+    @Test
     public void testConvertToClassDefaultNull() {
 
         final Converter<Class<?>> converter = new ClassConverter(null);
 
-        assertEquals("Invalid Test", null, converter.convert(Class.class, Integer.valueOf(6)));
-        assertEquals("Null Test", null, converter.convert(Class.class, null));
+        assertEquals(null, converter.convert(Class.class, Integer.valueOf(6)), "Invalid Test");
+        assertEquals(null, converter.convert(Class.class, null), "Null Test");
     }
 
     /**
      * Test Conversion to String
      */
+    @Test
     public void testConvertToString() {
         final Converter<Class<?>> converter = new ClassConverter();
 
-        assertEquals("Class Test", "java.lang.Integer", converter.convert(String.class, Integer.class));
-        assertEquals("Value Test", "foo", converter.convert(String.class, "foo"));
-        assertEquals("Value Test", "bar", converter.convert(String.class, new StringBuilder("bar")));
-        assertEquals("Null Test", null, converter.convert(String.class, null));
+        assertEquals("java.lang.Integer", converter.convert(String.class, Integer.class), "Class Test");
+        assertEquals("foo", converter.convert(String.class, "foo"), "Value Test");
+        assertEquals("bar", converter.convert(String.class, new StringBuilder("bar")), "Value Test");
+        assertEquals(null, converter.convert(String.class, null), "Null Test");
     }
 
     /**
      * Test Invalid
      */
+    @Test
     public void testInvalid() {
         final Converter<Class<?>> converter = new ClassConverter();
 
@@ -138,6 +141,7 @@ public class ClassConverterTestCase extends TestCase {
     /**
      * Tries a conversion to an unsupported target type.
      */
+    @Test
     public void testUnsupportedTargetType() {
         final Converter<Class<?>> converter = new ClassConverter();
         try {

--- a/src/test/java/org/apache/commons/beanutils2/converters/ClassReloaderTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ClassReloaderTestCase.java
@@ -17,23 +17,24 @@
 
 package org.apache.commons.beanutils2.converters;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the ClassReloader utility class.
  */
-public class ClassReloaderTestCase extends TestCase {
+public class ClassReloaderTestCase {
 
     public static class DummyClass {
-    }
-
-    public ClassReloaderTestCase(final String name) {
-        super(name);
     }
 
     /**
      * Test basic operation of the ClassReloader.
      */
+    @Test
     public void testBasicOperation() throws Exception {
         final ClassLoader sharedLoader = this.getClass().getClassLoader();
         final ClassReloader componentLoader = new ClassReloader(sharedLoader);
@@ -53,10 +54,10 @@ public class ClassReloaderTestCase extends TestCase {
         final Object obj1 = sharedClass.newInstance();
         final Object obj2 = componentClass.newInstance();
 
-        assertTrue("Obj1 class incorrect", sharedClass.isInstance(obj1));
-        assertFalse("Obj1 class incorrect", componentClass.isInstance(obj1));
-        assertFalse("Obj2 class incorrect", sharedClass.isInstance(obj2));
-        assertTrue("Obj2 class incorrect", componentClass.isInstance(obj2));
+        assertTrue(sharedClass.isInstance(obj1), "Obj1 class incorrect");
+        assertFalse(componentClass.isInstance(obj1), "Obj1 class incorrect");
+        assertFalse(sharedClass.isInstance(obj2), "Obj2 class incorrect");
+        assertTrue(componentClass.isInstance(obj2), "Obj2 class incorrect");
     }
 
 }

--- a/src/test/java/org/apache/commons/beanutils2/converters/DateConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/DateConverterTestCase.java
@@ -25,15 +25,6 @@ import java.util.Date;
 public class DateConverterTestCase extends AbstractDateConverterTest<Date> {
 
     /**
-     * Constructs a new Date test case.
-     *
-     * @param name Test Name
-     */
-    public DateConverterTestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Gets the expected type
      *
      * @return The expected type

--- a/src/test/java/org/apache/commons/beanutils2/converters/DateLocaleConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/DateLocaleConverterTestCase.java
@@ -46,10 +46,6 @@ public class DateLocaleConverterTestCase extends BaseLocaleConverterTestCase<Dat
     protected String defaultShortDateValue;
     protected boolean validLocalDateSymbols;
 
-    public DateLocaleConverterTestCase(final String name) {
-        super(name);
-    }
-
     /**
      * Sets up instance variables required by this test case.
      */

--- a/src/test/java/org/apache/commons/beanutils2/converters/DoubleConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/DoubleConverterTestCase.java
@@ -26,10 +26,6 @@ public class DoubleConverterTestCase extends AbstractNumberConverterTest<Double>
 
     private Converter<Double> converter;
 
-    public DoubleConverterTestCase(final String name) {
-        super(name);
-    }
-
     @Override
     protected Class<Double> getExpectedType() {
         return Double.class;

--- a/src/test/java/org/apache/commons/beanutils2/converters/DoubleLocaleConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/DoubleLocaleConverterTestCase.java
@@ -24,10 +24,6 @@ import org.apache.commons.beanutils2.locale.converters.DoubleLocaleConverter;
  */
 public class DoubleLocaleConverterTestCase extends BaseLocaleConverterTestCase<Double> {
 
-    public DoubleLocaleConverterTestCase(final String name) {
-        super(name);
-    }
-
     /**
      * Sets up instance variables required by this test case.
      */

--- a/src/test/java/org/apache/commons/beanutils2/converters/DurationConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/DurationConverterTestCase.java
@@ -17,23 +17,23 @@
 
 package org.apache.commons.beanutils2.converters;
 
-import java.time.Duration;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import junit.framework.TestCase;
+import java.time.Duration;
 
 import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Case for the DurationConverter class.
  */
-public class DurationConverterTestCase extends TestCase {
+public class DurationConverterTestCase {
 
     private Converter<Duration> converter;
-
-    public DurationConverterTestCase(final String name) {
-        super(name);
-    }
 
     protected Class<?> getExpectedType() {
         return Duration.class;
@@ -43,16 +43,17 @@ public class DurationConverterTestCase extends TestCase {
         return new DurationConverter();
     }
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         converter = makeConverter();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         converter = null;
     }
 
+    @Test
     public void testSimpleConversion() throws Exception {
         final String[] message = { "from String", "from String", "from String", "from String", "from String", "from String", "from String", "from String", };
 
@@ -61,18 +62,19 @@ public class DurationConverterTestCase extends TestCase {
         final Duration[] expected = { Duration.parse("PT20.345S"), Duration.parse("PT15M"), Duration.parse("P2DT3H4M") };
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(message[i] + " to URI", expected[i], converter.convert(Duration.class, input[i]));
-            assertEquals(message[i] + " to null type", expected[i], converter.convert(null, input[i]));
+            assertEquals(expected[i], converter.convert(Duration.class, input[i]), message[i] + " to URI");
+            assertEquals(expected[i], converter.convert(null, input[i]), message[i] + " to null type");
         }
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(input[i] + " to String", input[i], converter.convert(String.class, expected[i]));
+            assertEquals(input[i], converter.convert(String.class, expected[i]), input[i] + " to String");
         }
     }
 
     /**
      * Tests a conversion to an unsupported type.
      */
+    @Test
     public void testUnsupportedType() {
         try {
             converter.convert(Integer.class, "http://www.apache.org");

--- a/src/test/java/org/apache/commons/beanutils2/converters/EnumConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/EnumConverterTestCase.java
@@ -17,25 +17,25 @@
 
 package org.apache.commons.beanutils2.converters;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Case for the EnumConverter class.
  */
-public class EnumConverterTestCase extends TestCase {
+public class EnumConverterTestCase {
 
     public enum PizzaStatus {
         ORDERED, READY, DELIVERED;
     }
 
     private Converter<Enum<PizzaStatus>> converter;
-
-    public EnumConverterTestCase(final String name) {
-        super(name);
-    }
 
     protected Class<?> getExpectedType() {
         return Enum.class;
@@ -45,16 +45,17 @@ public class EnumConverterTestCase extends TestCase {
         return new EnumConverter<>();
     }
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         converter = makeConverter();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         converter = null;
     }
 
+    @Test
     public void testSimpleConversion() throws Exception {
         final String[] message = { "from String", "from String", "from String", "from String", "from String", "from String", "from String", "from String", };
 
@@ -63,17 +64,19 @@ public class EnumConverterTestCase extends TestCase {
         final PizzaStatus[] expected = { PizzaStatus.DELIVERED, PizzaStatus.ORDERED, PizzaStatus.READY };
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(message[i] + " to Enum", expected[i], converter.convert(PizzaStatus.class, input[i]));
+            assertEquals(expected[i], converter.convert(PizzaStatus.class, input[i]),
+                                    message[i] + " to Enum");
         }
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(input[i] + " to String", input[i], converter.convert(String.class, expected[i]));
+            assertEquals(input[i], converter.convert(String.class, expected[i]), input[i] + " to String");
         }
     }
 
     /**
      * Tests a conversion to an unsupported type.
      */
+    @Test
     public void testUnsupportedType() {
         try {
             converter.convert(Integer.class, "http://www.apache.org");

--- a/src/test/java/org/apache/commons/beanutils2/converters/FileConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/FileConverterTestCase.java
@@ -17,23 +17,23 @@
 
 package org.apache.commons.beanutils2.converters;
 
-import java.io.File;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import junit.framework.TestCase;
+import java.io.File;
 
 import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Case for the FileConverter class.
  */
-public class FileConverterTestCase extends TestCase {
+public class FileConverterTestCase {
 
     private Converter<File> converter;
-
-    public FileConverterTestCase(final String name) {
-        super(name);
-    }
 
     protected Class<?> getExpectedType() {
         return File.class;
@@ -43,16 +43,17 @@ public class FileConverterTestCase extends TestCase {
         return new FileConverter();
     }
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         converter = makeConverter();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         converter = null;
     }
 
+    @Test
     public void testSimpleConversion() throws Exception {
         final String[] message = { "from String", "from String", "from String" };
 
@@ -61,14 +62,15 @@ public class FileConverterTestCase extends TestCase {
         final File[] expected = { new File("/tmp"), new File("/tmp/foo.txt"), new File("/tmp/does/not/exist.foo") };
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(message[i] + " to File", expected[i], converter.convert(File.class, input[i]));
-            assertEquals(message[i] + " to null type", expected[i], converter.convert(null, input[i]));
+            assertEquals(expected[i], converter.convert(File.class, input[i]), message[i] + " to File");
+            assertEquals(expected[i], converter.convert(null, input[i]), message[i] + " to null type");
         }
     }
 
     /**
      * Tries a conversion to an unsupported target type.
      */
+    @Test
     public void testUnsupportedTargetType() {
         try {
             converter.convert(Integer.class, "/tmp");

--- a/src/test/java/org/apache/commons/beanutils2/converters/FloatConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/FloatConverterTestCase.java
@@ -26,10 +26,6 @@ public class FloatConverterTestCase extends AbstractNumberConverterTest<Float> {
 
     private Converter<Float> converter;
 
-    public FloatConverterTestCase(final String name) {
-        super(name);
-    }
-
     @Override
     protected Class<Float> getExpectedType() {
         return Float.class;

--- a/src/test/java/org/apache/commons/beanutils2/converters/FloatLocaleConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/FloatLocaleConverterTestCase.java
@@ -29,10 +29,6 @@ import org.apache.commons.beanutils2.locale.converters.FloatLocaleConverter;
  */
 public class FloatLocaleConverterTestCase extends BaseLocaleConverterTestCase<Float> {
 
-    public FloatLocaleConverterTestCase(final String name) {
-        super(name);
-    }
-
     /**
      * Sets up instance variables required by this test case.
      */

--- a/src/test/java/org/apache/commons/beanutils2/converters/IntegerConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/IntegerConverterTestCase.java
@@ -29,10 +29,6 @@ public class IntegerConverterTestCase extends AbstractNumberConverterTest<Intege
 
     private Converter<Integer> converter;
 
-    public IntegerConverterTestCase(final String name) {
-        super(name);
-    }
-
     @Override
     protected Class<Integer> getExpectedType() {
         return Integer.class;

--- a/src/test/java/org/apache/commons/beanutils2/converters/IntegerLocaleConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/IntegerLocaleConverterTestCase.java
@@ -24,10 +24,6 @@ import org.apache.commons.beanutils2.locale.converters.IntegerLocaleConverter;
  */
 public class IntegerLocaleConverterTestCase extends BaseLocaleConverterTestCase<Integer> {
 
-    public IntegerLocaleConverterTestCase(final String name) {
-        super(name);
-    }
-
     /**
      * Sets up instance variables required by this test case.
      */

--- a/src/test/java/org/apache/commons/beanutils2/converters/LocalDateConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/LocalDateConverterTestCase.java
@@ -27,15 +27,6 @@ import java.util.Calendar;
 public class LocalDateConverterTestCase extends AbstractDateConverterTest<LocalDate> {
 
     /**
-     * Constructs a new Date test case.
-     *
-     * @param name Test Name
-     */
-    public LocalDateConverterTestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Gets the expected type
      *
      * @return The expected type

--- a/src/test/java/org/apache/commons/beanutils2/converters/LocalDateTimeConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/LocalDateTimeConverterTestCase.java
@@ -27,15 +27,6 @@ import java.util.Calendar;
 public class LocalDateTimeConverterTestCase extends AbstractDateConverterTest<LocalDateTime> {
 
     /**
-     * Constructs a new Date test case.
-     *
-     * @param name Test Name
-     */
-    public LocalDateTimeConverterTestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Gets the expected type
      *
      * @return The expected type

--- a/src/test/java/org/apache/commons/beanutils2/converters/LocalTimeConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/LocalTimeConverterTestCase.java
@@ -17,23 +17,23 @@
 
 package org.apache.commons.beanutils2.converters;
 
-import java.time.LocalTime;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import junit.framework.TestCase;
+import java.time.LocalTime;
 
 import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Case for the LocalTimeConverter class.
  */
-public class LocalTimeConverterTestCase extends TestCase {
+public class LocalTimeConverterTestCase {
 
     private Converter<LocalTime> converter;
-
-    public LocalTimeConverterTestCase(final String name) {
-        super(name);
-    }
 
     protected Class<?> getExpectedType() {
         return LocalTime.class;
@@ -43,16 +43,17 @@ public class LocalTimeConverterTestCase extends TestCase {
         return new LocalTimeConverter();
     }
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         converter = makeConverter();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         converter = null;
     }
 
+    @Test
     public void testSimpleConversion() throws Exception {
         final String[] message = { "from String", "from String", "from String", "from String", "from String", "from String", "from String", "from String", };
 
@@ -61,18 +62,19 @@ public class LocalTimeConverterTestCase extends TestCase {
         final LocalTime[] expected = { LocalTime.parse("10:15"), LocalTime.parse("08:45:30") };
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(message[i] + " to URI", expected[i], converter.convert(LocalTime.class, input[i]));
-            assertEquals(message[i] + " to null type", expected[i], converter.convert(null, input[i]));
+            assertEquals(expected[i], converter.convert(LocalTime.class, input[i]), message[i] + " to URI");
+            assertEquals(expected[i], converter.convert(null, input[i]), message[i] + " to null type");
         }
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(input[i] + " to String", input[i], converter.convert(String.class, expected[i]));
+            assertEquals(input[i], converter.convert(String.class, expected[i]), input[i] + " to String");
         }
     }
 
     /**
      * Tests a conversion to an unsupported type.
      */
+    @Test
     public void testUnsupportedType() {
         try {
             converter.convert(Integer.class, "http://www.apache.org");

--- a/src/test/java/org/apache/commons/beanutils2/converters/LongConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/LongConverterTestCase.java
@@ -26,10 +26,6 @@ public class LongConverterTestCase extends AbstractNumberConverterTest<Long> {
 
     private Converter<Long> converter;
 
-    public LongConverterTestCase(final String name) {
-        super(name);
-    }
-
     @Override
     protected Class<Long> getExpectedType() {
         return Long.class;

--- a/src/test/java/org/apache/commons/beanutils2/converters/LongLocaleConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/LongLocaleConverterTestCase.java
@@ -24,10 +24,6 @@ import org.apache.commons.beanutils2.locale.converters.LongLocaleConverter;
  */
 public class LongLocaleConverterTestCase extends BaseLocaleConverterTestCase<Long> {
 
-    public LongLocaleConverterTestCase(final String name) {
-        super(name);
-    }
-
     /**
      * Sets up instance variables required by this test case.
      */

--- a/src/test/java/org/apache/commons/beanutils2/converters/MonthDayConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/MonthDayConverterTestCase.java
@@ -17,23 +17,23 @@
 
 package org.apache.commons.beanutils2.converters;
 
-import java.time.MonthDay;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import junit.framework.TestCase;
+import java.time.MonthDay;
 
 import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Case for the MonthDayConverter class.
  */
-public class MonthDayConverterTestCase extends TestCase {
+public class MonthDayConverterTestCase {
 
     private Converter<MonthDay> converter;
-
-    public MonthDayConverterTestCase(final String name) {
-        super(name);
-    }
 
     protected Class<?> getExpectedType() {
         return MonthDay.class;
@@ -43,16 +43,17 @@ public class MonthDayConverterTestCase extends TestCase {
         return new MonthDayConverter();
     }
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         converter = makeConverter();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         converter = null;
     }
 
+    @Test
     public void testSimpleConversion() throws Exception {
         final String[] message = { "from String", "from String", "from String", "from String", "from String", "from String", "from String", "from String", };
 
@@ -61,18 +62,19 @@ public class MonthDayConverterTestCase extends TestCase {
         final MonthDay[] expected = { MonthDay.parse("--12-03"), MonthDay.parse("--05-30"), MonthDay.parse("--01-01") };
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(message[i] + " to URI", expected[i], converter.convert(MonthDay.class, input[i]));
-            assertEquals(message[i] + " to null type", expected[i], converter.convert(null, input[i]));
+            assertEquals(expected[i], converter.convert(MonthDay.class, input[i]), message[i] + " to URI");
+            assertEquals(expected[i], converter.convert(null, input[i]), message[i] + " to null type");
         }
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(input[i] + " to String", input[i], converter.convert(String.class, expected[i]));
+            assertEquals(input[i], converter.convert(String.class, expected[i]), input[i] + " to String");
         }
     }
 
     /**
      * Tests a conversion to an unsupported type.
      */
+    @Test
     public void testUnsupportedType() {
         try {
             converter.convert(Integer.class, "http://www.apache.org");

--- a/src/test/java/org/apache/commons/beanutils2/converters/OffsetDateTimeConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/OffsetDateTimeConverterTestCase.java
@@ -27,15 +27,6 @@ import java.util.Calendar;
 public class OffsetDateTimeConverterTestCase extends AbstractDateConverterTest<OffsetDateTime> {
 
     /**
-     * Constructs a new Date test case.
-     *
-     * @param name Test Name
-     */
-    public OffsetDateTimeConverterTestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Gets the expected type
      *
      * @return The expected type

--- a/src/test/java/org/apache/commons/beanutils2/converters/OffsetTimeConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/OffsetTimeConverterTestCase.java
@@ -17,23 +17,23 @@
 
 package org.apache.commons.beanutils2.converters;
 
-import java.time.OffsetTime;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import junit.framework.TestCase;
+import java.time.OffsetTime;
 
 import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Case for the OffsetTimeConverter class.
  */
-public class OffsetTimeConverterTestCase extends TestCase {
+public class OffsetTimeConverterTestCase {
 
     private Converter<OffsetTime> converter;
-
-    public OffsetTimeConverterTestCase(final String name) {
-        super(name);
-    }
 
     protected Class<?> getExpectedType() {
         return OffsetTime.class;
@@ -43,16 +43,17 @@ public class OffsetTimeConverterTestCase extends TestCase {
         return new OffsetTimeConverter();
     }
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         converter = makeConverter();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         converter = null;
     }
 
+    @Test
     public void testSimpleConversion() throws Exception {
         final String[] message = { "from String", "from String", "from String", "from String", "from String", "from String", "from String", "from String", };
 
@@ -61,18 +62,19 @@ public class OffsetTimeConverterTestCase extends TestCase {
         final OffsetTime[] expected = { OffsetTime.parse("10:15+01:00"), OffsetTime.parse("08:45:30+14:00") };
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(message[i] + " to URI", expected[i], converter.convert(OffsetTime.class, input[i]));
-            assertEquals(message[i] + " to null type", expected[i], converter.convert(null, input[i]));
+            assertEquals(expected[i], converter.convert(OffsetTime.class, input[i]), message[i] + " to URI");
+            assertEquals(expected[i], converter.convert(null, input[i]), message[i] + " to null type");
         }
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(input[i] + " to String", input[i], converter.convert(String.class, expected[i]));
+            assertEquals(input[i], converter.convert(String.class, expected[i]), input[i] + " to String");
         }
     }
 
     /**
      * Tests a conversion to an unsupported type.
      */
+    @Test
     public void testUnsupportedType() {
         try {
             converter.convert(Integer.class, "http://www.apache.org");

--- a/src/test/java/org/apache/commons/beanutils2/converters/PathConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/PathConverterTestCase.java
@@ -17,25 +17,25 @@
 
 package org.apache.commons.beanutils2.converters;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
- * Test Case for the UUIDConverter class.
+ * Test Case for the PathConverter class.
  */
-public class PathConverterTestCase extends TestCase {
+public class PathConverterTestCase {
 
     private Converter<Path> converter;
-
-    public PathConverterTestCase(final String name) {
-        super(name);
-    }
 
     protected Class<?> getExpectedType() {
         return Path.class;
@@ -45,16 +45,17 @@ public class PathConverterTestCase extends TestCase {
         return new PathConverter();
     }
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         converter = makeConverter();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         converter = null;
     }
 
+    @Test
     public void testSimpleConversion() throws Exception {
         final String[] message = { "from String", "from String", "from String", "from String", "from String", "from String", "from String", "from String", };
 
@@ -66,18 +67,19 @@ public class PathConverterTestCase extends TestCase {
         final Path[] expected = { Paths.get(separator + "foo" + separator + "bar" + separator + "baz"), Paths.get(separator) };
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(message[i] + " to URI", expected[i], converter.convert(Path.class, input[i]));
-            assertEquals(message[i] + " to null type", expected[i], converter.convert(null, input[i]));
+            assertEquals(expected[i], converter.convert(Path.class, input[i]), message[i] + " to URI");
+            assertEquals(expected[i], converter.convert(null, input[i]), message[i] + " to null type");
         }
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(input[i] + " to String", input[i], converter.convert(String.class, expected[i]));
+            assertEquals(input[i], converter.convert(String.class, expected[i]), input[i] + " to String");
         }
     }
 
     /**
      * Tests a conversion to an unsupported type.
      */
+    @Test
     public void testUnsupportedType() {
         try {
             converter.convert(Integer.class, "http://www.apache.org");

--- a/src/test/java/org/apache/commons/beanutils2/converters/PeriodConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/PeriodConverterTestCase.java
@@ -17,23 +17,23 @@
 
 package org.apache.commons.beanutils2.converters;
 
-import java.time.Period;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import junit.framework.TestCase;
+import java.time.Period;
 
 import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Case for the PeriodConverter class.
  */
-public class PeriodConverterTestCase extends TestCase {
+public class PeriodConverterTestCase {
 
     private Converter<Period> converter;
-
-    public PeriodConverterTestCase(final String name) {
-        super(name);
-    }
 
     protected Class<?> getExpectedType() {
         return Period.class;
@@ -43,16 +43,17 @@ public class PeriodConverterTestCase extends TestCase {
         return new PeriodConverter();
     }
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         converter = makeConverter();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         converter = null;
     }
 
+    @Test
     public void testSimpleConversion() throws Exception {
         final String[] message = { "from String", "from String", "from String", "from String", "from String", "from String", "from String", "from String", };
 
@@ -61,18 +62,19 @@ public class PeriodConverterTestCase extends TestCase {
         final Period[] expected = { Period.parse("P2Y"), Period.parse("P5D"), Period.parse("P1Y2M3D") };
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(message[i] + " to URI", expected[i], converter.convert(Period.class, input[i]));
-            assertEquals(message[i] + " to null type", expected[i], converter.convert(null, input[i]));
+            assertEquals(expected[i], converter.convert(Period.class, input[i]), message[i] + " to URI");
+            assertEquals(expected[i], converter.convert(null, input[i]), message[i] + " to null type");
         }
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(input[i] + " to String", input[i], converter.convert(String.class, expected[i]));
+            assertEquals(input[i], converter.convert(String.class, expected[i]), input[i] + " to String");
         }
     }
 
     /**
      * Tests a conversion to an unsupported type.
      */
+    @Test
     public void testUnsupportedType() {
         try {
             converter.convert(Integer.class, "http://www.apache.org");

--- a/src/test/java/org/apache/commons/beanutils2/converters/ShortConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ShortConverterTestCase.java
@@ -26,10 +26,6 @@ public class ShortConverterTestCase extends AbstractNumberConverterTest<Short> {
 
     private ShortConverter converter;
 
-    public ShortConverterTestCase(final String name) {
-        super(name);
-    }
-
     @Override
     protected Class<Short> getExpectedType() {
         return Short.class;

--- a/src/test/java/org/apache/commons/beanutils2/converters/ShortLocaleConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ShortLocaleConverterTestCase.java
@@ -25,10 +25,6 @@ import org.apache.commons.beanutils2.locale.converters.ShortLocaleConverter;
 
 public class ShortLocaleConverterTestCase extends BaseLocaleConverterTestCase<Short> {
 
-    public ShortLocaleConverterTestCase(final String name) {
-        super(name);
-    }
-
     /**
      * Sets up instance variables required by this test case.
      */

--- a/src/test/java/org/apache/commons/beanutils2/converters/StringConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/StringConverterTestCase.java
@@ -16,34 +16,38 @@
  */
 package org.apache.commons.beanutils2.converters;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@code StringConverter}.
  */
-public class StringConverterTestCase extends TestCase {
+public class StringConverterTestCase {
     /** The converter to be tested. */
     private StringConverter converter;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         converter = new StringConverter();
     }
 
     /**
      * Tests a conversion to a string type.
      */
+    @Test
     public void testConvertToTypeString() {
         final Object value = new Object();
         final String strVal = converter.convert(String.class, value);
-        assertEquals("Wrong conversion result", value.toString(), strVal);
+        assertEquals(value.toString(), strVal, "Wrong conversion result");
     }
 
     /**
      * Tests whether the correct default type is returned.
      */
+    @Test
     public void testDefaultType() {
-        assertEquals("Wrong default type", String.class, converter.getDefaultType());
+        assertEquals(String.class, converter.getDefaultType(), "Wrong default type");
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/converters/URIConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/URIConverterTestCase.java
@@ -17,23 +17,23 @@
 
 package org.apache.commons.beanutils2.converters;
 
-import java.net.URI;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import junit.framework.TestCase;
+import java.net.URI;
 
 import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Case for the URIConverter class.
  */
-public class URIConverterTestCase extends TestCase {
+public class URIConverterTestCase {
 
     private Converter<URI> converter;
-
-    public URIConverterTestCase(final String name) {
-        super(name);
-    }
 
     protected Class<?> getExpectedType() {
         return URI.class;
@@ -43,16 +43,17 @@ public class URIConverterTestCase extends TestCase {
         return new URIConverter();
     }
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         converter = makeConverter();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         converter = null;
     }
 
+    @Test
     public void testSimpleConversion() throws Exception {
         final String[] message = { "from String", "from String", "from String", "from String", "from String", "from String", "from String", "from String", };
 
@@ -64,18 +65,19 @@ public class URIConverterTestCase extends TestCase {
                 new URI("http://user:admin@www.apache.org:50/one/two.three"), new URI("http://notreal.apache.org") };
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(message[i] + " to URI", expected[i], converter.convert(URI.class, input[i]));
-            assertEquals(message[i] + " to null type", expected[i], converter.convert(null, input[i]));
+            assertEquals(expected[i], converter.convert(URI.class, input[i]), message[i] + " to URI");
+            assertEquals(expected[i], converter.convert(null, input[i]), message[i] + " to null type");
         }
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(input[i] + " to String", input[i], converter.convert(String.class, expected[i]));
+            assertEquals(input[i], converter.convert(String.class, expected[i]), input[i] + " to String");
         }
     }
 
     /**
      * Tests a conversion to an unsupported type.
      */
+    @Test
     public void testUnsupportedType() {
         try {
             converter.convert(Integer.class, "http://www.apache.org");

--- a/src/test/java/org/apache/commons/beanutils2/converters/UUIDConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/UUIDConverterTestCase.java
@@ -17,23 +17,23 @@
 
 package org.apache.commons.beanutils2.converters;
 
-import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import junit.framework.TestCase;
+import java.util.UUID;
 
 import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Case for the UUIDConverter class.
  */
-public class UUIDConverterTestCase extends TestCase {
+public class UUIDConverterTestCase {
 
     private Converter<UUID> converter;
-
-    public UUIDConverterTestCase(final String name) {
-        super(name);
-    }
 
     protected Class<?> getExpectedType() {
         return UUID.class;
@@ -43,16 +43,17 @@ public class UUIDConverterTestCase extends TestCase {
         return new UUIDConverter();
     }
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         converter = makeConverter();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         converter = null;
     }
 
+    @Test
     public void testSimpleConversion() throws Exception {
         final String[] message = { "from String", "from String", "from String", "from String", "from String", "from String", "from String", "from String", };
 
@@ -61,18 +62,19 @@ public class UUIDConverterTestCase extends TestCase {
         final UUID[] expected = { UUID.fromString("123e4567-e89b-12d3-a456-556642440000"), UUID.fromString("7dc53df5-703e-49b3-8670-b1c468f47f1f") };
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(message[i] + " to URI", expected[i], converter.convert(UUID.class, input[i]));
-            assertEquals(message[i] + " to null type", expected[i], converter.convert(null, input[i]));
+            assertEquals(expected[i], converter.convert(UUID.class, input[i]), message[i] + " to URI");
+            assertEquals(expected[i], converter.convert(null, input[i]), message[i] + " to null type");
         }
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(input[i] + " to String", input[i], converter.convert(String.class, expected[i]));
+            assertEquals(input[i], converter.convert(String.class, expected[i]), input[i] + " to String");
         }
     }
 
     /**
      * Tests a conversion to an unsupported type.
      */
+    @Test
     public void testUnsupportedType() {
         try {
             converter.convert(Integer.class, "http://www.apache.org");

--- a/src/test/java/org/apache/commons/beanutils2/converters/YearConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/YearConverterTestCase.java
@@ -17,23 +17,23 @@
 
 package org.apache.commons.beanutils2.converters;
 
-import java.time.Year;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import junit.framework.TestCase;
+import java.time.Year;
 
 import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Case for the YearConverter class.
  */
-public class YearConverterTestCase extends TestCase {
+public class YearConverterTestCase {
 
     private Converter<Year> converter;
-
-    public YearConverterTestCase(final String name) {
-        super(name);
-    }
 
     protected Class<?> getExpectedType() {
         return Year.class;
@@ -43,16 +43,17 @@ public class YearConverterTestCase extends TestCase {
         return new YearConverter();
     }
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         converter = makeConverter();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         converter = null;
     }
 
+    @Test
     public void testSimpleConversion() throws Exception {
         final String[] message = { "from String", "from String", "from String", "from String", "from String", "from String", "from String", "from String", };
 
@@ -61,18 +62,19 @@ public class YearConverterTestCase extends TestCase {
         final Year[] expected = { Year.parse("2019"), Year.parse("1974"), Year.parse("2112") };
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(message[i] + " to URI", expected[i], converter.convert(Year.class, input[i]));
-            assertEquals(message[i] + " to null type", expected[i], converter.convert(null, input[i]));
+            assertEquals(expected[i], converter.convert(Year.class, input[i]), message[i] + " to URI");
+            assertEquals(expected[i], converter.convert(null, input[i]), message[i] + " to null type");
         }
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(input[i] + " to String", input[i], converter.convert(String.class, expected[i]));
+            assertEquals(input[i], converter.convert(String.class, expected[i]), input[i] + " to String");
         }
     }
 
     /**
      * Tests a conversion to an unsupported type.
      */
+    @Test
     public void testUnsupportedType() {
         try {
             converter.convert(Integer.class, "http://www.apache.org");

--- a/src/test/java/org/apache/commons/beanutils2/converters/YearMonthConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/YearMonthConverterTestCase.java
@@ -17,23 +17,23 @@
 
 package org.apache.commons.beanutils2.converters;
 
-import java.time.YearMonth;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import junit.framework.TestCase;
+import java.time.YearMonth;
 
 import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Case for the YearMonthConverter class.
  */
-public class YearMonthConverterTestCase extends TestCase {
+public class YearMonthConverterTestCase {
 
     private Converter<YearMonth> converter;
-
-    public YearMonthConverterTestCase(final String name) {
-        super(name);
-    }
 
     protected Class<?> getExpectedType() {
         return YearMonth.class;
@@ -43,16 +43,17 @@ public class YearMonthConverterTestCase extends TestCase {
         return new YearMonthConverter();
     }
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         converter = makeConverter();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         converter = null;
     }
 
+    @Test
     public void testSimpleConversion() throws Exception {
         final String[] message = { "from String", "from String", "from String", "from String", "from String", "from String", "from String", "from String", };
 
@@ -61,18 +62,19 @@ public class YearMonthConverterTestCase extends TestCase {
         final YearMonth[] expected = { YearMonth.parse("2007-12"), YearMonth.parse("1974-05"), YearMonth.parse("2112-01") };
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(message[i] + " to URI", expected[i], converter.convert(YearMonth.class, input[i]));
-            assertEquals(message[i] + " to null type", expected[i], converter.convert(null, input[i]));
+            assertEquals(expected[i], converter.convert(YearMonth.class, input[i]), message[i] + " to URI");
+            assertEquals(expected[i], converter.convert(null, input[i]), message[i] + " to null type");
         }
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(input[i] + " to String", input[i], converter.convert(String.class, expected[i]));
+            assertEquals(input[i], converter.convert(String.class, expected[i]), input[i] + " to String");
         }
     }
 
     /**
      * Tests a conversion to an unsupported type.
      */
+    @Test
     public void testUnsupportedType() {
         try {
             converter.convert(Integer.class, "http://www.apache.org");

--- a/src/test/java/org/apache/commons/beanutils2/converters/ZoneIdConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ZoneIdConverterTestCase.java
@@ -17,23 +17,23 @@
 
 package org.apache.commons.beanutils2.converters;
 
-import java.time.ZoneId;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import junit.framework.TestCase;
+import java.time.ZoneId;
 
 import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Case for the ZoneIdConverter class.
  */
-public class ZoneIdConverterTestCase extends TestCase {
+public class ZoneIdConverterTestCase {
 
     private Converter<ZoneId> converter;
-
-    public ZoneIdConverterTestCase(final String name) {
-        super(name);
-    }
 
     protected Class<?> getExpectedType() {
         return ZoneId.class;
@@ -43,16 +43,17 @@ public class ZoneIdConverterTestCase extends TestCase {
         return new ZoneIdConverter();
     }
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         converter = makeConverter();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         converter = null;
     }
 
+    @Test
     public void testSimpleConversion() throws Exception {
         final String[] message = { "from String", "from String", "from String", "from String", "from String", "from String", "from String", "from String", };
 
@@ -61,18 +62,19 @@ public class ZoneIdConverterTestCase extends TestCase {
         final ZoneId[] expected = { ZoneId.of("America/New_York"), ZoneId.of("-05:00"), ZoneId.of("Australia/Sydney") };
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(message[i] + " to URI", expected[i], converter.convert(ZoneId.class, input[i]));
-            assertEquals(message[i] + " to null type", expected[i], converter.convert(null, input[i]));
+            assertEquals(expected[i], converter.convert(ZoneId.class, input[i]), message[i] + " to URI");
+            assertEquals(expected[i], converter.convert(null, input[i]), message[i] + " to null type");
         }
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(input[i] + " to String", input[i], converter.convert(String.class, expected[i]));
+            assertEquals(input[i], converter.convert(String.class, expected[i]), input[i] + " to String");
         }
     }
 
     /**
      * Tests a conversion to an unsupported type.
      */
+    @Test
     public void testUnsupportedType() {
         try {
             converter.convert(Integer.class, "http://www.apache.org");

--- a/src/test/java/org/apache/commons/beanutils2/converters/ZoneOffsetConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ZoneOffsetConverterTestCase.java
@@ -17,23 +17,23 @@
 
 package org.apache.commons.beanutils2.converters;
 
-import java.time.ZoneOffset;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import junit.framework.TestCase;
+import java.time.ZoneOffset;
 
 import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Case for the ZoneOffsetConverter class.
  */
-public class ZoneOffsetConverterTestCase extends TestCase {
+public class ZoneOffsetConverterTestCase {
 
     private Converter<ZoneOffset> converter;
-
-    public ZoneOffsetConverterTestCase(final String name) {
-        super(name);
-    }
 
     protected Class<?> getExpectedType() {
         return ZoneOffset.class;
@@ -43,16 +43,17 @@ public class ZoneOffsetConverterTestCase extends TestCase {
         return new ZoneOffsetConverter();
     }
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         converter = makeConverter();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         converter = null;
     }
 
+    @Test
     public void testSimpleConversion() throws Exception {
         final String[] message = { "from String", "from String", "from String", "from String", "from String", "from String", "from String", "from String", };
 
@@ -61,18 +62,19 @@ public class ZoneOffsetConverterTestCase extends TestCase {
         final ZoneOffset[] expected = { ZoneOffset.of("-12:00"), ZoneOffset.of("+14:00"), ZoneOffset.of("+02:00") };
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(message[i] + " to URI", expected[i], converter.convert(ZoneOffset.class, input[i]));
-            assertEquals(message[i] + " to null type", expected[i], converter.convert(null, input[i]));
+            assertEquals(expected[i], converter.convert(ZoneOffset.class, input[i]), message[i] + " to URI");
+            assertEquals(expected[i], converter.convert(null, input[i]), message[i] + " to null type");
         }
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(input[i] + " to String", input[i], converter.convert(String.class, expected[i]));
+            assertEquals(input[i], converter.convert(String.class, expected[i]), input[i] + " to String");
         }
     }
 
     /**
      * Tests a conversion to an unsupported type.
      */
+    @Test
     public void testUnsupportedType() {
         try {
             converter.convert(Integer.class, "http://www.apache.org");

--- a/src/test/java/org/apache/commons/beanutils2/converters/ZonedDateTimeConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ZonedDateTimeConverterTestCase.java
@@ -27,15 +27,6 @@ import java.util.Calendar;
 public class ZonedDateTimeConverterTestCase extends AbstractDateConverterTest<ZonedDateTime> {
 
     /**
-     * Constructs a new Date test case.
-     *
-     * @param name Test Name
-     */
-    public ZonedDateTimeConverterTestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Gets the expected type
      *
      * @return The expected type

--- a/src/test/java/org/apache/commons/beanutils2/expression/DefaultResolverTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/expression/DefaultResolverTestCase.java
@@ -16,12 +16,19 @@
  */
 package org.apache.commons.beanutils2.expression;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Junit Test for BasicResolver.
  */
-public class DefaultResolverTestCase extends TestCase {
+public class DefaultResolverTestCase {
 
     private final DefaultResolver resolver = new DefaultResolver();
     // Simple Properties Test Data
@@ -43,15 +50,6 @@ public class DefaultResolverTestCase extends TestCase {
 
     private final String[] removeProperties = { null, null, "e", "h", "kl", null, null, "s", null, "wx" };
 
-    /**
-     * Constructs a DefaultResolver Test Case.
-     *
-     * @param name The name of the test
-     */
-    public DefaultResolverTestCase(final String name) {
-        super(name);
-    }
-
     private String label(final String expression, final int i) {
         return "Expression[" + i + "]=\"" + expression + "\"";
     }
@@ -59,20 +57,21 @@ public class DefaultResolverTestCase extends TestCase {
     /**
      * Sets Up
      */
-    @Override
+    @BeforeEach
     protected void setUp() {
     }
 
     /**
      * Tear Down
      */
-    @Override
+    @AfterEach
     protected void tearDown() {
     }
 
     /**
      * Test getIndex() method.
      */
+    @Test
     public void testGetIndex() {
         String label = null;
 
@@ -80,7 +79,7 @@ public class DefaultResolverTestCase extends TestCase {
         for (int i = 0; i < validProperties.length; i++) {
             try {
                 label = "Simple " + label(validProperties[i], i);
-                assertEquals(label, -1, resolver.getIndex(validProperties[i]));
+                assertEquals(-1, resolver.getIndex(validProperties[i]), label);
             } catch (final Throwable t) {
                 fail(label + " threw " + t);
             }
@@ -90,7 +89,7 @@ public class DefaultResolverTestCase extends TestCase {
         for (int i = 0; i < validIndexProperties.length; i++) {
             try {
                 label = "Indexed " + label(validIndexProperties[i], i);
-                assertEquals(label, validIndexValues[i], resolver.getIndex(validIndexProperties[i]));
+                assertEquals(validIndexValues[i], resolver.getIndex(validIndexProperties[i]), label);
             } catch (final Throwable t) {
                 fail(label + " threw " + t);
             }
@@ -100,7 +99,7 @@ public class DefaultResolverTestCase extends TestCase {
         for (int i = 0; i < validMapProperties.length; i++) {
             try {
                 label = "Mapped " + label(validMapProperties[i], i);
-                assertEquals(label, -1, resolver.getIndex(validMapProperties[i]));
+                assertEquals(-1, resolver.getIndex(validMapProperties[i]), label);
             } catch (final Throwable t) {
                 fail(label + " threw " + t);
             }
@@ -112,7 +111,7 @@ public class DefaultResolverTestCase extends TestCase {
             final int index = resolver.getIndex("foo[]");
             fail(label + " expected IllegalArgumentException: " + index);
         } catch (final IllegalArgumentException e) {
-            assertEquals(label + " Error Message", "No Index Value", e.getMessage());
+            assertEquals("No Index Value", e.getMessage(), label + " Error Message");
         } catch (final Throwable t) {
             fail(label + " expected IllegalArgumentException: " + t);
         }
@@ -123,7 +122,7 @@ public class DefaultResolverTestCase extends TestCase {
             final int index = resolver.getIndex("foo[12");
             fail(label + " expected IllegalArgumentException: " + index);
         } catch (final IllegalArgumentException e) {
-            assertEquals(label + " Error Message", "Missing End Delimiter", e.getMessage());
+            assertEquals("Missing End Delimiter", e.getMessage(), label + " Error Message");
         } catch (final Throwable t) {
             fail(label + " expected IllegalArgumentException: " + t);
         }
@@ -134,7 +133,7 @@ public class DefaultResolverTestCase extends TestCase {
             final int index = resolver.getIndex("foo[BAR]");
             fail(label + " expected IllegalArgumentException: " + index);
         } catch (final IllegalArgumentException e) {
-            assertEquals(label + " Error Message", "Invalid index value 'BAR'", e.getMessage());
+            assertEquals("Invalid index value 'BAR'", e.getMessage(), label + " Error Message");
         } catch (final Throwable t) {
             fail(label + " expected IllegalArgumentException: " + t);
         }
@@ -143,6 +142,7 @@ public class DefaultResolverTestCase extends TestCase {
     /**
      * Test getMapKey() method.
      */
+    @Test
     public void testGetMapKey() {
         String label = null;
 
@@ -150,7 +150,7 @@ public class DefaultResolverTestCase extends TestCase {
         for (int i = 0; i < validProperties.length; i++) {
             try {
                 label = "Simple " + label(validProperties[i], i);
-                assertEquals(label, null, resolver.getKey(validProperties[i]));
+                assertEquals(null, resolver.getKey(validProperties[i]), label);
             } catch (final Throwable t) {
                 fail(label + " threw " + t);
             }
@@ -160,7 +160,7 @@ public class DefaultResolverTestCase extends TestCase {
         for (int i = 0; i < validIndexProperties.length; i++) {
             try {
                 label = "Indexed " + label(validIndexProperties[i], i);
-                assertEquals(label, null, resolver.getKey(validIndexProperties[i]));
+                assertEquals(null, resolver.getKey(validIndexProperties[i]), label);
             } catch (final Throwable t) {
                 fail(label + " threw " + t);
             }
@@ -170,7 +170,7 @@ public class DefaultResolverTestCase extends TestCase {
         for (int i = 0; i < validMapProperties.length; i++) {
             try {
                 label = "Mapped " + label(validMapProperties[i], i);
-                assertEquals(label, validMapKeys[i], resolver.getKey(validMapProperties[i]));
+                assertEquals(validMapKeys[i], resolver.getKey(validMapProperties[i]), label);
             } catch (final Throwable t) {
                 fail(label + " threw " + t);
             }
@@ -182,7 +182,7 @@ public class DefaultResolverTestCase extends TestCase {
             final String key = resolver.getKey("foo(bar");
             fail(label + " expected IllegalArgumentException: " + key);
         } catch (final IllegalArgumentException e) {
-            assertEquals(label + " Error Message", "Missing End Delimiter", e.getMessage());
+            assertEquals("Missing End Delimiter", e.getMessage(), label + " Error Message");
         } catch (final Throwable t) {
             fail(label + " expected IllegalArgumentException: " + t);
         }
@@ -191,6 +191,7 @@ public class DefaultResolverTestCase extends TestCase {
     /**
      * Test getName() method.
      */
+    @Test
     public void testGetName() {
         String label = null;
 
@@ -198,7 +199,7 @@ public class DefaultResolverTestCase extends TestCase {
         for (int i = 0; i < validProperties.length; i++) {
             try {
                 label = "Simple " + label(validProperties[i], i);
-                assertEquals(label, validNames[i], resolver.getProperty(validProperties[i]));
+                assertEquals(validNames[i], resolver.getProperty(validProperties[i]), label);
             } catch (final Throwable t) {
                 fail(label + " threw " + t);
             }
@@ -208,7 +209,7 @@ public class DefaultResolverTestCase extends TestCase {
         for (int i = 0; i < validIndexProperties.length; i++) {
             try {
                 label = "Indexed " + label(validIndexProperties[i], i);
-                assertEquals(label, validIndexNames[i], resolver.getProperty(validIndexProperties[i]));
+                assertEquals(validIndexNames[i], resolver.getProperty(validIndexProperties[i]), label);
             } catch (final Throwable t) {
                 fail(label + " threw " + t);
             }
@@ -218,7 +219,7 @@ public class DefaultResolverTestCase extends TestCase {
         for (int i = 0; i < validMapProperties.length; i++) {
             try {
                 label = "Mapped " + label(validMapProperties[i], i);
-                assertEquals(label, validMapNames[i], resolver.getProperty(validMapProperties[i]));
+                assertEquals(validMapNames[i], resolver.getProperty(validMapProperties[i]), label);
             } catch (final Throwable t) {
                 fail(label + " threw " + t);
             }
@@ -228,6 +229,7 @@ public class DefaultResolverTestCase extends TestCase {
     /**
      * Test isIndexed() method.
      */
+    @Test
     public void testIsIndexed() {
         String label = null;
 
@@ -235,7 +237,7 @@ public class DefaultResolverTestCase extends TestCase {
         for (int i = 0; i < validProperties.length; i++) {
             try {
                 label = "Simple " + label(validProperties[i], i);
-                assertFalse(label, resolver.isIndexed(validProperties[i]));
+                assertFalse(resolver.isIndexed(validProperties[i]), label);
             } catch (final Throwable t) {
                 fail(label + " threw " + t);
             }
@@ -245,7 +247,7 @@ public class DefaultResolverTestCase extends TestCase {
         for (int i = 0; i < validIndexProperties.length; i++) {
             try {
                 label = "Indexed " + label(validIndexProperties[i], i);
-                assertTrue(label, resolver.isIndexed(validIndexProperties[i]));
+                assertTrue(resolver.isIndexed(validIndexProperties[i]), label);
             } catch (final Throwable t) {
                 fail(label + " threw " + t);
             }
@@ -255,7 +257,7 @@ public class DefaultResolverTestCase extends TestCase {
         for (int i = 0; i < validMapProperties.length; i++) {
             try {
                 label = "Mapped " + label(validMapProperties[i], i);
-                assertFalse(label, resolver.isIndexed(validMapProperties[i]));
+                assertFalse(resolver.isIndexed(validMapProperties[i]), label);
             } catch (final Throwable t) {
                 fail(label + " threw " + t);
             }
@@ -265,6 +267,7 @@ public class DefaultResolverTestCase extends TestCase {
     /**
      * Test isMapped() method.
      */
+    @Test
     public void testIsMapped() {
         String label = null;
 
@@ -272,7 +275,7 @@ public class DefaultResolverTestCase extends TestCase {
         for (int i = 0; i < validProperties.length; i++) {
             try {
                 label = "Simple " + label(validProperties[i], i);
-                assertFalse(label, resolver.isMapped(validProperties[i]));
+                assertFalse(resolver.isMapped(validProperties[i]), label);
             } catch (final Throwable t) {
                 fail(label + " threw " + t);
             }
@@ -282,7 +285,7 @@ public class DefaultResolverTestCase extends TestCase {
         for (int i = 0; i < validIndexProperties.length; i++) {
             try {
                 label = "Indexed " + label(validIndexProperties[i], i);
-                assertFalse(label, resolver.isMapped(validIndexProperties[i]));
+                assertFalse(resolver.isMapped(validIndexProperties[i]), label);
             } catch (final Throwable t) {
                 fail(label + " threw " + t);
             }
@@ -292,7 +295,7 @@ public class DefaultResolverTestCase extends TestCase {
         for (int i = 0; i < validMapProperties.length; i++) {
             try {
                 label = "Mapped " + label(validMapProperties[i], i);
-                assertTrue(label, resolver.isMapped(validMapProperties[i]));
+                assertTrue(resolver.isMapped(validMapProperties[i]), label);
             } catch (final Throwable t) {
                 fail(label + " threw " + t);
             }
@@ -302,12 +305,13 @@ public class DefaultResolverTestCase extends TestCase {
     /**
      * Test next() method.
      */
+    @Test
     public void testNext() {
         String label = null;
         for (int i = 0; i < nextExpressions.length; i++) {
             try {
                 label = label(nextExpressions[i], i);
-                assertEquals(label, nextProperties[i], resolver.next(nextExpressions[i]));
+                assertEquals(nextProperties[i], resolver.next(nextExpressions[i]), label);
             } catch (final Throwable t) {
                 fail(label + " threw " + t);
             }
@@ -317,12 +321,13 @@ public class DefaultResolverTestCase extends TestCase {
     /**
      * Test remove() method.
      */
+    @Test
     public void testRemove() {
         String label = null;
         for (int i = 0; i < nextExpressions.length; i++) {
             try {
                 label = label(nextExpressions[i], i);
-                assertEquals(label, removeProperties[i], resolver.remove(nextExpressions[i]));
+                assertEquals(removeProperties[i], resolver.remove(nextExpressions[i]), label);
             } catch (final Throwable t) {
                 fail(label + " threw " + t);
             }

--- a/src/test/java/org/apache/commons/beanutils2/locale/LocaleConvertUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/locale/LocaleConvertUtilsTestCase.java
@@ -17,54 +17,50 @@
 
 package org.apache.commons.beanutils2.locale;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.text.NumberFormat;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.beanutils2.ConversionException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>
  * Test Case for the LocaleConvertUtils class. See unimplemented functionality of the convert utils in the method begining with fixme
  * </p>
  */
-
-public class LocaleConvertUtilsTestCase extends TestCase {
+public class LocaleConvertUtilsTestCase {
 
     private char decimalSeparator;
 
-    /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public LocaleConvertUtilsTestCase(final String name) {
-        super(name);
-    }
-
     private void checkIntegerArray(final Object value, final int[] intArray) {
 
-        assertNotNull("Returned value is not null", value);
-        assertEquals("Returned value is int[]", intArray.getClass(), value.getClass());
+        assertNotNull(value, "Returned value is not null");
+        assertEquals(intArray.getClass(), value.getClass(), "Returned value is int[]");
         final int[] results = (int[]) value;
-        assertEquals("Returned array length", intArray.length, results.length);
+        assertEquals(intArray.length, results.length, "Returned array length");
         for (int i = 0; i < intArray.length; i++) {
-            assertEquals("Returned array value " + i, intArray[i], results[i]);
+            assertEquals(intArray[i], results[i], "Returned array value " + i);
         }
 
     }
 
     private void checkStringArray(final Object value, final String[] stringArray) {
 
-        assertNotNull("Returned value is not null", value);
-        assertEquals("Returned value is String[]", stringArray.getClass(), value.getClass());
+        assertNotNull(value, "Returned value is not null");
+        assertEquals(stringArray.getClass(), value.getClass(), "Returned value is String[]");
         final String[] results = (String[]) value;
-        assertEquals("Returned array length", stringArray.length, results.length);
+        assertEquals(stringArray.length, results.length, "Returned array length");
         for (int i = 0; i < stringArray.length; i++) {
-            assertEquals("Returned array value " + i, stringArray[i], results[i]);
+            assertEquals(stringArray[i], results[i], "Returned array value " + i);
         }
 
     }
@@ -123,13 +119,13 @@ public class LocaleConvertUtilsTestCase extends TestCase {
         final String[] stringArray1 = { "abc" };
         final String[] stringArray2 = { "abc", "def" };
 
-        assertEquals("intArray0", null, LocaleConvertUtils.convert(intArray0));
-        assertEquals("intArray1", "123", LocaleConvertUtils.convert(intArray1));
-        assertEquals("intArray2", "123", LocaleConvertUtils.convert(intArray2));
+        assertEquals(null, LocaleConvertUtils.convert(intArray0), "intArray0");
+        assertEquals("123", LocaleConvertUtils.convert(intArray1), "intArray1");
+        assertEquals("123", LocaleConvertUtils.convert(intArray2), "intArray2");
 
-        assertEquals("stringArray0", null, LocaleConvertUtils.convert(stringArray0));
-        assertEquals("stringArray1", "abc", LocaleConvertUtils.convert(stringArray1));
-        assertEquals("stringArray2", "abc", LocaleConvertUtils.convert(stringArray2));
+        assertEquals(null, LocaleConvertUtils.convert(stringArray0), "stringArray0");
+        assertEquals("abc", LocaleConvertUtils.convert(stringArray1), "stringArray1");
+        assertEquals("abc", LocaleConvertUtils.convert(stringArray2), "stringArray2");
 
     }
 
@@ -246,7 +242,7 @@ public class LocaleConvertUtilsTestCase extends TestCase {
     /**
      * Sets up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     public void setUp() {
 
         LocaleConvertUtils.deregister();
@@ -262,7 +258,7 @@ public class LocaleConvertUtilsTestCase extends TestCase {
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     public void tearDown() {
         // No action required
     }
@@ -270,6 +266,7 @@ public class LocaleConvertUtilsTestCase extends TestCase {
     /**
      * Test conversion of a String array using a Locale and pattern.
      */
+    @Test
     public void testConvertStringArrayLocaleNull() {
         Object result = null;
         try {
@@ -278,15 +275,16 @@ public class LocaleConvertUtilsTestCase extends TestCase {
             e.printStackTrace();
             fail("Threw: " + e);
         }
-        assertNotNull("Null Result", result);
-        assertEquals("Integer Array Type", Integer[].class, result.getClass());
-        assertEquals("Integer Array Length", 1, ((Integer[]) result).length);
-        assertEquals("Integer Array Value", Integer.valueOf(123), ((Integer[]) result)[0]);
+        assertNotNull(result, "Null Result");
+        assertEquals(Integer[].class, result.getClass(), "Integer Array Type");
+        assertEquals(1, ((Integer[]) result).length, "Integer Array Length");
+        assertEquals(Integer.valueOf(123), ((Integer[]) result)[0], "Integer Array Value");
     }
 
     /**
      * Test conversion of a String using a Locale and pattern.
      */
+    @Test
     public void testConvertStringLocaleNull() {
         Object result = null;
         try {
@@ -295,23 +293,26 @@ public class LocaleConvertUtilsTestCase extends TestCase {
             e.printStackTrace();
             fail("Threw: " + e);
         }
-        assertNotNull("Null Result", result);
-        assertEquals("Integer Type", Integer.class, result.getClass());
-        assertEquals("Integer Value", Integer.valueOf(123), result);
+        assertNotNull(result, "Null Result");
+        assertEquals(Integer.class, result.getClass(), "Integer Type");
+        assertEquals(Integer.valueOf(123), result, "Integer Value");
     }
 
     /**
      * Tests a conversion if there is no suitable converter registered. In this case, the string converter is used, and the passed in target type is ignored.
      * (This test is added to prevent a regression after the locale converters have been generified.)
      */
+    @Test
     public void testDefaultToStringConversionUnsupportedType() {
         final Integer value = 20131101;
-        assertEquals("Wrong result", value.toString(), LocaleConvertUtils.convert(value.toString(), getClass()));
+        assertEquals(value.toString(), LocaleConvertUtils.convert(value.toString(), getClass()),
+                                "Wrong result");
     }
 
     /**
      * Negative scalar conversion tests. These rely on the standard default value conversions in LocaleConvertUtils.
      */
+    @Test
     public void testNegativeScalar() {
 
         /*
@@ -414,25 +415,29 @@ public class LocaleConvertUtilsTestCase extends TestCase {
     /**
      * Test conversion of object to string for scalars.
      */
+    @Test
     public void testObjectToStringScalar() {
 
-        assertEquals("Boolean->String", "false", LocaleConvertUtils.convert(Boolean.FALSE));
-        assertEquals("Boolean->String", "true", LocaleConvertUtils.convert(Boolean.TRUE));
-        assertEquals("Byte->String", "123", LocaleConvertUtils.convert(Byte.valueOf((byte) 123)));
-        assertEquals("Character->String", "a", LocaleConvertUtils.convert(Character.valueOf('a')));
-        assertEquals("Double->String", "123" + decimalSeparator + "4", LocaleConvertUtils.convert(Double.valueOf(123.4)));
-        assertEquals("Float->String", "123" + decimalSeparator + "4", LocaleConvertUtils.convert(Float.valueOf((float) 123.4)));
-        assertEquals("Integer->String", "123", LocaleConvertUtils.convert(Integer.valueOf(123)));
-        assertEquals("Long->String", "123", LocaleConvertUtils.convert(Long.valueOf(123)));
-        assertEquals("Short->String", "123", LocaleConvertUtils.convert(Short.valueOf((short) 123)));
-        assertEquals("String->String", "abc", LocaleConvertUtils.convert("abc"));
-        assertEquals("String->String null", null, LocaleConvertUtils.convert(null));
+        assertEquals("false", LocaleConvertUtils.convert(Boolean.FALSE), "Boolean->String");
+        assertEquals("true", LocaleConvertUtils.convert(Boolean.TRUE), "Boolean->String");
+        assertEquals("123", LocaleConvertUtils.convert(Byte.valueOf((byte) 123)), "Byte->String");
+        assertEquals("a", LocaleConvertUtils.convert(Character.valueOf('a')), "Character->String");
+        assertEquals("123" + decimalSeparator + "4", LocaleConvertUtils.convert(Double.valueOf(123.4)),
+                                "Double->String");
+        assertEquals("123" + decimalSeparator + "4",
+                                LocaleConvertUtils.convert(Float.valueOf((float) 123.4)), "Float->String");
+        assertEquals("123", LocaleConvertUtils.convert(Integer.valueOf(123)), "Integer->String");
+        assertEquals("123", LocaleConvertUtils.convert(Long.valueOf(123)), "Long->String");
+        assertEquals("123", LocaleConvertUtils.convert(Short.valueOf((short) 123)), "Short->String");
+        assertEquals("abc", LocaleConvertUtils.convert("abc"), "String->String");
+        assertEquals(null, LocaleConvertUtils.convert(null), "String->String null");
 
     }
 
     /**
      * Positive scalar conversion tests.
      */
+    @Test
     public void testPositiveScalar() {
         Object value;
 
@@ -476,11 +481,11 @@ public class LocaleConvertUtilsTestCase extends TestCase {
          */
 
         value = LocaleConvertUtils.convert("123", Byte.TYPE);
-        assertTrue(value instanceof Byte);
+        assertInstanceOf(Byte.class, value);
         assertEquals(((Byte) value).byteValue(), (byte) 123);
 
         value = LocaleConvertUtils.convert("123", Byte.class);
-        assertTrue(value instanceof Byte);
+        assertInstanceOf(Byte.class, value);
         assertEquals(((Byte) value).byteValue(), (byte) 123);
 
         /*
@@ -495,35 +500,35 @@ public class LocaleConvertUtilsTestCase extends TestCase {
          */
 
         value = LocaleConvertUtils.convert("123" + decimalSeparator + "456", Double.TYPE);
-        assertTrue(value instanceof Double);
+        assertInstanceOf(Double.class, value);
         assertEquals(((Double) value).doubleValue(), 123.456, 0.005);
 
         value = LocaleConvertUtils.convert("123" + decimalSeparator + "456", Double.class);
-        assertTrue(value instanceof Double);
+        assertInstanceOf(Double.class, value);
         assertEquals(((Double) value).doubleValue(), 123.456, 0.005);
 
         value = LocaleConvertUtils.convert("123" + decimalSeparator + "456", Float.TYPE);
-        assertTrue(value instanceof Float);
+        assertInstanceOf(Float.class, value);
         assertEquals(((Float) value).floatValue(), (float) 123.456, (float) 0.005);
 
         value = LocaleConvertUtils.convert("123" + decimalSeparator + "456", Float.class);
-        assertTrue(value instanceof Float);
+        assertInstanceOf(Float.class, value);
         assertEquals(((Float) value).floatValue(), (float) 123.456, (float) 0.005);
 
         value = LocaleConvertUtils.convert("123", Integer.TYPE);
-        assertTrue(value instanceof Integer);
+        assertInstanceOf(Integer.class, value);
         assertEquals(((Integer) value).intValue(), 123);
 
         value = LocaleConvertUtils.convert("123", Integer.class);
-        assertTrue(value instanceof Integer);
+        assertInstanceOf(Integer.class, value);
         assertEquals(((Integer) value).intValue(), 123);
 
         value = LocaleConvertUtils.convert("123", Long.TYPE);
-        assertTrue(value instanceof Long);
+        assertInstanceOf(Long.class, value);
         assertEquals(((Long) value).longValue(), 123);
 
         value = LocaleConvertUtils.convert("123456", Long.class);
-        assertTrue(value instanceof Long);
+        assertInstanceOf(Long.class, value);
         assertEquals(((Long) value).longValue(), 123456);
 
         /*
@@ -537,17 +542,17 @@ public class LocaleConvertUtilsTestCase extends TestCase {
 
         input = "2002-03-17";
         value = LocaleConvertUtils.convert(input, Date.class);
-        assertTrue(value instanceof Date);
+        assertInstanceOf(Date.class, value);
         assertEquals(input, value.toString());
 
         input = "20:30:40";
         value = LocaleConvertUtils.convert(input, Time.class);
-        assertTrue(value instanceof Time);
+        assertInstanceOf(Time.class, value);
         assertEquals(input, value.toString());
 
         input = "2002-03-17 20:30:40.0";
         value = LocaleConvertUtils.convert(input, Timestamp.class);
-        assertTrue(value instanceof Timestamp);
+        assertInstanceOf(Timestamp.class, value);
         assertEquals(input, value.toString());
 
     }

--- a/src/test/java/org/apache/commons/beanutils2/sql/DynaResultSetTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/sql/DynaResultSetTestCase.java
@@ -17,21 +17,26 @@
 
 package org.apache.commons.beanutils2.sql;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.math.BigDecimal;
 import java.util.Iterator;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.beanutils2.DynaBean;
 import org.apache.commons.beanutils2.DynaProperty;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test accessing ResultSets via DynaBeans.
  */
-
-public class DynaResultSetTestCase extends TestCase {
+public class DynaResultSetTestCase {
 
     /**
      * The mock result set DynaClass to be tested.
@@ -45,20 +50,9 @@ public class DynaResultSetTestCase extends TestCase {
             "longproperty", "nullproperty", "shortproperty", "stringproperty", "timeproperty", "timestampproperty" };
 
     /**
-     * Constructs a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public DynaResultSetTestCase(final String name) {
-
-        super(name);
-
-    }
-
-    /**
      * Sets up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
 
         dynaClass = new ResultSetDynaClass(TestResultSet.createProxy());
@@ -68,45 +62,50 @@ public class DynaResultSetTestCase extends TestCase {
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     public void tearDown() {
 
         dynaClass = null;
 
     }
 
+    @Test
     public void testGetDynaProperties() {
 
         final DynaProperty[] dynaProps = dynaClass.getDynaProperties();
-        assertNotNull("dynaProps exists", dynaProps);
-        assertEquals("dynaProps length", columns.length, dynaProps.length);
+        assertNotNull(dynaProps, "dynaProps exists");
+        assertEquals(columns.length, dynaProps.length, "dynaProps length");
         for (int i = 0; i < columns.length; i++) {
-            assertEquals("Property " + columns[i], columns[i], dynaProps[i].getName());
+            assertEquals(columns[i], dynaProps[i].getName(), "Property " + columns[i]);
         }
 
     }
 
+    @Test
     public void testGetDynaProperty() {
         // Invalid argument test
         assertThrows(NullPointerException.class, () -> dynaClass.getDynaProperty(null));
         // Negative test
         DynaProperty dynaProp = dynaClass.getDynaProperty("unknownProperty");
-        assertNull("unknown property returns null", dynaProp);
+        assertNull(dynaProp, "unknown property returns null");
         // Positive test
         dynaProp = dynaClass.getDynaProperty("stringproperty");
-        assertNotNull("string property exists", dynaProp);
-        assertEquals("string property name", "stringproperty", dynaProp.getName());
-        assertEquals("string property class", String.class, dynaProp.getType());
+        assertNotNull(dynaProp, "string property exists");
+        assertEquals("stringproperty", dynaProp.getName(), "string property name");
+        assertEquals(String.class, dynaProp.getType(), "string property class");
     }
 
+    @Test
     public void testGetName() {
-        assertEquals("DynaClass name", "org.apache.commons.beanutils2.sql.ResultSetDynaClass", dynaClass.getName());
+        assertEquals("org.apache.commons.beanutils2.sql.ResultSetDynaClass", dynaClass.getName(),
+                                "DynaClass name");
     }
 
+    @Test
     public void testIteratorCount() {
 
         final Iterator<?> rows = dynaClass.iterator();
-        assertNotNull("iterator exists", rows);
+        assertNotNull(rows, "iterator exists");
         int n = 0;
         while (rows.hasNext()) {
             rows.next();
@@ -115,10 +114,11 @@ public class DynaResultSetTestCase extends TestCase {
                 fail("Returned too many rows");
             }
         }
-        assertEquals("iterator rows", 5, n);
+        assertEquals(5, n, "iterator rows");
 
     }
 
+    @Test
     public void testIteratorResults() {
 
         // Grab the third row
@@ -138,28 +138,30 @@ public class DynaResultSetTestCase extends TestCase {
         // Verify property values
 
         final Object bigDecimalProperty = row.get("bigdecimalproperty");
-        assertNotNull("bigDecimalProperty exists", bigDecimalProperty);
-        assertTrue("bigDecimalProperty type", bigDecimalProperty instanceof BigDecimal);
-        assertEquals("bigDecimalProperty value", 123.45, ((BigDecimal) bigDecimalProperty).doubleValue(), 0.005);
+        assertNotNull(bigDecimalProperty, "bigDecimalProperty exists");
+        assertTrue(bigDecimalProperty instanceof BigDecimal, "bigDecimalProperty type");
+        assertEquals(123.45, ((BigDecimal) bigDecimalProperty).doubleValue(), 0.005,
+                                "bigDecimalProperty value");
 
         final Object intProperty = row.get("intproperty");
-        assertNotNull("intProperty exists", intProperty);
-        assertTrue("intProperty type", intProperty instanceof Integer);
-        assertEquals("intProperty value", 103, ((Integer) intProperty).intValue());
+        assertNotNull(intProperty, "intProperty exists");
+        assertTrue(intProperty instanceof Integer, "intProperty type");
+        assertEquals(103, ((Integer) intProperty).intValue(), "intProperty value");
 
         final Object nullProperty = row.get("nullproperty");
-        assertNull("nullProperty null", nullProperty);
+        assertNull(nullProperty, "nullProperty null");
 
         final Object stringProperty = row.get("stringproperty");
-        assertNotNull("stringProperty exists", stringProperty);
-        assertTrue("stringProperty type", stringProperty instanceof String);
-        assertEquals("stringProperty value", "This is a string", (String) stringProperty);
+        assertNotNull(stringProperty, "stringProperty exists");
+        assertTrue(stringProperty instanceof String, "stringProperty type");
+        assertEquals("This is a string", (String) stringProperty, "stringProperty value");
 
     }
 
     /**
      * Test normal case column names (i.e. not converted to lower case)
      */
+    @Test
     public void testIteratorResultsNormalCase() {
         ResultSetDynaClass dynaClass = null;
         try {
@@ -185,25 +187,27 @@ public class DynaResultSetTestCase extends TestCase {
         // Verify property values
 
         final Object bigDecimalProperty = row.get("bigDecimalProperty");
-        assertNotNull("bigDecimalProperty exists", bigDecimalProperty);
-        assertTrue("bigDecimalProperty type", bigDecimalProperty instanceof BigDecimal);
-        assertEquals("bigDecimalProperty value", 123.45, ((BigDecimal) bigDecimalProperty).doubleValue(), 0.005);
+        assertNotNull(bigDecimalProperty, "bigDecimalProperty exists");
+        assertTrue(bigDecimalProperty instanceof BigDecimal, "bigDecimalProperty type");
+        assertEquals(123.45, ((BigDecimal) bigDecimalProperty).doubleValue(), 0.005,
+                                "bigDecimalProperty value");
 
         final Object intProperty = row.get("intProperty");
-        assertNotNull("intProperty exists", intProperty);
-        assertTrue("intProperty type", intProperty instanceof Integer);
-        assertEquals("intProperty value", 103, ((Integer) intProperty).intValue());
+        assertNotNull(intProperty, "intProperty exists");
+        assertTrue(intProperty instanceof Integer, "intProperty type");
+        assertEquals(103, ((Integer) intProperty).intValue(), "intProperty value");
 
         final Object nullProperty = row.get("nullProperty");
-        assertNull("nullProperty null", nullProperty);
+        assertNull(nullProperty, "nullProperty null");
 
         final Object stringProperty = row.get("stringProperty");
-        assertNotNull("stringProperty exists", stringProperty);
-        assertTrue("stringProperty type", stringProperty instanceof String);
-        assertEquals("stringProperty value", "This is a string", (String) stringProperty);
+        assertNotNull(stringProperty, "stringProperty exists");
+        assertTrue(stringProperty instanceof String, "stringProperty type");
+        assertEquals("This is a string", (String) stringProperty, "stringProperty value");
 
     }
 
+    @Test
     public void testNewInstance() {
 
         try {

--- a/src/test/java/org/apache/commons/beanutils2/sql/converters/SqlDateConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/sql/converters/SqlDateConverterTestCase.java
@@ -29,15 +29,6 @@ import org.apache.commons.beanutils2.converters.DateTimeConverter;
 public class SqlDateConverterTestCase extends AbstractDateConverterTest<Date> {
 
     /**
-     * Constructs a new Date test case.
-     *
-     * @param name Test Name
-     */
-    public SqlDateConverterTestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Gets the expected type
      *
      * @return The expected type

--- a/src/test/java/org/apache/commons/beanutils2/sql/converters/SqlTimeConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/sql/converters/SqlTimeConverterTestCase.java
@@ -29,15 +29,6 @@ import org.apache.commons.beanutils2.converters.AbstractDateConverterTest;
 public class SqlTimeConverterTestCase extends AbstractDateConverterTest<Time> {
 
     /**
-     * Constructs a new Date test case.
-     *
-     * @param name Test Name
-     */
-    public SqlTimeConverterTestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Gets the expected type
      *
      * @return The expected type

--- a/src/test/java/org/apache/commons/beanutils2/sql/converters/SqlTimestampConverterTestCase.java
+++ b/src/test/java/org/apache/commons/beanutils2/sql/converters/SqlTimestampConverterTestCase.java
@@ -31,15 +31,6 @@ import org.apache.commons.beanutils2.converters.AbstractDateConverterTest;
 public class SqlTimestampConverterTestCase extends AbstractDateConverterTest<Timestamp> {
 
     /**
-     * Constructs a new Date test case.
-     *
-     * @param name Test Name
-     */
-    public SqlTimestampConverterTestCase(final String name) {
-        super(name);
-    }
-
-    /**
      * Gets the expected type
      *
      * @return The expected type


### PR DESCRIPTION
I've updated a lot of the remaining tests to JUnit 5

I think this will leave the tests extending the following to do:

* `AbstractDateConverterTest`
* `AbstractNumberConverterTest`
* `BaseLocaleConverterTest`

