### PR TITLE
Perform locale-sensitive string comparison in `BooleanConverter`

### DIFF
--- a/src/test/java/org/apache/commons/beanutils2/converters/BooleanConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/BooleanConverterTest.java
@@ -22,6 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Locale;
+
 import org.apache.commons.beanutils2.ConversionException;
 import org.junit.jupiter.api.Test;
 
@@ -42,6 +44,24 @@ class BooleanConverterTest {
 
         assertThrows(ConversionException.class, () -> converter.convert(Boolean.class, "true"));
         assertThrows(ConversionException.class, () -> converter.convert(Boolean.class, "bogus"));
+    }
+
+    @Test
+    void testAdditionalStringsLocale() {
+        final String[] trueStrings = { "ναι" };
+        final String[] falseStrings = { "hayır" };
+        final BooleanConverter converter = new BooleanConverter(trueStrings, falseStrings);
+
+        converter.setLocale(Locale.forLanguageTag("el"));
+        for (final String trueValue : new String[] { "ναι", "Ναι" }) {
+            assertEquals(Boolean.TRUE, converter.convert(Boolean.class, trueValue));
+        }
+
+        converter.setLocale(Locale.forLanguageTag("tr"));
+        for (final String falseValue : new String[] { "hayır", "Hayır" }) {
+            assertEquals(Boolean.FALSE, converter.convert(Boolean.class, falseValue));
+        }
+        assertThrows(ConversionException.class, () -> converter.convert(Boolean.class, "hayir"));
     }
 
     @Test


### PR DESCRIPTION
Extends #366 (so is not subject to @garydgregory's veto, which applied to a different hunk of code), but also incorporates a suggested enhancement from @ppkarwasz (adding full locale support to custom boolean types). The new test fails before the changes to `src/main` to do locale-sensitive string comparison and passes after them.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best-practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
