### PR TITLE
Reject out-of-range long and float values in NumberConverter

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/converters/NumberConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/converters/NumberConverter.java
@@ -449,6 +449,12 @@ public abstract class NumberConverter<N extends Number> extends AbstractConverte
 
         // Long
         if (targetType.equals(Long.class)) {
+            if (value.doubleValue() > Long.MAX_VALUE) {
+                throw ConversionException.format("%s value '%s' is too large for %s", toString(sourceType), value, toString(targetType));
+            }
+            if (value.doubleValue() < Long.MIN_VALUE) {
+                throw ConversionException.format("%s value '%s' is too small %s", toString(sourceType), value, toString(targetType));
+            }
             return targetType.cast(Long.valueOf(value.longValue()));
         }
 
@@ -456,6 +462,9 @@ public abstract class NumberConverter<N extends Number> extends AbstractConverte
         if (targetType.equals(Float.class)) {
             if (value.doubleValue() > Float.MAX_VALUE) {
                 throw ConversionException.format("%s value '%s' is too large for %s", toString(sourceType), value, toString(targetType));
+            }
+            if (value.doubleValue() < -Float.MAX_VALUE) {
+                throw ConversionException.format("%s value '%s' is too small %s", toString(sourceType), value, toString(targetType));
             }
             return targetType.cast(Float.valueOf(value.floatValue()));
         }

--- a/src/test/java/org/apache/commons/beanutils2/converters/FloatConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/FloatConverterTest.java
@@ -70,11 +70,17 @@ class FloatConverterTest extends AbstractNumberConverterTest<Float> {
         final Converter<Float> converter = makeConverter();
         final Class<?> clazz = Float.class;
         final Double max = Double.valueOf(Float.MAX_VALUE);
+        final Double min = Double.valueOf(-Float.MAX_VALUE);
         final Double tooBig = Double.valueOf(Double.MAX_VALUE);
+        final Double tooSmall = Double.valueOf(-Double.MAX_VALUE);
         // Maximum
         assertEquals(Float.valueOf(Float.MAX_VALUE), converter.convert(clazz, max), "Maximum");
+        // Minimum
+        assertEquals(Float.valueOf(-Float.MAX_VALUE), converter.convert(clazz, min), "Minimum");
         // Too Large
         assertThrows(ConversionException.class, () -> converter.convert(clazz, tooBig), "More than maximum, expected ConversionException");
+        // Too Small
+        assertThrows(ConversionException.class, () -> converter.convert(clazz, tooSmall), "Less than minimum, expected ConversionException");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/beanutils2/converters/LongConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/LongConverterTest.java
@@ -18,7 +18,12 @@
 package org.apache.commons.beanutils2.converters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.math.BigInteger;
+import java.util.Locale;
+
+import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,6 +63,34 @@ class LongConverterTest extends AbstractNumberConverterTest<Long> {
     @AfterEach
     public void tearDown() throws Exception {
         converter = null;
+    }
+
+    /**
+     * Test Invalid Amounts (too big/small)
+     */
+    @Test
+    void testInvalidAmount() {
+        final Converter<Long> converter = makeConverter();
+        final Class<?> clazz = Long.class;
+        // Boundaries still convert
+        assertEquals(Long.valueOf(Long.MIN_VALUE), converter.convert(clazz, Long.valueOf(Long.MIN_VALUE)), "Minimum");
+        assertEquals(Long.valueOf(Long.MAX_VALUE), converter.convert(clazz, Long.valueOf(Long.MAX_VALUE)), "Maximum");
+        // Out of range Number values must be rejected, not silently truncated/clamped
+        final BigInteger tooSmall = BigInteger.valueOf(Long.MIN_VALUE).multiply(BigInteger.TEN);
+        final BigInteger tooBig = BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.TEN);
+        assertThrows(ConversionException.class, () -> converter.convert(clazz, tooSmall), "Less than minimum, expected ConversionException");
+        assertThrows(ConversionException.class, () -> converter.convert(clazz, tooBig), "More than maximum, expected ConversionException");
+    }
+
+    /**
+     * A locale-parsed String beyond long range comes back from {@link java.text.DecimalFormat} as a {@link Double} and must be rejected rather than clamped to
+     * {@link Long#MAX_VALUE}.
+     */
+    @Test
+    void testLocaleStringOutOfRange() {
+        final LongConverter converter = makeConverter();
+        converter.setLocale(Locale.US);
+        assertThrows(ConversionException.class, () -> converter.convert(Long.class, "99999999999999999999"), "More than maximum, expected ConversionException");
     }
 
     @Test


### PR DESCRIPTION
`NumberConverter.toNumber(Class, Number)` range-checks the `byte`/`short`/`int` branches but the `Long` branch has no bounds check and the `Float` branch only checks the upper bound, so an out-of-range value (for example a locale-parsed string past `long` range, which `DecimalFormat` returns as a `Double`) is silently clamped to `Long.MAX_VALUE` or to `-Infinity` instead of throwing; found while auditing the numeric converters, fixed by adding the missing bounds checks next to the existing ones.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.