### PR TITLE
Make MethodUtils CACHE_ENABLED volatile

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/MethodUtils.java
+++ b/src/main/java/org/apache/commons/beanutils2/MethodUtils.java
@@ -118,7 +118,7 @@ public final class MethodUtils {
      * would mean having a map keyed by context classloader which may introduce memory-leak problems.
      * </p>
      */
-    private static boolean CACHE_ENABLED = true; //NOPMD @GuardedBy("this")
+    private static volatile boolean CACHE_ENABLED = true; //NOPMD volatile: written under the class monitor, read lock-free in computeIfAbsent
 
     /**
      * Stores a cache of MethodKey -> Method.


### PR DESCRIPTION
`setCacheMethods` writes the `@GuardedBy`-annotated `CACHE_ENABLED` flag under the class monitor but `computeIfAbsent` reads it lock-free on the method-lookup path, so a runtime `setCacheMethods(false)` may never be observed by other threads and they keep populating and reading the shared static `CACHE`; marking the field `volatile` restores cross-thread visibility while writes stay synchronized so the flag flip and `CACHE.clear()` remain atomic. Found while auditing the `@GuardedBy` field; a memory-visibility fix has no deterministic unit test, so none is added.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
