### PR TITLE
Stop narrowing BigInteger and BigDecimal in StringLocaleConverter

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/StringLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/StringLocaleConverter.java
@@ -121,9 +121,11 @@ public class StringLocaleConverter extends BaseLocaleConverter<String> {
     protected String parse(final Object value, final String pattern) throws ParseException {
         String result = null;
 
-        if (value instanceof Integer || value instanceof Long || value instanceof BigInteger || value instanceof Byte || value instanceof Short) {
+        if (value instanceof BigInteger || value instanceof BigDecimal) {
+            result = getDecimalFormat(locale, pattern).format(value);
+        } else if (value instanceof Integer || value instanceof Long || value instanceof Byte || value instanceof Short) {
             result = getDecimalFormat(locale, pattern).format(((Number) value).longValue());
-        } else if (value instanceof Double || value instanceof BigDecimal || value instanceof Float) {
+        } else if (value instanceof Double || value instanceof Float) {
             result = getDecimalFormat(locale, pattern).format(((Number) value).doubleValue());
         } else if (value instanceof Date) { // java.util.Date, java.sql.Date, java.sql.Time, java.sql.Timestamp
             result = new SimpleDateFormat(pattern, locale).format(value);

--- a/src/test/java/org/apache/commons/beanutils2/converters/StringLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/StringLocaleConverterTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.beanutils2.converters;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Locale;
+
+import org.apache.commons.beanutils2.locale.converters.StringLocaleConverter;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test Case for the StringLocaleConverter class.
+ */
+class StringLocaleConverterTest extends AbstractLocaleConverterTest<String> {
+
+    /**
+     * A {@link BigDecimal} beyond {@code double} precision must keep its full magnitude instead of being narrowed via {@code doubleValue()}.
+     */
+    @Test
+    void testConvertBigDecimalKeepsMagnitude() {
+        converter = StringLocaleConverter.builder().setLocale(Locale.US).get();
+        final BigDecimal huge = new BigDecimal("123456789012345678901234567890");
+        assertEquals("123,456,789,012,345,678,901,234,567,890", converter.convert(huge));
+    }
+
+    /**
+     * A {@link BigInteger} wider than a {@code long} must keep its full magnitude instead of being narrowed via {@code longValue()}.
+     */
+    @Test
+    void testConvertBigIntegerKeepsMagnitude() {
+        converter = StringLocaleConverter.builder().setLocale(Locale.US).get();
+        final BigInteger huge = new BigInteger("99999999999999999999");
+        assertEquals("99,999,999,999,999,999,999", converter.convert(huge));
+    }
+}


### PR DESCRIPTION
`StringLocaleConverter.parse` formatted `BigInteger` via `((Number) value).longValue()` and `BigDecimal` via `doubleValue()`, so a value wider than 64 bits was narrowed before formatting and came back silently wrong (`new BigInteger("99999999999999999999")` formatted to `7,766,279,631,452,241,919`); `DecimalFormat.format(Object)` handles `BigInteger`/`BigDecimal` with full magnitude natively, so I format those two types directly and keep the `long`/`double` path for the primitive wrappers. Found while auditing the locale converters against the magnitude handling in `BigIntegerLocaleConverter`/`BigDecimalLocaleConverter`.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
