### PR TITLE
Reject out-of-range values in LongLocaleConverter

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/LongLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/LongLocaleConverter.java
@@ -78,6 +78,11 @@ public class LongLocaleConverter extends DecimalLocaleConverter<Long> {
             return (Long) result;
         }
 
+        final double doubleValue = result.doubleValue();
+        if (doubleValue < Long.MIN_VALUE || doubleValue > Long.MAX_VALUE) {
+            throw new ConversionException("Supplied number is not of type Long: " + result);
+        }
+
         return Long.valueOf(result.longValue());
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/converters/LongLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/LongLocaleConverterTest.java
@@ -17,6 +17,12 @@
 
 package org.apache.commons.beanutils2.converters;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.text.DecimalFormat;
+
+import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.locale.converters.LongLocaleConverter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -188,5 +194,28 @@ class LongLocaleConverterTest extends AbstractLocaleConverterTest<Long> {
         convertValueWithPattern(converter, "(C)", localizedIntegerValue, defaultIntegerPattern, expectedValue);
         convertInvalid(converter, "(C)", defaultValue);
         convertNull(converter, "(C)", defaultValue);
+    }
+
+    /**
+     * Test Long limits
+     */
+    @Test
+    void testLongLimits() {
+        converter = LongLocaleConverter.builder().setLocale(defaultLocale).get();
+        final DecimalFormat fmt = new DecimalFormat("#");
+        assertEquals(Long.valueOf(Long.MAX_VALUE), converter.convert(fmt.format(Long.MAX_VALUE)), "Long.MAX_VALUE");
+        assertEquals(Long.valueOf(Long.MIN_VALUE), converter.convert(fmt.format(Long.MIN_VALUE)), "Long.MIN_VALUE");
+        try {
+            converter.convert("99999999999999999999");
+            fail("Positive out of range should throw ConversionException");
+        } catch (final ConversionException e) {
+            // expected result
+        }
+        try {
+            converter.convert("-99999999999999999999");
+            fail("Negative out of range should throw ConversionException");
+        } catch (final ConversionException e) {
+            // expected result
+        }
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/converters/LongLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/LongLocaleConverterTest.java
@@ -18,7 +18,7 @@
 package org.apache.commons.beanutils2.converters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.text.DecimalFormat;
 
@@ -205,17 +205,7 @@ class LongLocaleConverterTest extends AbstractLocaleConverterTest<Long> {
         final DecimalFormat fmt = new DecimalFormat("#");
         assertEquals(Long.valueOf(Long.MAX_VALUE), converter.convert(fmt.format(Long.MAX_VALUE)), "Long.MAX_VALUE");
         assertEquals(Long.valueOf(Long.MIN_VALUE), converter.convert(fmt.format(Long.MIN_VALUE)), "Long.MIN_VALUE");
-        try {
-            converter.convert("99999999999999999999");
-            fail("Positive out of range should throw ConversionException");
-        } catch (final ConversionException e) {
-            // expected result
-        }
-        try {
-            converter.convert("-99999999999999999999");
-            fail("Negative out of range should throw ConversionException");
-        } catch (final ConversionException e) {
-            // expected result
-        }
+        assertThrows(ConversionException.class, () -> converter.convert("99999999999999999999"));
+        assertThrows(ConversionException.class, () -> converter.convert("-99999999999999999999"));
     }
 }


### PR DESCRIPTION
`LongLocaleConverter.parse` narrows the parsed number with `result.longValue()` and never range-checks it, so a value beyond `long` range like `99999999999999999999` is silently clamped to `Long.MAX_VALUE` instead of rejected: `DecimalFormat` returns it as a `Double` (the converter does not set `parseBigDecimal`) and `Double.longValue()` saturates. The sibling narrowing locale converters `IntegerLocaleConverter`, `ByteLocaleConverter`, `ShortLocaleConverter` and `FloatLocaleConverter` already reject out-of-range input, so `LongLocaleConverter` gets the same bounds check before narrowing. Found while auditing the locale converter family against those sibling checks.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
