### PR TITLE
Case-fold column and bean property names with Locale.ROOT (1.X)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,13 @@
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit-pioneer</groupId>
+      <artifactId>junit-pioneer</artifactId>
+      <!-- 2.x requires Java 11 -->
+      <version>1.9.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
       <defaultGoal>clean apache-rat:check verify japicmp:cmp javadoc:javadoc checkstyle:check</defaultGoal>

--- a/src/main/java/org/apache/commons/beanutils/DefaultBeanIntrospector.java
+++ b/src/main/java/org/apache/commons/beanutils/DefaultBeanIntrospector.java
@@ -23,6 +23,7 @@ import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -95,7 +96,7 @@ public class DefaultBeanIntrospector implements BeanIntrospector {
             if (pd instanceof IndexedPropertyDescriptor) {
                 final IndexedPropertyDescriptor descriptor = (IndexedPropertyDescriptor) pd;
                 final String propName = descriptor.getName().substring(0, 1)
-                        .toUpperCase()
+                        .toUpperCase(Locale.ROOT)
                         + descriptor.getName().substring(1);
 
                 if (descriptor.getReadMethod() == null) {

--- a/src/main/java/org/apache/commons/beanutils/JDBCDynaClass.java
+++ b/src/main/java/org/apache/commons/beanutils/JDBCDynaClass.java
@@ -26,6 +26,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -89,7 +90,7 @@ abstract class JDBCDynaClass implements DynaClass, Serializable {
         if (columnName == null || columnName.trim().length() == 0) {
             columnName = metadata.getColumnName(i);
         }
-        final String name = lowerCase ? columnName.toLowerCase() : columnName;
+        final String name = lowerCase ? columnName.toLowerCase(Locale.ROOT) : columnName;
         if (!name.equals(columnName)) {
             if (columnNameXref == null) {
                 columnNameXref = new HashMap<>();

--- a/src/test/java/org/apache/commons/beanutils/JdbcDynaClassLocaleTest.java
+++ b/src/test/java/org/apache/commons/beanutils/JdbcDynaClassLocaleTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.beanutils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Types;
+
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
+
+/**
+ * Tests that column names are folded to lower case independently of the default locale.
+ */
+class JdbcDynaClassLocaleTest {
+
+    private static ResultSet singleColumnResultSet(final String columnName) {
+        final InvocationHandler metaData = (proxy, method, args) -> {
+            switch (method.getName()) {
+            case "getColumnCount":
+                return Integer.valueOf(1);
+            case "getColumnLabel":
+            case "getColumnName":
+                return columnName;
+            case "getColumnType":
+                return Integer.valueOf(Types.VARCHAR);
+            case "getColumnClassName":
+                return String.class.getName();
+            default:
+                throw new UnsupportedOperationException(method.getName());
+            }
+        };
+        final ResultSetMetaData metaDataProxy = (ResultSetMetaData) Proxy.newProxyInstance(ResultSetMetaData.class.getClassLoader(),
+                new Class[] { ResultSetMetaData.class }, metaData);
+        final InvocationHandler resultSet = (proxy, method, args) -> {
+            if ("getMetaData".equals(method.getName())) {
+                return metaDataProxy;
+            }
+            throw new UnsupportedOperationException(method.getName());
+        };
+        return (ResultSet) Proxy.newProxyInstance(ResultSet.class.getClassLoader(), new Class[] { ResultSet.class }, resultSet);
+    }
+
+    @Test
+    @DefaultLocale(language = "tr", country = "TR")
+    void testColumnNameLowerCasedIndependentOfLocale() throws Exception {
+        // Under the Turkish locale "ID".toLowerCase() is "ıd" (dotless i), not "id".
+        final ResultSetDynaClass dynaClass = new ResultSetDynaClass(singleColumnResultSet("ID"));
+        final DynaProperty property = dynaClass.getDynaProperty("id");
+        assertNotNull(property, "column 'ID' must map to property 'id'");
+        assertEquals("id", property.getName());
+    }
+}


### PR DESCRIPTION
Port of #415 to 1.X. `JDBCDynaClass.createDynaProperty` folds JDBC column names to lower case with `String.toLowerCase()`, and `DefaultBeanIntrospector.handleIndexedPropertyDescriptors` upper-cases the first letter of an indexed property name with `String.toUpperCase()`, both using the default locale. Under a Turkish locale `"ID".toLowerCase()` is `"ıd"` (dotless i), so a column `ID` maps to property `ıd` and `getDynaProperty("id")` returns `null`; the introspector likewise rebuilds an indexed accessor as `getİmages` instead of `getImages`. Both now fold with `Locale.ROOT`, same as the fix merged on master.

Per the review on #415, the regression test uses `@DefaultLocale` from JUnit Pioneer instead of saving and restoring the default locale by hand; junit-pioneer 1.9.1 (the last Java 8 compatible line) is added as a test dependency. The test fails on `1.X` without the runtime change and passes with it.

Note: `mvn test` on a clean `1.X` checkout fails `LocaleBeanificationTest#testContextClassloaderIndependence` in my environment (it passes in isolation and CI on `1.X` is green), so I could not get a fully green default-goal run locally; the failure is identical with and without this change.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
