### PR TITLE
Make MethodUtils CACHE_METHODS volatile (1.X)

### DIFF
--- a/src/main/java/org/apache/commons/beanutils/MethodUtils.java
+++ b/src/main/java/org/apache/commons/beanutils/MethodUtils.java
@@ -126,7 +126,7 @@ public class MethodUtils {
      * which may introduce memory-leak problems.
      * </p>
      */
-    private static boolean CACHE_METHODS = true;
+    private static volatile boolean CACHE_METHODS = true;
 
     /** An empty class array */
     private static final Class<?>[] EMPTY_CLASS_PARAMETERS = new Class[0];


### PR DESCRIPTION
Port of #414 to the `1.X` branch.

`setCacheMethods` writes `CACHE_METHODS` under the class monitor but `getCachedMethod` and `cacheMethod` read it lock-free on the method-lookup path, so a runtime `setCacheMethods(false)` may never be observed by other threads and they keep populating and reading the shared static `cache`; marking the field `volatile` restores cross-thread visibility while writes stay synchronized so the flag flip and `clearCache()` remain atomic.

Same caveat as #414: a memory-visibility fix has no deterministic unit test, so none is added. `mvn test -Dtest=MethodUtilsTest` is green. The full default goal hits one failure in `LocaleBeanificationTest.testContextClassloaderIndependence` on my machine, but it fails identically on unmodified `1.X` and passes standalone, so it is pre-existing and unrelated to this change.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.