### PR TITLE
Reject out-of-range values in LongLocaleConverter (1.X)

### DIFF
--- a/src/main/java/org/apache/commons/beanutils/locale/converters/LongLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils/locale/converters/LongLocaleConverter.java
@@ -20,6 +20,8 @@ package org.apache.commons.beanutils.locale.converters;
 import java.text.ParseException;
 import java.util.Locale;
 
+import org.apache.commons.beanutils.ConversionException;
+
 /**
  * Standard {@link org.apache.commons.beanutils.locale.LocaleConverter} implementation that converts an incoming locale-sensitive String into a
  * {@code java.lang.Long} object, optionally using a default value or throwing a {@link org.apache.commons.beanutils.ConversionException} if a conversion error
@@ -172,6 +174,10 @@ public class LongLocaleConverter extends DecimalLocaleConverter {
         final Object result = super.parse(value, pattern);
         if (result == null || result instanceof Long) {
             return result;
+        }
+        final double doubleValue = ((Number) result).doubleValue();
+        if (doubleValue < Long.MIN_VALUE || doubleValue > Long.MAX_VALUE) {
+            throw new ConversionException("Supplied number is not of type Long: " + result);
         }
         return Long.valueOf(((Number) result).longValue());
     }

--- a/src/test/java/org/apache/commons/beanutils/locale/converters/LongLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils/locale/converters/LongLocaleConverterTest.java
@@ -17,6 +17,10 @@
 
 package org.apache.commons.beanutils.locale.converters;
 
+import java.text.DecimalFormat;
+
+import org.apache.commons.beanutils.ConversionException;
+
 /**
  * Test Case for the LongLocaleConverter class.
  *
@@ -223,6 +227,28 @@ public class LongLocaleConverterTest extends BaseLocaleConverterTest {
         convertInvalid(converter, "(C)", defaultValue);
         convertNull(converter, "(C)", defaultValue);
 
+    }
+
+    /**
+     * Test Long limits
+     */
+    public void testLongLimits() {
+        converter = new LongLocaleConverter();
+        final DecimalFormat fmt = new DecimalFormat("#");
+        assertEquals(Long.valueOf(Long.MAX_VALUE), converter.convert(fmt.format(Long.MAX_VALUE)));
+        assertEquals(Long.valueOf(Long.MIN_VALUE), converter.convert(fmt.format(Long.MIN_VALUE)));
+        try {
+            converter.convert("99999999999999999999");
+            fail("Positive out of range should throw ConversionException");
+        } catch (final ConversionException expected) {
+            // expected result
+        }
+        try {
+            converter.convert("-99999999999999999999");
+            fail("Negative out of range should throw ConversionException");
+        } catch (final ConversionException expected) {
+            // expected result
+        }
     }
 
 }

--- a/src/test/java/org/apache/commons/beanutils/locale/converters/LongLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils/locale/converters/LongLocaleConverterTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.beanutils.locale.converters;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.text.DecimalFormat;
 
 import org.apache.commons.beanutils.ConversionException;
@@ -237,18 +239,8 @@ public class LongLocaleConverterTest extends BaseLocaleConverterTest {
         final DecimalFormat fmt = new DecimalFormat("#");
         assertEquals(Long.valueOf(Long.MAX_VALUE), converter.convert(fmt.format(Long.MAX_VALUE)));
         assertEquals(Long.valueOf(Long.MIN_VALUE), converter.convert(fmt.format(Long.MIN_VALUE)));
-        try {
-            converter.convert("99999999999999999999");
-            fail("Positive out of range should throw ConversionException");
-        } catch (final ConversionException expected) {
-            // expected result
-        }
-        try {
-            converter.convert("-99999999999999999999");
-            fail("Negative out of range should throw ConversionException");
-        } catch (final ConversionException expected) {
-            // expected result
-        }
+        assertThrows(ConversionException.class, () -> converter.convert("99999999999999999999"));
+        assertThrows(ConversionException.class, () -> converter.convert("-99999999999999999999"));
     }
 
 }


### PR DESCRIPTION
Port of #406 to the `1.X` branch.

`LongLocaleConverter.parse` narrows the parsed number with `result.longValue()` and never range-checks it, so a value beyond `long` range like `99999999999999999999` is silently clamped to `Long.MAX_VALUE` instead of rejected: `DecimalFormat` returns it as a `Double` (the converter does not set `parseBigDecimal`) and `Double.longValue()` saturates.

The sibling narrowing locale converters `IntegerLocaleConverter`, `ByteLocaleConverter`, `ShortLocaleConverter` and `FloatLocaleConverter` already reject out-of-range input, so `LongLocaleConverter` gets the same bounds check before narrowing. Found while auditing the locale converter family against those sibling checks.

Added a regression test to `LongLocaleConverterTest`; it fails without the runtime change (`99999999999999999999` comes back as `9223372036854775807`). `mvn test -Dtest='*LocaleConverterTest'` is green (107 tests).

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
