### PR TITLE
Reject non-integer strings in integer locale converters

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/BigIntegerLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/BigIntegerLocaleConverter.java
@@ -80,7 +80,11 @@ public class BigIntegerLocaleConverter extends DecimalLocaleConverter<BigInteger
             return (BigInteger) result;
         }
         if (result instanceof BigDecimal) {
-            return ((BigDecimal) result).toBigInteger();
+            try {
+                return ((BigDecimal) result).toBigIntegerExact();
+            } catch (final ArithmeticException e) {
+                throw new ConversionException("Supplied number is not an integer: " + result, e);
+            }
         }
         return BigInteger.valueOf(result.longValue());
     }

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/ByteLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/ByteLocaleConverter.java
@@ -74,6 +74,10 @@ public class ByteLocaleConverter extends DecimalLocaleConverter<Byte> {
         if (parsed.longValue() != parsed.byteValue()) {
             throw new ConversionException("Supplied number is not of type Byte: " + parsed.longValue());
         }
+        final double doubleValue = parsed.doubleValue();
+        if (doubleValue != Math.rint(doubleValue)) {
+            throw new ConversionException("Supplied number is not an integer: " + parsed);
+        }
         // now returns property Byte
         return Byte.valueOf(parsed.byteValue());
     }

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/IntegerLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/IntegerLocaleConverter.java
@@ -74,6 +74,10 @@ public class IntegerLocaleConverter extends DecimalLocaleConverter<Integer> {
         if (parsed.longValue() != parsed.intValue()) {
             throw new ConversionException("Supplied number is not of type Integer: " + parsed.longValue());
         }
+        final double doubleValue = parsed.doubleValue();
+        if (doubleValue != Math.rint(doubleValue)) {
+            throw new ConversionException("Supplied number is not an integer: " + parsed);
+        }
         return Integer.valueOf(parsed.intValue()); // unlike superclass it will return proper Integer
     }
 }

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/LongLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/LongLocaleConverter.java
@@ -79,6 +79,9 @@ public class LongLocaleConverter extends DecimalLocaleConverter<Long> {
         if (doubleValue < Long.MIN_VALUE || doubleValue > Long.MAX_VALUE) {
             throw new ConversionException("Supplied number is not of type Long: " + result);
         }
+        if (doubleValue != Math.rint(doubleValue)) {
+            throw new ConversionException("Supplied number is not an integer: " + result);
+        }
         return Long.valueOf(result.longValue());
     }
 }

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/ShortLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/ShortLocaleConverter.java
@@ -84,6 +84,10 @@ public class ShortLocaleConverter extends DecimalLocaleConverter<Short> {
         if (parsed.longValue() != parsed.shortValue()) {
             throw new ConversionException("Supplied number is not of type Short: " + parsed.longValue());
         }
+        final double doubleValue = parsed.doubleValue();
+        if (doubleValue != Math.rint(doubleValue)) {
+            throw new ConversionException("Supplied number is not an integer: " + parsed);
+        }
         // now returns property Short
         return Short.valueOf(parsed.shortValue());
     }

--- a/src/test/java/org/apache/commons/beanutils2/converters/BigIntegerLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/BigIntegerLocaleConverterTest.java
@@ -176,12 +176,12 @@ class BigIntegerLocaleConverterTest extends AbstractLocaleConverterTest<BigInteg
         convertInvalid(converter, "(A)", defaultValue);
         convertNull(converter, "(A)", defaultValue);
         // **************************************************************************
-        // Convert value in the wrong format - maybe you would expect it to throw an
-        // exception and return the default - it doesn't, DecimalFormat parses it
-        // quite happily turning "1,234" into "1"
-        // I guess this is one of the limitations of DecimalFormat
+        // Convert value in the wrong format - the localized (German) converter reads
+        // ',' as the decimal separator, so "1,234" parses to the fractional value
+        // 1.234; the integer converter now rejects a non-integer result and returns
+        // the default.
         // **************************************************************************
-        convertValueNoPattern(converter, "(B)", defaultIntegerValue, new BigInteger("1"));
+        convertValueNoPattern(converter, "(B)", defaultIntegerValue, defaultValue);
         // **************************************************************************
         // Convert with non-localized pattern - the trailing characters left after the
         // partial parse are now rejected, so the converter returns the default.
@@ -202,5 +202,14 @@ class BigIntegerLocaleConverterTest extends AbstractLocaleConverterTest<BigInteg
         convertValueWithPattern(converter, "(C)", localizedIntegerValue, defaultIntegerPattern, expectedValue);
         convertInvalid(converter, "(C)", defaultValue);
         convertNull(converter, "(C)", defaultValue);
+    }
+
+    /**
+     * Tests that a non-integer value is rejected rather than silently truncated to an integer.
+     */
+    @Test
+    void testNonIntegerRejected() {
+        converter = BigIntegerLocaleConverter.builder().setDefault(defaultValue).setLocale(defaultLocale).get();
+        convertValueNoPattern(converter, "non-integer", "5.5", defaultValue);
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/converters/ByteLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ByteLocaleConverterTest.java
@@ -169,12 +169,12 @@ class ByteLocaleConverterTest extends AbstractLocaleConverterTest<Byte> {
         convertInvalid(converter, "(A)", defaultValue);
         convertNull(converter, "(A)", defaultValue);
         // **************************************************************************
-        // Convert value in the wrong format - maybe you would expect it to throw an
-        // exception and return the default - it doesn't, DecimalFormat parses it
-        // quite happily turning ",123" into "0"
-        // I guess this is one of the limitations of DecimalFormat
+        // Convert value in the wrong format - the localized (German) converter reads
+        // ',' as the decimal separator, so ",123" parses to the fractional value
+        // 0.123; the integer converter now rejects a non-integer result and returns
+        // the default.
         // **************************************************************************
-        convertValueNoPattern(converter, "(B)", defaultIntegerValue, Byte.valueOf("0"));
+        convertValueNoPattern(converter, "(B)", defaultIntegerValue, defaultValue);
         // **************************************************************************
         // Convert with non-localized pattern
         // **************************************************************************
@@ -195,5 +195,14 @@ class ByteLocaleConverterTest extends AbstractLocaleConverterTest<Byte> {
         convertValueWithPattern(converter, "(C)", localizedIntegerValue, defaultIntegerPattern, expectedValue);
         convertInvalid(converter, "(C)", defaultValue);
         convertNull(converter, "(C)", defaultValue);
+    }
+
+    /**
+     * Tests that a non-integer value is rejected rather than silently truncated to an integer.
+     */
+    @Test
+    void testNonIntegerRejected() {
+        converter = ByteLocaleConverter.builder().setDefault(defaultValue).setLocale(defaultLocale).get();
+        convertValueNoPattern(converter, "non-integer", "5.5", defaultValue);
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/converters/IntegerLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/IntegerLocaleConverterTest.java
@@ -164,12 +164,12 @@ class IntegerLocaleConverterTest extends AbstractLocaleConverterTest<Integer> {
         convertInvalid(converter, "(A)", defaultValue);
         convertNull(converter, "(A)", defaultValue);
         // **************************************************************************
-        // Convert value in the wrong format - maybe you would expect it to throw an
-        // exception and return the default - it doesn't, DecimalFormat parses it
-        // quite happily turning "1,234" into "1"
-        // I guess this is one of the limitations of DecimalFormat
+        // Convert value in the wrong format - the localized (German) converter reads
+        // ',' as the decimal separator, so "1,234" parses to the fractional value
+        // 1.234; the integer converter now rejects a non-integer result and returns
+        // the default.
         // **************************************************************************
-        convertValueNoPattern(converter, "(B)", defaultIntegerValue, Integer.valueOf("1"));
+        convertValueNoPattern(converter, "(B)", defaultIntegerValue, defaultValue);
         // **************************************************************************
         // Convert with non-localized pattern - the trailing characters left after the
         // partial parse are now rejected, so the converter returns the default.
@@ -214,5 +214,14 @@ class IntegerLocaleConverterTest extends AbstractLocaleConverterTest<Integer> {
         final Class<Integer> target = Integer.TYPE;
         final int result = converter.convert(target, (Object) value.toString());
         assertEquals(value.intValue(), result, "Wrong result");
+    }
+
+    /**
+     * Tests that a non-integer value is rejected rather than silently truncated to an integer.
+     */
+    @Test
+    void testNonIntegerRejected() {
+        converter = IntegerLocaleConverter.builder().setDefault(defaultValue).setLocale(defaultLocale).get();
+        convertValueNoPattern(converter, "non-integer", "5.5", defaultValue);
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/converters/LongLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/LongLocaleConverterTest.java
@@ -168,12 +168,12 @@ class LongLocaleConverterTest extends AbstractLocaleConverterTest<Long> {
         convertInvalid(converter, "(A)", defaultValue);
         convertNull(converter, "(A)", defaultValue);
         // **************************************************************************
-        // Convert value in the wrong format - maybe you would expect it to throw an
-        // exception and return the default - it doesn't, DecimalFormat parses it
-        // quite happily turning "1,234" into "1"
-        // I guess this is one of the limitations of DecimalFormat
+        // Convert value in the wrong format - the localized (German) converter reads
+        // ',' as the decimal separator, so "1,234" parses to the fractional value
+        // 1.234; the integer converter now rejects a non-integer result and returns
+        // the default.
         // **************************************************************************
-        convertValueNoPattern(converter, "(B)", defaultIntegerValue, Long.valueOf("1"));
+        convertValueNoPattern(converter, "(B)", defaultIntegerValue, defaultValue);
         // **************************************************************************
         // Convert with non-localized pattern - the trailing characters left after the
         // partial parse are now rejected, so the converter returns the default.
@@ -207,5 +207,14 @@ class LongLocaleConverterTest extends AbstractLocaleConverterTest<Long> {
         assertEquals(Long.valueOf(Long.MIN_VALUE), converter.convert(fmt.format(Long.MIN_VALUE)), "Long.MIN_VALUE");
         assertThrows(ConversionException.class, () -> converter.convert("99999999999999999999"));
         assertThrows(ConversionException.class, () -> converter.convert("-99999999999999999999"));
+    }
+
+    /**
+     * Tests that a non-integer value is rejected rather than silently truncated to an integer.
+     */
+    @Test
+    void testNonIntegerRejected() {
+        converter = LongLocaleConverter.builder().setDefault(defaultValue).setLocale(defaultLocale).get();
+        convertValueNoPattern(converter, "non-integer", "5.5", defaultValue);
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/converters/ShortLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ShortLocaleConverterTest.java
@@ -162,12 +162,12 @@ class ShortLocaleConverterTest extends AbstractLocaleConverterTest<Short> {
         convertInvalid(converter, "(A)", defaultValue);
         convertNull(converter, "(A)", defaultValue);
         // **************************************************************************
-        // Convert value in the wrong format - maybe you would expect it to throw an
-        // exception and return the default - it doesn't, DecimalFormat parses it
-        // quite happily turning "1,234" into "1"
-        // I guess this is one of the limitations of DecimalFormat
+        // Convert value in the wrong format - the localized (German) converter reads
+        // ',' as the decimal separator, so "1,234" parses to the fractional value
+        // 1.234; the integer converter now rejects a non-integer result and returns
+        // the default.
         // **************************************************************************
-        convertValueNoPattern(converter, "(B)", defaultIntegerValue, Short.valueOf("1"));
+        convertValueNoPattern(converter, "(B)", defaultIntegerValue, defaultValue);
         // **************************************************************************
         // Convert with non-localized pattern - the trailing characters left after the
         // partial parse are now rejected, so the converter returns the default.
@@ -188,5 +188,14 @@ class ShortLocaleConverterTest extends AbstractLocaleConverterTest<Short> {
         convertValueWithPattern(converter, "(C)", localizedIntegerValue, defaultIntegerPattern, expectedValue);
         convertInvalid(converter, "(C)", defaultValue);
         convertNull(converter, "(C)", defaultValue);
+    }
+
+    /**
+     * Tests that a non-integer value is rejected rather than silently truncated to an integer.
+     */
+    @Test
+    void testNonIntegerRejected() {
+        converter = ShortLocaleConverter.builder().setDefault(defaultValue).setLocale(defaultLocale).get();
+        convertValueNoPattern(converter, "non-integer", "5.5", defaultValue);
     }
 }


### PR DESCRIPTION
The integer locale converters `IntegerLocaleConverter`, `LongLocaleConverter`, `ShortLocaleConverter`, `ByteLocaleConverter` and `BigIntegerLocaleConverter` parse with a `DecimalFormat` that accepts a fractional part, then narrow the result with `intValue()`/`longValue()`/`byteValue()`/`toBigInteger()`. Their only guard checks that the value fits the target range, so `5.5` slips through and is silently truncated to `5` instead of rejected. Found by diffing them against the non-locale `IntegerConverter`, which rejects `5.5` through `Integer.valueOf`.

Each `parse` now rejects a non-integer result before narrowing, and `BigIntegerLocaleConverter` uses `toBigIntegerExact`. Grouping separators and large in-range integers still convert. The stale `(B)` assertions that pinned the old truncated values now expect the default.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
