### PR TITLE
Make WrapDynaClass instance cache thread-safe (1.X)

### DIFF
--- a/src/main/java/org/apache/commons/beanutils/WrapDynaClass.java
+++ b/src/main/java/org/apache/commons/beanutils/WrapDynaClass.java
@@ -26,7 +26,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-import java.util.WeakHashMap;
 
 /**
  * <p>Implements {@code DynaClass} for DynaBeans that wrap
@@ -94,7 +93,7 @@ public class WrapDynaClass implements DynaClass {
         new ContextClassLoaderLocal<Map<CacheKey, WrapDynaClass>>() {
             @Override
             protected Map<CacheKey, WrapDynaClass> initialValue() {
-                return new WeakHashMap<>();
+                return BeanUtils.createCache();
         }
     };
 
@@ -238,12 +237,17 @@ public class WrapDynaClass implements DynaClass {
     public static WrapDynaClass createDynaClass(final Class<?> beanClass, final PropertyUtilsBean pu) {
         final PropertyUtilsBean propUtils = pu != null ? pu : PropertyUtilsBean.getInstance();
         final CacheKey key = new CacheKey(beanClass, propUtils);
-        WrapDynaClass dynaClass = getClassesCache().get(key);
-        if (dynaClass == null) {
-            dynaClass = new WrapDynaClass(beanClass, propUtils);
-            getClassesCache().put(key, dynaClass);
+        final Map<CacheKey, WrapDynaClass> cache = getClassesCache();
+        // The get/create/put sequence must be atomic so that concurrent callers
+        // cannot create and return distinct instances for the same key.
+        synchronized (cache) {
+            WrapDynaClass dynaClass = cache.get(key);
+            if (dynaClass == null) {
+                dynaClass = new WrapDynaClass(beanClass, propUtils);
+                cache.put(key, dynaClass);
+            }
+            return dynaClass;
         }
-        return dynaClass;
     }
 
     /**

--- a/src/test/java/org/apache/commons/beanutils/WrapDynaClassTest.java
+++ b/src/test/java/org/apache/commons/beanutils/WrapDynaClassTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.beanutils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link WrapDynaClass}.
+ */
+class WrapDynaClassTest {
+
+    /**
+     * Simple bean used as a cache key.
+     */
+    public static final class ConcurrentBean {
+
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(final String value) {
+            this.value = value;
+        }
+    }
+
+    /**
+     * The cache key is one bean class, so {@code createDynaClass} must hand back a single instance no matter how many threads race to populate the
+     * per-classloader cache. With a plain {@code WeakHashMap} and an unsynchronized get/create/put sequence, concurrent callers could build and return
+     * distinct instances for one key; this drives that race and fails if more than one instance escapes.
+     */
+    @Test
+    void testConcurrentCreateDynaClassReturnsSameInstance() throws Exception {
+        final int threads = 16;
+        final int rounds = 200;
+        final ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            for (int r = 0; r < rounds; r++) {
+                WrapDynaClass.clear();
+                final CyclicBarrier barrier = new CyclicBarrier(threads);
+                final Set<WrapDynaClass> results = Collections.newSetFromMap(new IdentityHashMap<>());
+                final Future<?>[] futures = new Future<?>[threads];
+                for (int t = 0; t < threads; t++) {
+                    futures[t] = pool.submit(() -> {
+                        barrier.await();
+                        final WrapDynaClass wdc = WrapDynaClass.createDynaClass(ConcurrentBean.class);
+                        synchronized (results) {
+                            results.add(wdc);
+                        }
+                        return null;
+                    });
+                }
+                for (final Future<?> f : futures) {
+                    f.get();
+                }
+                assertEquals(1, results.size(), "createDynaClass returned more than one instance for one key");
+            }
+        } finally {
+            pool.shutdownNow();
+            pool.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * The single-threaded cache contract: repeated calls for one bean class return the same instance until the cache is cleared.
+     */
+    @Test
+    void testCreateDynaClassIsCached() {
+        WrapDynaClass.clear();
+        final WrapDynaClass first = WrapDynaClass.createDynaClass(ConcurrentBean.class);
+        assertSame(first, WrapDynaClass.createDynaClass(ConcurrentBean.class));
+        WrapDynaClass.clear();
+    }
+}


### PR DESCRIPTION
Port of #418 to the `1.X` branch.

`WrapDynaClass.createDynaClass` reads and populates its per-classloader cache through an unsynchronized get/create/put over a plain `WeakHashMap`, so threads that share a context classloader can corrupt the map and receive distinct `WrapDynaClass` instances for one key. Unlike master there is no atomic `computeIfAbsent` to lean on here (`WeakFastHashMap` inherits `HashMap.computeIfAbsent`, which bypasses its delegate map), so the port swaps the cache to `BeanUtils.createCache()` — the synchronized weak-keyed `WeakFastHashMap` that `MethodUtils` already uses — and synchronizes the get/create/put sequence on the cache so one key yields one instance. Includes the regression test from #418: it races 16 threads on `createDynaClass` for one bean class over 200 rounds; it fails on unmodified `1.X` (two distinct instances for one key) and passes with the change.

Same caveat as #416: the full default goal hits one failure in `LocaleBeanificationTest.testContextClassloaderIndependence` on my machine, but it fails identically on unmodified `1.X` and passes standalone, so it is pre-existing and unrelated to this change.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
