### PR TITLE
Preserve magnitude in BigInteger and BigDecimal locale converters (1.X)

### DIFF
--- a/src/main/java/org/apache/commons/beanutils/locale/converters/BigDecimalLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils/locale/converters/BigDecimalLocaleConverter.java
@@ -182,4 +182,9 @@ public class BigDecimalLocaleConverter extends DecimalLocaleConverter {
             throw new ConversionException("Suplied number is not of type BigDecimal: " + result);
         }
     }
+
+    @Override
+    protected boolean isParseBigDecimal() {
+        return true;
+    }
 }

--- a/src/main/java/org/apache/commons/beanutils/locale/converters/BigIntegerLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils/locale/converters/BigIntegerLocaleConverter.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.beanutils.locale.converters;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.ParseException;
 import java.util.Locale;
@@ -176,6 +177,9 @@ public class BigIntegerLocaleConverter extends DecimalLocaleConverter {
         if (result == null || result instanceof BigInteger) {
             return result;
         }
+        if (result instanceof BigDecimal) {
+            return ((BigDecimal) result).toBigInteger();
+        }
         if (result instanceof Number) {
             return BigInteger.valueOf(((Number) result).longValue());
         }
@@ -184,5 +188,10 @@ public class BigIntegerLocaleConverter extends DecimalLocaleConverter {
         } catch (final NumberFormatException ex) {
             throw new ConversionException("Suplied number is not of type BigInteger: " + result);
         }
+    }
+
+    @Override
+    protected boolean isParseBigDecimal() {
+        return true;
     }
 }

--- a/src/main/java/org/apache/commons/beanutils/locale/converters/DecimalLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils/locale/converters/DecimalLocaleConverter.java
@@ -178,6 +178,18 @@ public class DecimalLocaleConverter extends BaseLocaleConverter {
      * @throws org.apache.commons.beanutils.ConversionException if conversion cannot be performed successfully.
      * @throws ParseException                                   if an error occurs parsing a String to a Number.
      */
+    /**
+     * Tests whether the underlying {@link DecimalFormat} should parse into a {@link java.math.BigDecimal} so that magnitude and precision are preserved.
+     * Subclasses that build {@link java.math.BigInteger} or {@link java.math.BigDecimal} values override this to return {@code true}; the narrowing converters
+     * keep the default {@code Long} / {@code Double} result.
+     *
+     * @return {@code true} to parse into a {@link java.math.BigDecimal}, {@code false} otherwise.
+     * @since 1.11.1
+     */
+    protected boolean isParseBigDecimal() {
+        return false;
+    }
+
     @Override
     protected Object parse(final Object value, final String pattern) throws ParseException {
         if (value instanceof Number) {
@@ -188,6 +200,7 @@ public class DecimalLocaleConverter extends BaseLocaleConverter {
         // representation, each call to getInstance actually returns a new
         // object.
         final DecimalFormat formatter = (DecimalFormat) NumberFormat.getInstance(locale);
+        formatter.setParseBigDecimal(isParseBigDecimal());
         // if some constructors default pattern to null, it makes only sense
         // to handle null pattern gracefully
         if (pattern != null) {

--- a/src/test/java/org/apache/commons/beanutils/locale/converters/BigDecimalLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils/locale/converters/BigDecimalLocaleConverterTest.java
@@ -228,5 +228,13 @@ public class BigDecimalLocaleConverterTest extends BaseLocaleConverterTest {
 
     }
 
+    /**
+     * Test that a value beyond {@code double} precision is preserved instead of being rounded to a lossy {@code 1.0E+19}.
+     */
+    public void testConvertLargeValueKeepsPrecision() {
+        converter = new BigDecimalLocaleConverter();
+        convertValueNoPattern(converter, "9999999999999999999", new BigDecimal("9999999999999999999"));
+    }
+
 }
 

--- a/src/test/java/org/apache/commons/beanutils/locale/converters/BigIntegerLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils/locale/converters/BigIntegerLocaleConverterTest.java
@@ -230,6 +230,15 @@ public class BigIntegerLocaleConverterTest extends BaseLocaleConverterTest {
     }
 
     /**
+     * Test that a value beyond {@code long} range keeps its full magnitude instead of being clamped to {@code Long.MAX_VALUE}.
+     */
+    public void testConvertLargeValueKeepsMagnitude() {
+        converter = new BigIntegerLocaleConverter();
+        convertValueNoPattern(converter, "9999999999999999999", new BigInteger("9999999999999999999"));
+        convertValueNoPattern(converter, "123456789012345678901234567890", new BigInteger("123456789012345678901234567890"));
+    }
+
+    /**
      * Tries to convert to an unsupported type. This tests behavior of the base
      * class. All locale converters should react in the same way.
      */


### PR DESCRIPTION
Port of #401 to the `1.X` branch.

`DecimalLocaleConverter.parse` builds a `DecimalFormat` but never enables `setParseBigDecimal`, so `DecimalFormat.parse` returns a clamped `Long` (when the value fits in long) or a lossy `Double` (out of long range). `BigIntegerLocaleConverter` and `BigDecimalLocaleConverter` then derive their result from that `Number`, so a value past `long`/`double` range comes back silently wrong: `9999999999999999999` becomes `9223372036854775807` for `BigInteger` and `1.0E+19` for `BigDecimal`. The non-locale `BigIntegerConverter`/`BigDecimalConverter` avoid this by parsing the string directly.

Added a protected `isParseBigDecimal()` hook (default `false`) on `DecimalLocaleConverter` and pass it to `formatter.setParseBigDecimal(...)`; only `BigIntegerLocaleConverter` and `BigDecimalLocaleConverter` override it to `true`, so `DecimalFormat` returns a lossless `BigDecimal` for them while the narrowing `Byte`/`Short`/`Integer`/`Long`/`Float`/`Double` converters keep the `Long`/`Double` path. `BigIntegerLocaleConverter` converts the `BigDecimal` via `toBigInteger()`.

Added regression tests to `BigIntegerLocaleConverterTest` and `BigDecimalLocaleConverterTest`; both fail without the runtime change (`9223372036854775807` and `1.0E+19` respectively).

`mvn test -Dtest='*LocaleConverterTest'` is green (106 tests). The only failure in a full `mvn` run is `LocaleBeanificationTest.testContextClassloaderIndependence`, a pre-existing flake unrelated to this change (it fails the same way on a clean `1.X` checkout).

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
