### PR TITLE
Reject trailing characters in DecimalLocaleConverter.parse (1.X)

### DIFF
--- a/src/main/java/org/apache/commons/beanutils/locale/converters/DecimalLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils/locale/converters/DecimalLocaleConverter.java
@@ -20,6 +20,7 @@ package org.apache.commons.beanutils.locale.converters;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
+import java.text.ParsePosition;
 import java.util.Locale;
 
 import org.apache.commons.beanutils.locale.BaseLocaleConverter;
@@ -239,6 +240,12 @@ public class DecimalLocaleConverter extends BaseLocaleConverter {
             log.debug("No pattern provided, using default.");
         }
 
-        return formatter.parse((String) value);
+        final String strValue = (String) value;
+        final ParsePosition pos = new ParsePosition(0);
+        final Number parsed = formatter.parse(strValue, pos);
+        if (parsed == null || pos.getErrorIndex() >= 0 || pos.getIndex() != strValue.length()) {
+            throw new ParseException("Error parsing '" + strValue + "' as a number", pos.getIndex());
+        }
+        return parsed;
     }
 }

--- a/src/test/java/org/apache/commons/beanutils/locale/converters/BigDecimalLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils/locale/converters/BigDecimalLocaleConverterTest.java
@@ -193,12 +193,10 @@ public class BigDecimalLocaleConverterTest extends BaseLocaleConverterTest {
         convertNull(converter, "(A)", defaultValue);
 
         // **************************************************************************
-        // Convert value in the wrong format - maybe you would expect it to throw an
-        // exception and return the default - it doesn't, DecimalFormat parses it
-        // quite happily turning "1,234.56" into "1.234"
-        // I guess this is one of the limitations of DecimalFormat
+        // Convert value in the wrong format - the trailing characters left after the
+        // partial parse are now rejected, so the converter returns the default.
         // **************************************************************************
-        convertValueNoPattern(converter, "(B)", defaultDecimalValue, new BigDecimal("1.234"));
+        convertValueNoPattern(converter, "(B)", defaultDecimalValue, defaultValue);
 
         // **************************************************************************
         // Convert with non-localized pattern - this causes an exception in parse()

--- a/src/test/java/org/apache/commons/beanutils/locale/converters/BigIntegerLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils/locale/converters/BigIntegerLocaleConverterTest.java
@@ -203,12 +203,10 @@ public class BigIntegerLocaleConverterTest extends BaseLocaleConverterTest {
         convertValueNoPattern(converter, "(B)", defaultIntegerValue, new BigInteger("1"));
 
         // **************************************************************************
-        // Convert with non-localized pattern - unlike the equivalent BigDecimal Test Case
-        // it doesn't causes an exception in parse() - DecimalFormat parses it
-        // quite happily turning "1,234" into "1"
-        // Again this is one of the limitations of DecimalFormat
+        // Convert with non-localized pattern - the trailing characters left after the
+        // partial parse are now rejected, so the converter returns the default.
         // **************************************************************************
-        convertValueWithPattern(converter, "(B)", localizedIntegerValue, defaultIntegerPattern, new BigInteger("1"));
+        convertValueWithPattern(converter, "(B)", localizedIntegerValue, defaultIntegerPattern, defaultValue);
 
         // **************************************************************************
         // Convert with specified type

--- a/src/test/java/org/apache/commons/beanutils/locale/converters/DecimalLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils/locale/converters/DecimalLocaleConverterTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.beanutils.locale.converters;
+
+import java.util.Locale;
+
+import org.apache.commons.beanutils.ConversionException;
+
+/**
+ * Tests that {@link DecimalLocaleConverter} fully consumes its input and rejects trailing, unparsed characters.
+ */
+public class DecimalLocaleConverterTest extends BaseLocaleConverterTest {
+
+    public DecimalLocaleConverterTest(final String name) {
+        super(name);
+    }
+
+    /**
+     * A grouped number is still parsed in full.
+     */
+    public void testParseAcceptsGroupedNumber() {
+        final IntegerLocaleConverter converter = new IntegerLocaleConverter(Locale.US);
+        assertEquals(Integer.valueOf(1234), converter.convert("1,234"));
+    }
+
+    /**
+     * Trailing characters left after a partial parse are rejected.
+     */
+    public void testParseRejectsTrailingCharacters() {
+        final IntegerLocaleConverter converter = new IntegerLocaleConverter(Locale.US);
+        try {
+            converter.convert("123abc");
+            fail("Expected ConversionException for trailing characters");
+        } catch (final ConversionException expected) {
+            // expected
+        }
+    }
+
+    /**
+     * A numeric prefix followed by an expression is rejected.
+     */
+    public void testParseRejectsTrailingExpression() {
+        final IntegerLocaleConverter converter = new IntegerLocaleConverter(Locale.US);
+        try {
+            converter.convert("42 OR 1=1");
+            fail("Expected ConversionException for trailing expression");
+        } catch (final ConversionException expected) {
+            // expected
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/beanutils/locale/converters/DoubleLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils/locale/converters/DoubleLocaleConverterTest.java
@@ -191,12 +191,10 @@ public class DoubleLocaleConverterTest extends BaseLocaleConverterTest {
         convertNull(converter, "(A)", defaultValue);
 
         // **************************************************************************
-        // Convert value in the wrong format - maybe you would expect it to throw an
-        // exception and return the default - it doesn't, DecimalFormat parses it
-        // quite happily turning "1,234.56" into "1.234"
-        // I guess this is one of the limitations of DecimalFormat
+        // Convert value in the wrong format - the trailing characters left after the
+        // partial parse are now rejected, so the converter returns the default.
         // **************************************************************************
-        convertValueNoPattern(converter, "(B)", defaultDecimalValue, Double.valueOf("1.234"));
+        convertValueNoPattern(converter, "(B)", defaultDecimalValue, defaultValue);
 
         // **************************************************************************
         // Convert with non-localized pattern - this causes an exception in parse()

--- a/src/test/java/org/apache/commons/beanutils/locale/converters/FloatLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils/locale/converters/FloatLocaleConverterTest.java
@@ -197,12 +197,10 @@ public class FloatLocaleConverterTest extends BaseLocaleConverterTest {
         convertNull(converter, "(A)", defaultValue);
 
         // **************************************************************************
-        // Convert value in the wrong format - maybe you would expect it to throw an
-        // exception and return the default - it doesn't, DecimalFormat parses it
-        // quite happily turning "1,234.56" into "1.234"
-        // I guess this is one of the limitations of DecimalFormat
+        // Convert value in the wrong format - the trailing characters left after the
+        // partial parse are now rejected, so the converter returns the default.
         // **************************************************************************
-        convertValueNoPattern(converter, "(B)", defaultDecimalValue, Float.valueOf("1.234"));
+        convertValueNoPattern(converter, "(B)", defaultDecimalValue, defaultValue);
 
         // **************************************************************************
         // Convert with non-localized pattern - this causes an exception in parse()

--- a/src/test/java/org/apache/commons/beanutils/locale/converters/IntegerLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils/locale/converters/IntegerLocaleConverterTest.java
@@ -191,12 +191,10 @@ public class IntegerLocaleConverterTest extends BaseLocaleConverterTest {
         convertValueNoPattern(converter, "(B)", defaultIntegerValue, Integer.valueOf("1"));
 
         // **************************************************************************
-        // Convert with non-localized pattern - unlike the equivalent BigDecimal Test Case
-        // it doesn't causes an exception in parse() - DecimalFormat parses it
-        // quite happily turning "1,234" into "1"
-        // Again this is one of the limitations of DecimalFormat
+        // Convert with non-localized pattern - the trailing characters left after the
+        // partial parse are now rejected, so the converter returns the default.
         // **************************************************************************
-        convertValueWithPattern(converter, "(B)", localizedIntegerValue, defaultIntegerPattern, Integer.valueOf("1"));
+        convertValueWithPattern(converter, "(B)", localizedIntegerValue, defaultIntegerPattern, defaultValue);
 
         // **************************************************************************
         // Convert with specified type

--- a/src/test/java/org/apache/commons/beanutils/locale/converters/LongLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils/locale/converters/LongLocaleConverterTest.java
@@ -199,12 +199,10 @@ public class LongLocaleConverterTest extends BaseLocaleConverterTest {
         convertValueNoPattern(converter, "(B)", defaultIntegerValue, Long.valueOf("1"));
 
         // **************************************************************************
-        // Convert with non-localized pattern - unlike the equivalent BigDecimal Test Case
-        // it doesn't causes an exception in parse() - DecimalFormat parses it
-        // quite happily turning "1,234" into "1"
-        // Again this is one of the limitations of DecimalFormat
+        // Convert with non-localized pattern - the trailing characters left after the
+        // partial parse are now rejected, so the converter returns the default.
         // **************************************************************************
-        convertValueWithPattern(converter, "(B)", localizedIntegerValue, defaultIntegerPattern, Long.valueOf("1"));
+        convertValueWithPattern(converter, "(B)", localizedIntegerValue, defaultIntegerPattern, defaultValue);
 
         // **************************************************************************
         // Convert with specified type

--- a/src/test/java/org/apache/commons/beanutils/locale/converters/ShortLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils/locale/converters/ShortLocaleConverterTest.java
@@ -199,12 +199,10 @@ public class ShortLocaleConverterTest extends BaseLocaleConverterTest {
         convertValueNoPattern(converter, "(B)", defaultIntegerValue, Short.valueOf("1"));
 
         // **************************************************************************
-        // Convert with non-localized pattern - unlike the equivalent BigDecimal Test Case
-        // it doesn't causes an exception in parse() - DecimalFormat parses it
-        // quite happily turning "1,234" into "1"
-        // Again this is one of the limitations of DecimalFormat
+        // Convert with non-localized pattern - the trailing characters left after the
+        // partial parse are now rejected, so the converter returns the default.
         // **************************************************************************
-        convertValueWithPattern(converter, "(B)", localizedIntegerValue, defaultIntegerPattern, Short.valueOf("1"));
+        convertValueWithPattern(converter, "(B)", localizedIntegerValue, defaultIntegerPattern, defaultValue);
 
         // **************************************************************************
         // Convert with specified type


### PR DESCRIPTION
Port of #399 to the `1.X` branch.

`DecimalLocaleConverter.parse` calls `DecimalFormat.parse(String)`, which stops at the first character it cannot read and silently drops the rest, so a locale numeric conversion of `123abc` returns `123` and `42 OR 1=1` returns `42`. Every numeric locale converter (`Byte`/`Short`/`Integer`/`Long`/`Float`/`Double`/`BigDecimal`/`BigInteger`) routes through this one method, while the sibling `DateLocaleConverter` already rejects leftover input with a `ParsePosition` check. Switched to that same form so the whole string must be consumed, otherwise `ParseException` is thrown.

Added `DecimalLocaleConverterTest` (fails without the runtime change) and updated the now-stale `(B)` assertions across the numeric locale converter tests, which pinned `DecimalFormat`'s old partial-parse values and now fall through to the converter default.

`mvn test -Dtest='*LocaleConverterTest'` is green (104 tests). The only failure in a full `mvn` run is `LocaleBeanificationTest.testContextClassloaderIndependence`, which is a pre-existing flake unrelated to this change (it fails the same way on a clean `1.X` checkout and installs its own mock converters that bypass real parsing).

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.