### PR TITLE
Do not initialize arbitrary classes in EnumConverter

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/converters/EnumConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/converters/EnumConverter.java
@@ -73,7 +73,7 @@ public final class EnumConverter<E extends Enum<E>> extends AbstractConverter<En
             final String enumValue = stringValue.substring(Math.max(lastHash, lastDot) + 1);
             final String className = stringValue.substring(0, stringValue.length() - enumValue.length() - 1);
             try {
-                final Class classForName = Class.forName(className);
+                final Class classForName = Class.forName(className, false, getClass().getClassLoader());
                 if (!classForName.isEnum()) {
                     throw new IllegalArgumentException("Value isn't an enumerated type.");
                 }

--- a/src/test/java/org/apache/commons/beanutils2/converters/EnumConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/EnumConverterTest.java
@@ -18,6 +18,7 @@
 package org.apache.commons.beanutils2.converters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.DayOfWeek;
@@ -36,6 +37,16 @@ class EnumConverterTest {
 
     public enum PizzaStatus {
         ORDERED, READY, DELIVERED;
+    }
+
+    /** Set from {@link StaticInitProbe}'s static initializer; read without touching the probe class. */
+    static volatile boolean probeInitialized;
+
+    /** Non-enum helper whose static initializer records that it ran. */
+    public static final class StaticInitProbe {
+        static {
+            probeInitialized = true;
+        }
     }
 
     private Converter<Enum<PizzaStatus>> converter;
@@ -107,5 +118,12 @@ class EnumConverterTest {
     @Test
     void testNonExistingClasses() {
         assertThrows(ConversionException.class, () -> converter.convert(Enum.class, "java.lang.does.not.exist#MONDAY"));
+    }
+
+    @Test
+    void testNonEnumClassIsNotInitialized() {
+        final String name = StaticInitProbe.class.getName() + "#VALUE";
+        assertThrows(ConversionException.class, () -> converter.convert(Enum.class, name));
+        assertFalse(probeInitialized, "Resolving a non-enum class must not run its static initializer");
     }
 }


### PR DESCRIPTION
1. convertToType resolves a fully qualified name straight from the conversion input with Class.forName(name), which both loads and initializes the named class before the isEnum() check runs.
2. so a String coming from an untrusted source (for example a request parameter bound through BeanUtils onto an enum property) can name any class on the classpath and fire its static initializer, even though the conversion then fails with "isn't an enumerated type".

Switched to the three-arg Class.forName(name, false, loader) so the class is resolved but not initialized until Enum.valueOf actually accepts it. Enum resolution is unchanged.

What happens with a hostile value: `converter.convert(Enum.class, "com.example.Gadget#X")` runs Gadget's static block today; after the change it does not. Have we considered that the existing isEnum()/assignable checks already gate the *return* value but not the *side effect* of loading? That gap is the whole point here. Added a regression test that resolves a non-enum probe class and asserts its static initializer never ran (fails on the old code, passes now).