### PR TITLE
Reject out-of-range color components in ColorConverter

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/converters/ColorConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/converters/ColorConverter.java
@@ -39,7 +39,7 @@ public class ColorConverter extends AbstractConverter<Color> {
     private static final String HEX_COLOR_PREFIX = "#";
 
     /** Regular expression matching the output of {@link Color#toString()}. */
-    private static final Pattern JAVA_COLOR_PATTERN = Pattern.compile("^(?:[A-Za-z\\d._]+)??\\[?(?:r=)?(\\d{1,3}),(?:g=)?(\\d{1,3}),(?:b=)?(\\d{1,3})\\]?$");
+    private static final Pattern JAVA_COLOR_PATTERN = Pattern.compile("^(?:[A-Za-z\\d._]*\\[)?(?:r=)?(\\d{1,3}),(?:g=)?(\\d{1,3}),(?:b=)?(\\d{1,3})\\]?$");
 
     /**
      * Construct a <strong>{@link Color}</strong> <em>Converter</em> that throws a {@code ConversionException} if an error occurs.

--- a/src/test/java/org/apache/commons/beanutils2/converters/ColorConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ColorConverterTest.java
@@ -106,6 +106,13 @@ class ColorConverterTest {
     }
 
     @Test
+    void testConvertingOutOfRangeComponentRejected() {
+        assertThrows(ConversionException.class, () -> converter.convert(Color.class, "1234,5,6"));
+        assertThrows(ConversionException.class, () -> converter.convert(Color.class, "1000,0,0"));
+        assertThrows(ConversionException.class, () -> converter.convert(Color.class, "2550,0,0"));
+    }
+
+    @Test
     void testConvertingLiteralHex() {
         final Color expected = Color.BLUE;
         final Color actual = converter.convert(Color.class, "0x0000FF");


### PR DESCRIPTION
`ColorConverter.parseToStringColor` already rejects color components above 255, but the `JAVA_COLOR_PATTERN` label prefix `[A-Za-z\d._]+` includes `\d`, so for a bare triple whose first component has four or more digits the greedy label swallows the leading digit and the first capture group only sees the trailing one to three digits. `1234,5,6` is parsed as `Color(4,5,6)`, and `1000,0,0` / `2550,0,0` as black, so a malformed out-of-range value is accepted as a different in-range color instead of ever reaching the `> 255` check. Binding the optional class-name label to its opening `[` (`(?:[A-Za-z\d._]*\[)?`) stops it absorbing digits from the numeric groups; every string `Color#toString()` emits still parses the same, including class names that contain digits. Found while auditing the converters that parse untrusted strings.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
