### PR TITLE
Fix sql time and timestamp locale tests on java 20+

### DIFF
--- a/src/test/java/org/apache/commons/beanutils2/sql/converters/SqlTimeConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/sql/converters/SqlTimeConverterTest.java
@@ -18,7 +18,9 @@
 package org.apache.commons.beanutils2.sql.converters;
 
 import java.sql.Time;
+import java.text.DateFormat;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.Locale;
 
 import org.apache.commons.beanutils2.converters.AbstractDateConverterTest;
@@ -28,6 +30,15 @@ import org.junit.jupiter.api.Test;
  * Test Case for the {@link SqlTimeConverter} class.
  */
 class SqlTimeConverterTest extends AbstractDateConverterTest<Time> {
+
+    /**
+     * Gets the separator that precedes the AM/PM field in the US SHORT time format. Java 20 and up (CLDR) use a narrow no-break space (U+202F) here,
+     * earlier versions use a regular space.
+     */
+    private static String amPmSeparator() {
+        final String formatted = DateFormat.getTimeInstance(DateFormat.SHORT, Locale.US).format(new Date());
+        return formatted.contains("\u202f") ? "\u202f" : " ";
+    }
 
     /**
      * Gets the expected type
@@ -89,14 +100,14 @@ class SqlTimeConverterTest extends AbstractDateConverterTest<Time> {
         final Locale defaultLocale = Locale.getDefault();
         Locale.setDefault(Locale.US);
 
-        final String pattern = "h:mm a"; // SHORT style time format for US Locale
+        final String pattern = "h:mm" + amPmSeparator() + "a"; // SHORT style time format for US Locale
 
         // Create & Configure the Converter
         final SqlTimeConverter converter = makeConverter();
         converter.setUseLocaleFormat(true);
 
         // Valid String --> Type Conversion
-        final String testString = "3:06 pm";
+        final String testString = "3:06" + amPmSeparator() + "pm";
         final Object expected = toType(testString, pattern, null);
         validConversion(converter, expected, testString);
 

--- a/src/test/java/org/apache/commons/beanutils2/sql/converters/SqlTimestampConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/sql/converters/SqlTimestampConverterTest.java
@@ -32,6 +32,15 @@ import org.junit.jupiter.api.Test;
 class SqlTimestampConverterTest extends AbstractDateConverterTest<Timestamp> {
 
     /**
+     * Gets the separator that precedes the AM/PM field in the US SHORT time format. Java 20 and up (CLDR) use a narrow no-break space (U+202F) here,
+     * earlier versions use a regular space.
+     */
+    private static String amPmSeparator() {
+        final String formatted = DateFormat.getTimeInstance(DateFormat.SHORT, Locale.US).format(new Date());
+        return formatted.contains("\u202f") ? "\u202f" : " ";
+    }
+
+    /**
      * Gets the expected type
      *
      * @return The expected type
@@ -108,12 +117,12 @@ class SqlTimestampConverterTest extends AbstractDateConverterTest<Timestamp> {
         String pattern; // SHORT style Date & Time format for US Locale
         String testString;
         if (isUSFormatWithComma()) {
-            pattern = "M/d/yy, h:mm a";
-            testString = "3/21/06, 3:06 PM";
+            pattern = "M/d/yy, h:mm" + amPmSeparator() + "a";
+            testString = "3/21/06, 3:06" + amPmSeparator() + "PM";
         } else {
             // More regular pattern for Java 8 and earlier
-            pattern = "M/d/yy h:mm a";
-            testString = "3/21/06 3:06 PM";
+            pattern = "M/d/yy h:mm" + amPmSeparator() + "a";
+            testString = "3/21/06 3:06" + amPmSeparator() + "PM";
         }
 
         // Valid String --> Type Conversion


### PR DESCRIPTION
Follow-up to the request on #406 to fix the SQL test failures on Java 25 and up.

`SqlTimeConverterTest.testLocale` and `SqlTimestampConverterTest.testLocale` fail on JDK 20+ because CLDR changed the US SHORT time format to use a narrow no-break space (U+202F) before the AM/PM marker instead of a regular space. The locale converter parses using the JVM's own `DateFormat`, so it expects U+202F, while the tests hard-coded a regular space in both the input string and the pattern that computes the expected value (and `toCalendar` parses non-lenient). The non-SQL date test only uses a date pattern, which is why it wasn't affected.

Rather than hard-code either separator, the tests now derive it from the running JVM's SHORT time format, so they pass on both older JDKs (regular space) and JDK 20+ (U+202F).

Verified failing before and passing after on OpenJDK 26; full suite still green on JDK 21.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This is a test-only fix; there is no runtime change.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
