### PR TITLE
Suppress class and declaringClass pseudo-properties in BeanMap

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/BeanMap.java
+++ b/src/main/java/org/apache/commons/beanutils2/BeanMap.java
@@ -479,6 +479,11 @@ public class BeanMap extends AbstractMap<String, Object> implements Cloneable {
                 for (final PropertyDescriptor propertyDescriptor : propertyDescriptors) {
                     if (propertyDescriptor != null) {
                         final String name = propertyDescriptor.getName();
+                        if ("class".equals(name) || "declaringClass".equals(name)) {
+                            // These pseudo-properties expose the bean's ClassLoader; skip them to match the
+                            // suppression PropertyUtilsBean applies by default (see SuppressPropertiesBeanIntrospector).
+                            continue;
+                        }
                         final Method readMethod = propertyDescriptor.getReadMethod();
                         final Method writeMethod = propertyDescriptor.getWriteMethod();
                         final Class<?> aType = propertyDescriptor.getPropertyType();

--- a/src/test/java/org/apache/commons/beanutils2/BeanMapTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/BeanMapTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.time.DayOfWeek;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -295,7 +296,7 @@ class BeanMapTest extends AbstractMapTest<BeanMap, String, Object> {
         assertNull(map.get("class"));
         assertNull(map.getReadMethod("class"));
 
-        final BeanMap enumMap = new BeanMap(java.time.DayOfWeek.MONDAY);
+        final BeanMap enumMap = new BeanMap(DayOfWeek.MONDAY);
         assertFalse(enumMap.containsKey("class"), "class must not be exposed as a property");
         assertFalse(enumMap.containsKey("declaringClass"), "declaringClass must not be exposed as a property");
         assertNull(enumMap.get("declaringClass"));

--- a/src/test/java/org/apache/commons/beanutils2/BeanMapTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/BeanMapTest.java
@@ -17,7 +17,9 @@
 package org.apache.commons.beanutils2;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -176,7 +178,7 @@ class BeanMapTest extends AbstractMapTest<BeanMap, String, Object> {
     @Override
     public Object[] getNewSampleValues() {
         final Object[] values = { Integer.valueOf(223), Long.valueOf(23341928234L), Double.valueOf(23423.34), Float.valueOf(213332.12f),
-                Short.valueOf((short) 234), Byte.valueOf((byte) 20), Character.valueOf('b'), Integer.valueOf(232), "SomeNewStringValue", new Object(), null, };
+                Short.valueOf((short) 234), Byte.valueOf((byte) 20), Character.valueOf('b'), Integer.valueOf(232), "SomeNewStringValue", new Object(), };
         return values;
     }
 
@@ -188,12 +190,12 @@ class BeanMapTest extends AbstractMapTest<BeanMap, String, Object> {
     // To:
     // "some\2Value",
     //
-    // Then, I manually added the "class" key, which is a property that exists for
-    // all beans (and all objects for that matter.
+    // The "class" pseudo-property is intentionally absent: it is suppressed so the bean's
+    // ClassLoader is not reachable through the map.
     @Override
     public String[] getSampleKeys() {
         final String[] keys = { "someIntValue", "someLongValue", "someDoubleValue", "someFloatValue", "someShortValue", "someByteValue", "someCharValue",
-                "someIntegerValue", "someStringValue", "someObjectValue", "class", };
+                "someIntegerValue", "someStringValue", "someObjectValue", };
         return keys;
     }
 
@@ -201,8 +203,7 @@ class BeanMapTest extends AbstractMapTest<BeanMap, String, Object> {
     @Override
     public Object[] getSampleValues() {
         final Object[] values = { Integer.valueOf(1234), Long.valueOf(1298341928234L), Double.valueOf(123423.34), Float.valueOf(1213332.12f),
-                Short.valueOf((short) 134), Byte.valueOf((byte) 10), Character.valueOf('a'), Integer.valueOf(1432), "SomeStringValue", objectInFullMap,
-                BeanWithProperties.class, };
+                Short.valueOf((short) 134), Byte.valueOf((byte) 10), Character.valueOf('a'), Integer.valueOf(1432), "SomeStringValue", objectInFullMap, };
         return values;
     }
 
@@ -281,6 +282,23 @@ class BeanMapTest extends AbstractMapTest<BeanMap, String, Object> {
         } catch (final CloneNotSupportedException exception) {
             fail("BeanMap.clone() should not throw a CloneNotSupportedException when clone should succeed.");
         }
+    }
+
+    /**
+     * The {@code class} and (for enums) {@code declaringClass} pseudo-properties expose the bean's {@link ClassLoader} and must not be reachable through the map,
+     * matching the suppression {@link PropertyUtilsBean} applies by default.
+     */
+    @Test
+    void testClassPropertyNotExposed() {
+        final BeanMap map = new BeanMap(new BeanWithProperties());
+        assertFalse(map.containsKey("class"), "class must not be exposed as a property");
+        assertNull(map.get("class"));
+        assertNull(map.getReadMethod("class"));
+
+        final BeanMap enumMap = new BeanMap(java.time.DayOfWeek.MONDAY);
+        assertFalse(enumMap.containsKey("class"), "class must not be exposed as a property");
+        assertFalse(enumMap.containsKey("declaringClass"), "declaringClass must not be exposed as a property");
+        assertNull(enumMap.get("declaringClass"));
     }
 
     @Test


### PR DESCRIPTION
`BeanMap.initialize` introspects the bean with `java.beans.Introspector` directly and registers every property descriptor, so the `class` pseudo-property (`Object.getClass`, present on every bean) and `declaringClass` (`Enum.getDeclaringClass`, on enums) become map entries. `PropertyUtilsBean` registers `SuppressPropertiesBeanIntrospector.SUPPRESS_CLASS`/`SUPPRESS_DECLARING_CLASS` by default to drop exactly these, but `BeanMap` applies no suppression, so `new BeanMap(bean).get("class")` hands back the bean's `Class` and its class loader, and `keySet()`/`entrySet()` enumerate that entry to any caller treating the `BeanMap` as an opaque `Map`. Skip both names in `initialize()`, matching the `"class".equals(name)` guard already in `BeanUtilsBean.copyProperties`.

Found while auditing which introspection paths honor the default `class` suppression; `BeanMap` was the one that reintroduces it. `BeanMapTest.testClassPropertyNotExposed` fails without the runtime change. Updated the sample key/value arrays that pinned the `class` entry.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
