### PR TITLE
Do not resolve suppressed mapped properties in getPropertyDescriptor

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java
+++ b/src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java
@@ -675,6 +675,13 @@ public class PropertyUtilsBean {
             return result;
         }
 
+        // A name removed by a SuppressPropertiesBeanIntrospector is absent from data above, but the
+        // mapped-descriptor fallback below rebuilds descriptors straight from the class methods and never
+        // consults the introspectors, so a suppressed mapped property would still be resolved. Keep it hidden.
+        if (isPropertySuppressed(name)) {
+            return null;
+        }
+
         Map mappedDescriptors = getMappedPropertyDescriptors(bean);
         if (mappedDescriptors == null) {
             mappedDescriptors = new ConcurrentHashMap<Class<?>, Map>();
@@ -696,6 +703,23 @@ public class PropertyUtilsBean {
         }
 
         return result;
+    }
+
+    /**
+     * Tests whether a property name has been removed by a registered {@link SuppressPropertiesBeanIntrospector}. The mapped-descriptor fallback in
+     * {@link #getPropertyDescriptor(Object, String)} bypasses the introspection pipeline, so suppressed mapped property names must be filtered explicitly.
+     *
+     * @param name The property name to test.
+     * @return {@code true} if the name is suppressed by an introspector.
+     */
+    private boolean isPropertySuppressed(final String name) {
+        for (final BeanIntrospector introspector : introspectors) {
+            if (introspector instanceof SuppressPropertiesBeanIntrospector
+                    && ((SuppressPropertiesBeanIntrospector) introspector).getSuppressedProperties().contains(name)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/test/java/org/apache/commons/beanutils2/PropertyUtilsTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/PropertyUtilsTest.java
@@ -295,6 +295,27 @@ class PropertyUtilsTest {
     }
 
     /**
+     * A mapped property removed by a {@link SuppressPropertiesBeanIntrospector} must stay hidden. The mapped-descriptor fallback in
+     * {@code getPropertyDescriptor} rebuilt the descriptor directly from the class methods without consulting the introspectors, so a suppressed mapped
+     * property was still readable and writable through {@code name(key)} access.
+     */
+    @Test
+    void testCustomIntrospectionSuppressedMappedProperty() throws Exception {
+        final PropertyUtilsBean pub = new PropertyUtilsBean();
+        pub.addBeanIntrospector(new SuppressPropertiesBeanIntrospector(Arrays.asList("mappedProperty")));
+
+        assertNull(pub.getPropertyDescriptor(bean, "mappedProperty"), "Suppressed mapped property should have no descriptor");
+        assertThrows(NoSuchMethodException.class, () -> pub.getProperty(bean, "mappedProperty(First Key)"), "Suppressed mapped property must not be readable");
+        assertThrows(NoSuchMethodException.class, () -> pub.setProperty(bean, "mappedProperty(First Key)", "changed"),
+                "Suppressed mapped property must not be writable");
+        assertEquals("First Value", bean.getMappedProperty("First Key"), "Suppressed mapped property must be unchanged");
+
+        // A mapped property that is not suppressed is still accessible.
+        final PropertyUtilsBean unsuppressed = new PropertyUtilsBean();
+        assertEquals("First Value", unsuppressed.getProperty(bean, "mappedProperty(First Key)"), "Mapped property should be readable when not suppressed");
+    }
+
+    /**
      * Test the describe() method.
      */
     @Test


### PR DESCRIPTION
The mapped-descriptor fallback in `getPropertyDescriptor` rebuilds a `MappedPropertyDescriptor` directly from the class methods and never consults the registered `BeanIntrospector`s, so a mapped property removed by `SuppressPropertiesBeanIntrospector` is still readable and writable through `name(key)` access, while a suppressed simple property is correctly blocked. The fix skips that fallback for suppressed names. Found while auditing the suppression path after the recent `class`/`declaringClass` suppression work.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
