### PR TITLE
Reject out-of-range long and float values in NumberConverter (1.X)

### DIFF
--- a/src/main/java/org/apache/commons/beanutils/converters/NumberConverter.java
+++ b/src/main/java/org/apache/commons/beanutils/converters/NumberConverter.java
@@ -481,6 +481,14 @@ public abstract class NumberConverter extends AbstractConverter {
 
         // Long
         if (targetType.equals(Long.class)) {
+            if (value.doubleValue() > Long.MAX_VALUE) {
+                throw new ConversionException(toString(sourceType) + " value '" + value
+                        + "' is too large for " + toString(targetType));
+            }
+            if (value.doubleValue() < Long.MIN_VALUE) {
+                throw new ConversionException(toString(sourceType) + " value '" + value
+                        + "' is too small " + toString(targetType));
+            }
             return targetType.cast(Long.valueOf(value.longValue()));
         }
 
@@ -489,6 +497,10 @@ public abstract class NumberConverter extends AbstractConverter {
             if (value.doubleValue() > Float.MAX_VALUE) {
                 throw new ConversionException(toString(sourceType) + " value '" + value
                         + "' is too large for " + toString(targetType));
+            }
+            if (value.doubleValue() < -Float.MAX_VALUE) {
+                throw new ConversionException(toString(sourceType) + " value '" + value
+                        + "' is too small " + toString(targetType));
             }
             return targetType.cast(Float.valueOf(value.floatValue()));
         }

--- a/src/test/java/org/apache/commons/beanutils/converters/FloatConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils/converters/FloatConverterTest.java
@@ -67,16 +67,29 @@ public class FloatConverterTest extends NumberConverterTest {
         final Converter converter = makeConverter();
         final Class<?> clazz = Float.class;
 
-        final Double max     = Double.valueOf(Float.MAX_VALUE);
-        final Double tooBig  = Double.valueOf(Double.MAX_VALUE);
+        final Double max      = Double.valueOf(Float.MAX_VALUE);
+        final Double min      = Double.valueOf(-Float.MAX_VALUE);
+        final Double tooBig   = Double.valueOf(Double.MAX_VALUE);
+        final Double tooSmall = Double.valueOf(-Double.MAX_VALUE);
 
         // Maximum
         assertEquals("Maximum", Float.valueOf(Float.MAX_VALUE), converter.convert(clazz, max));
+
+        // Minimum
+        assertEquals("Minimum", Float.valueOf(-Float.MAX_VALUE), converter.convert(clazz, min));
 
         // Too Large
         try {
             assertEquals("Too Big", null, converter.convert(clazz, tooBig));
             fail("More than maximum, expected ConversionException");
+        } catch (final Exception e) {
+            // expected result
+        }
+
+        // Too Small
+        try {
+            assertEquals("Too Small", null, converter.convert(clazz, tooSmall));
+            fail("Less than minimum, expected ConversionException");
         } catch (final Exception e) {
             // expected result
         }

--- a/src/test/java/org/apache/commons/beanutils/converters/LongConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils/converters/LongConverterTest.java
@@ -17,6 +17,9 @@
 
 package org.apache.commons.beanutils.converters;
 
+import java.math.BigInteger;
+import java.util.Locale;
+
 import org.apache.commons.beanutils.Converter;
 
 /**
@@ -58,6 +61,53 @@ public class LongConverterTest extends NumberConverterTest {
     @Override
     public void tearDown() throws Exception {
         converter = null;
+    }
+
+    /**
+     * Test Invalid Amounts (too big/small)
+     */
+    public void testInvalidAmount() {
+        final Converter converter = makeConverter();
+        final Class<?> clazz = Long.class;
+
+        // Boundaries still convert
+        assertEquals("Minimum", Long.valueOf(Long.MIN_VALUE), converter.convert(clazz, Long.valueOf(Long.MIN_VALUE)));
+        assertEquals("Maximum", Long.valueOf(Long.MAX_VALUE), converter.convert(clazz, Long.valueOf(Long.MAX_VALUE)));
+
+        // Out of range values must be rejected, not silently truncated/clamped
+        final BigInteger tooSmall = BigInteger.valueOf(Long.MIN_VALUE).multiply(BigInteger.TEN);
+        final BigInteger tooBig   = BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.TEN);
+
+        // Too Small
+        try {
+            converter.convert(clazz, tooSmall);
+            fail("Less than minimum, expected ConversionException");
+        } catch (final Exception e) {
+            // expected result
+        }
+
+        // Too Large
+        try {
+            converter.convert(clazz, tooBig);
+            fail("More than maximum, expected ConversionException");
+        } catch (final Exception e) {
+            // expected result
+        }
+    }
+
+    /**
+     * A locale-parsed String beyond long range comes back from DecimalFormat as a Double and must be
+     * rejected rather than clamped to Long.MAX_VALUE.
+     */
+    public void testLocaleStringOutOfRange() {
+        final NumberConverter converter = makeConverter();
+        converter.setLocale(Locale.US);
+        try {
+            converter.convert(Long.class, "99999999999999999999");
+            fail("More than maximum, expected ConversionException");
+        } catch (final Exception e) {
+            // expected result
+        }
     }
 
     public void testSimpleConversion() throws Exception {


### PR DESCRIPTION
Port of #404 to the 1.X branch. @garydgregory asked to verify whether the fix applies there, and it does, identically.

`NumberConverter.toNumber(Class, Number)` range-checks the `byte`/`short`/`int` branches, but the `Long` branch has no bounds check and the `Float` branch only checks the upper bound, so an out-of-range value is silently clamped instead of rejected: a `Double`/`BigInteger`/`BigDecimal` beyond `long` range is truncated/clamped to `Long.MAX_VALUE`, a locale-parsed String past `long` range comes back from `DecimalFormat` as a `Double` and gets clamped the same way, and a `Number` below `-Float.MAX_VALUE` becomes `-Infinity`. Fix adds the missing bounds checks to the `Long` branch and the lower bound to the `Float` branch, mirroring the existing branches, so out-of-range input throws `ConversionException`.

Regression tests added to `LongConverterTest` (`testInvalidAmount`, `testLocaleStringOutOfRange`) and `FloatConverterTest` (negative overflow); they fail without the runtime change. Both converter test classes pass. The full `mvn` run is green except for `LocaleBeanificationTest.testContextClassloaderIndependence`, which already fails on an unmodified 1.X checkout in my environment (it passes in isolation) and is unrelated to this change.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
