### PR TITLE
Preserve magnitude in BigInteger and BigDecimal locale converters

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/BigDecimalLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/BigDecimalLocaleConverter.java
@@ -88,4 +88,9 @@ public class BigDecimalLocaleConverter extends DecimalLocaleConverter<BigDecimal
         }
     }
 
+    @Override
+    protected boolean isParseBigDecimal() {
+        return true;
+    }
+
 }

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/BigIntegerLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/BigIntegerLocaleConverter.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.beanutils2.locale.converters;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.ParseException;
 import java.util.Locale;
@@ -81,7 +82,16 @@ public class BigIntegerLocaleConverter extends DecimalLocaleConverter<BigInteger
             return (BigInteger) result;
         }
 
+        if (result instanceof BigDecimal) {
+            return ((BigDecimal) result).toBigInteger();
+        }
+
         return BigInteger.valueOf(result.longValue());
+    }
+
+    @Override
+    protected boolean isParseBigDecimal() {
+        return true;
     }
 
 }

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/DecimalLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/DecimalLocaleConverter.java
@@ -98,6 +98,17 @@ public class DecimalLocaleConverter<T extends Number> extends BaseLocaleConverte
     }
 
     /**
+     * Tests whether the underlying {@link DecimalFormat} should parse into a {@link java.math.BigDecimal} so that magnitude and precision are preserved.
+     * Subclasses that build {@link java.math.BigInteger} or {@link java.math.BigDecimal} values override this to return {@code true}; the narrowing
+     * converters keep the default {@code Long} / {@code Double} result.
+     *
+     * @return {@code true} to parse into a {@link java.math.BigDecimal}, {@code false} otherwise.
+     */
+    protected boolean isParseBigDecimal() {
+        return false;
+    }
+
+    /**
      * Converts the specified locale-sensitive input object into an output object of the specified type.
      *
      * @param value   The input object to be converted
@@ -117,6 +128,7 @@ public class DecimalLocaleConverter<T extends Number> extends BaseLocaleConverte
         // representation, each call to getInstance actually returns a new
         // object.
         final DecimalFormat formatter = (DecimalFormat) NumberFormat.getInstance(locale);
+        formatter.setParseBigDecimal(isParseBigDecimal());
 
         // if some constructors default pattern to null, it makes only sense
         // to handle null pattern gracefully

--- a/src/test/java/org/apache/commons/beanutils2/converters/BigDecimalLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/BigDecimalLocaleConverterTest.java
@@ -180,6 +180,17 @@ class BigDecimalLocaleConverterTest extends AbstractLocaleConverterTest<BigDecim
     }
 
     /**
+     * A value with more significant digits than a {@code double} can hold must not be rounded through {@code double}.
+     */
+    @Test
+    void testConvertLargeValueKeepsPrecision() {
+        converter = BigDecimalLocaleConverter.builder().get();
+
+        final String big = "9999999999999999999";
+        convertValueNoPattern(converter, big, new BigDecimal(big));
+    }
+
+    /**
      * Test Converter(defaultValue, locale, pattern, localizedPattern) constructor
      */
     @Test

--- a/src/test/java/org/apache/commons/beanutils2/converters/BigIntegerLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/BigIntegerLocaleConverterTest.java
@@ -180,6 +180,20 @@ class BigIntegerLocaleConverterTest extends AbstractLocaleConverterTest<BigInteg
     }
 
     /**
+     * A value with more digits than fit in a {@code long} must keep its full magnitude instead of saturating to {@link Long#MAX_VALUE}.
+     */
+    @Test
+    void testConvertLargeValueKeepsMagnitude() {
+        converter = BigIntegerLocaleConverter.builder().get();
+
+        final String big = "9999999999999999999";
+        convertValueNoPattern(converter, big, new BigInteger(big));
+
+        final String huge = "123456789012345678901234567890";
+        convertValueNoPattern(converter, huge, new BigInteger(huge));
+    }
+
+    /**
      * Test Converter(defaultValue, locale, pattern, localizedPattern) constructor
      */
     @Test


### PR DESCRIPTION
`BigIntegerLocaleConverter` and `BigDecimalLocaleConverter` derive their result from the `Long`/`Double` that `DecimalLocaleConverter.parse` returns because `setParseBigDecimal` is never enabled, so a value past `long`/`double` range comes back silently wrong (`9999999999999999999` becomes `9223372036854775807` for `BigInteger` and `1.0E+19` for `BigDecimal`); enabling `setParseBigDecimal` only for those two converters via an `isParseBigDecimal()` hook keeps the parse lossless while the narrowing `Byte`/`Short`/`Integer`/`Long`/`Float`/`Double` converters (and `DoubleLocaleConverter`'s `(Double)` cast) are untouched, found by comparing the locale converters with the non-locale `BigInteger`/`BigDecimal` converters that parse the string directly.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
