### PR TITLE
Reject trailing characters in DecimalLocaleConverter.parse

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/DecimalLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/DecimalLocaleConverter.java
@@ -20,6 +20,7 @@ package org.apache.commons.beanutils2.locale.converters;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
+import java.text.ParsePosition;
 import java.util.Locale;
 
 import org.apache.commons.beanutils2.ConversionException;
@@ -129,6 +130,12 @@ public class DecimalLocaleConverter<T extends Number> extends BaseLocaleConverte
             LOG.debug("No pattern provided, using default.");
         }
 
-        return (T) formatter.parse((String) value);
+        final String strValue = (String) value;
+        final ParsePosition pos = new ParsePosition(0);
+        final Number parsed = formatter.parse(strValue, pos);
+        if (parsed == null || pos.getErrorIndex() >= 0 || pos.getIndex() != strValue.length()) {
+            throw new ParseException("Error parsing '" + strValue + "' as a number", pos.getIndex());
+        }
+        return (T) parsed;
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/converters/BigDecimalLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/BigDecimalLocaleConverterTest.java
@@ -194,11 +194,9 @@ class BigDecimalLocaleConverterTest extends AbstractLocaleConverterTest<BigDecim
         convertInvalid(converter, "(A)", defaultValue);
         convertNull(converter, "(A)", defaultValue);
 
-        // Convert value in the wrong format - maybe you would expect it to throw an
-        // exception and return the default - it doesn't, DecimalFormat parses it
-        // quite happily turning "1,234.56" into "1.234"
-        // I guess this is one of the limitations of DecimalFormat
-        convertValueNoPattern(converter, "(B)", defaultDecimalValue, new BigDecimal("1.234"));
+        // Convert value in the wrong format - the trailing characters left after the
+        // partial parse are now rejected, so the converter returns the default.
+        convertValueNoPattern(converter, "(B)", defaultDecimalValue, defaultValue);
 
         // Convert with non-localized pattern - this causes an exception in parse()
         // but it gets swallowed in convert() method and returns default.

--- a/src/test/java/org/apache/commons/beanutils2/converters/BigIntegerLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/BigIntegerLocaleConverterTest.java
@@ -203,12 +203,10 @@ class BigIntegerLocaleConverterTest extends AbstractLocaleConverterTest<BigInteg
         convertValueNoPattern(converter, "(B)", defaultIntegerValue, new BigInteger("1"));
 
         // **************************************************************************
-        // Convert with non-localized pattern - unlike the equivalent BigDecimal Test Case
-        // it doesn't causes an exception in parse() - DecimalFormat parses it
-        // quite happily turning "1,234" into "1"
-        // Again this is one of the limitations of DecimalFormat
+        // Convert with non-localized pattern - the trailing characters left after the
+        // partial parse are now rejected, so the converter returns the default.
         // **************************************************************************
-        convertValueWithPattern(converter, "(B)", localizedIntegerValue, defaultIntegerPattern, new BigInteger("1"));
+        convertValueWithPattern(converter, "(B)", localizedIntegerValue, defaultIntegerPattern, defaultValue);
 
         // **************************************************************************
         // Convert with specified type

--- a/src/test/java/org/apache/commons/beanutils2/converters/DecimalLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/DecimalLocaleConverterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.beanutils2.converters;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Locale;
+
+import org.apache.commons.beanutils2.ConversionException;
+import org.apache.commons.beanutils2.locale.converters.DecimalLocaleConverter;
+import org.apache.commons.beanutils2.locale.converters.IntegerLocaleConverter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that {@link DecimalLocaleConverter} fully consumes its input and rejects trailing, unparsed characters.
+ */
+class DecimalLocaleConverterTest {
+
+    private Locale origLocale;
+
+    @BeforeEach
+    public void setUp() {
+        origLocale = Locale.getDefault();
+        Locale.setDefault(Locale.US);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Locale.setDefault(origLocale);
+    }
+
+    @Test
+    void testParseAcceptsGroupedNumber() {
+        final IntegerLocaleConverter converter = IntegerLocaleConverter.builder().setLocale(Locale.US).get();
+        assertEquals(Integer.valueOf(1234), converter.convert("1,234"));
+    }
+
+    @Test
+    void testParseRejectsTrailingCharacters() {
+        final IntegerLocaleConverter converter = IntegerLocaleConverter.builder().setLocale(Locale.US).get();
+        assertThrows(ConversionException.class, () -> converter.convert("123abc"));
+    }
+
+    @Test
+    void testParseRejectsTrailingExpression() {
+        final IntegerLocaleConverter converter = IntegerLocaleConverter.builder().setLocale(Locale.US).get();
+        assertThrows(ConversionException.class, () -> converter.convert("42 OR 1=1"));
+    }
+}

--- a/src/test/java/org/apache/commons/beanutils2/converters/DoubleLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/DoubleLocaleConverterTest.java
@@ -196,12 +196,10 @@ class DoubleLocaleConverterTest extends AbstractLocaleConverterTest<Double> {
         convertNull(converter, "(A)", defaultValue);
 
         // **************************************************************************
-        // Convert value in the wrong format - maybe you would expect it to throw an
-        // exception and return the default - it doesn't, DecimalFormat parses it
-        // quite happily turning "1,234.56" into "1.234"
-        // I guess this is one of the limitations of DecimalFormat
+        // Convert value in the wrong format - the trailing characters left after the
+        // partial parse are now rejected, so the converter returns the default.
         // **************************************************************************
-        convertValueNoPattern(converter, "(B)", defaultDecimalValue, Double.valueOf("1.234"));
+        convertValueNoPattern(converter, "(B)", defaultDecimalValue, defaultValue);
 
         // **************************************************************************
         // Convert with non-localized pattern - this causes an exception in parse()

--- a/src/test/java/org/apache/commons/beanutils2/converters/FloatLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/FloatLocaleConverterTest.java
@@ -204,12 +204,10 @@ class FloatLocaleConverterTest extends AbstractLocaleConverterTest<Float> {
         convertNull(converter, "(A)", defaultValue);
 
         // **************************************************************************
-        // Convert value in the wrong format - maybe you would expect it to throw an
-        // exception and return the default - it doesn't, DecimalFormat parses it
-        // quite happily turning "1,234.56" into "1.234"
-        // I guess this is one of the limitations of DecimalFormat
+        // Convert value in the wrong format - the trailing characters left after the
+        // partial parse are now rejected, so the converter returns the default.
         // **************************************************************************
-        convertValueNoPattern(converter, "(B)", defaultDecimalValue, Float.valueOf("1.234"));
+        convertValueNoPattern(converter, "(B)", defaultDecimalValue, defaultValue);
 
         // **************************************************************************
         // Convert with non-localized pattern - this causes an exception in parse()

--- a/src/test/java/org/apache/commons/beanutils2/converters/IntegerLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/IntegerLocaleConverterTest.java
@@ -187,12 +187,10 @@ class IntegerLocaleConverterTest extends AbstractLocaleConverterTest<Integer> {
         convertValueNoPattern(converter, "(B)", defaultIntegerValue, Integer.valueOf("1"));
 
         // **************************************************************************
-        // Convert with non-localized pattern - unlike the equivalent BigDecimal Test Case
-        // it doesn't causes an exception in parse() - DecimalFormat parses it
-        // quite happily turning "1,234" into "1"
-        // Again this is one of the limitations of DecimalFormat
+        // Convert with non-localized pattern - the trailing characters left after the
+        // partial parse are now rejected, so the converter returns the default.
         // **************************************************************************
-        convertValueWithPattern(converter, "(B)", localizedIntegerValue, defaultIntegerPattern, Integer.valueOf("1"));
+        convertValueWithPattern(converter, "(B)", localizedIntegerValue, defaultIntegerPattern, defaultValue);
 
         // **************************************************************************
         // Convert with specified type

--- a/src/test/java/org/apache/commons/beanutils2/converters/LongLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/LongLocaleConverterTest.java
@@ -204,12 +204,10 @@ class LongLocaleConverterTest extends AbstractLocaleConverterTest<Long> {
         convertValueNoPattern(converter, "(B)", defaultIntegerValue, Long.valueOf("1"));
 
         // **************************************************************************
-        // Convert with non-localized pattern - unlike the equivalent BigDecimal Test Case
-        // it doesn't causes an exception in parse() - DecimalFormat parses it
-        // quite happily turning "1,234" into "1"
-        // Again this is one of the limitations of DecimalFormat
+        // Convert with non-localized pattern - the trailing characters left after the
+        // partial parse are now rejected, so the converter returns the default.
         // **************************************************************************
-        convertValueWithPattern(converter, "(B)", localizedIntegerValue, defaultIntegerPattern, Long.valueOf("1"));
+        convertValueWithPattern(converter, "(B)", localizedIntegerValue, defaultIntegerPattern, defaultValue);
 
         // **************************************************************************
         // Convert with specified type

--- a/src/test/java/org/apache/commons/beanutils2/converters/ShortLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ShortLocaleConverterTest.java
@@ -204,12 +204,10 @@ class ShortLocaleConverterTest extends AbstractLocaleConverterTest<Short> {
         convertValueNoPattern(converter, "(B)", defaultIntegerValue, Short.valueOf("1"));
 
         // **************************************************************************
-        // Convert with non-localized pattern - unlike the equivalent BigDecimal Test Case
-        // it doesn't causes an exception in parse() - DecimalFormat parses it
-        // quite happily turning "1,234" into "1"
-        // Again this is one of the limitations of DecimalFormat
+        // Convert with non-localized pattern - the trailing characters left after the
+        // partial parse are now rejected, so the converter returns the default.
         // **************************************************************************
-        convertValueWithPattern(converter, "(B)", localizedIntegerValue, defaultIntegerPattern, Short.valueOf("1"));
+        convertValueWithPattern(converter, "(B)", localizedIntegerValue, defaultIntegerPattern, defaultValue);
 
         // **************************************************************************
         // Convert with specified type


### PR DESCRIPTION
`DecimalLocaleConverter.parse` calls `DecimalFormat.parse(String)`, which stops at the first character it cannot read and silently drops the rest, so a locale numeric conversion of `123abc` returns `123` and `42 OR 1=1` returns `42`. Every numeric locale converter (`Byte`/`Short`/`Integer`/`Long`/`Float`/`Double`/`BigDecimal`/`BigInteger`) routes through this one method, while the sibling `DateLocaleConverter` and the non-locale `NumberConverter` already reject leftover input with a `ParsePosition` check. Found by comparing the locale number parsers against `DateLocaleConverter`; switched to that same check so the whole string must be consumed.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.