### PR TITLE
reject non-canonical UUID strings in UUIDConverter

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/converters/UUIDConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/converters/UUIDConverter.java
@@ -57,7 +57,14 @@ public final class UUIDConverter extends AbstractConverter<UUID> {
     @Override
     protected <T> T convertToType(final Class<T> type, final Object value) throws Throwable {
         if (UUID.class.equals(type)) {
-            return type.cast(UUID.fromString(String.valueOf(value)));
+            final String stringValue = String.valueOf(value);
+            final UUID uuid = UUID.fromString(stringValue);
+            // UUID.fromString accepts abbreviated groups (e.g. "1-1-1-1-1"), so
+            // reject anything that is not the canonical 8-4-4-4-12 representation.
+            if (!uuid.toString().equalsIgnoreCase(stringValue)) {
+                throw new IllegalArgumentException("Invalid UUID string: " + stringValue);
+            }
+            return type.cast(uuid);
         }
 
         throw conversionException(type, value);

--- a/src/test/java/org/apache/commons/beanutils2/converters/UUIDConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/UUIDConverterTest.java
@@ -68,6 +68,25 @@ class UUIDConverterTest {
     }
 
     /**
+     * Non-canonical strings accepted by {@link UUID#fromString(String)} (abbreviated groups) must be rejected.
+     */
+    @Test
+    void testNonCanonicalStringRejected() {
+        assertThrows(ConversionException.class, () -> converter.convert(UUID.class, "1-1-1-1-1"));
+        assertThrows(ConversionException.class, () -> converter.convert(UUID.class, "0-0-0-0-0"));
+    }
+
+    /**
+     * Canonical strings, including upper case, must still convert.
+     */
+    @Test
+    void testCanonicalStringAccepted() {
+        final UUID expected = UUID.fromString("123e4567-e89b-12d3-a456-556642440000");
+        assertEquals(expected, converter.convert(UUID.class, "123e4567-e89b-12d3-a456-556642440000"));
+        assertEquals(expected, converter.convert(UUID.class, "123E4567-E89B-12D3-A456-556642440000"));
+    }
+
+    /**
      * Tests a conversion to an unsupported type.
      */
     @Test


### PR DESCRIPTION
`UUID.fromString` accepts abbreviated groups like `1-1-1-1-1` and silently canonicalizes them to `00000001-0001-0001-0001-000000000001`, so `UUIDConverter` converts strings that are not the canonical 8-4-4-4-12 form; found while auditing the converters that delegate straight to a lenient JDK parse, and fixed by rejecting any input that does not round-trip to its canonical string (upper case still converts).

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
