### PR TITLE
Pass configured locale to SimpleDateFormat in DateTimeConverter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,11 @@
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit-pioneer</groupId>
+      <artifactId>junit-pioneer</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/apache/commons/beanutils2/converters/DateTimeConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/converters/DateTimeConverter.java
@@ -293,7 +293,7 @@ public abstract class DateTimeConverter<D> extends AbstractConverter<D> {
      * @return The DateFormat
      */
     private DateFormat getFormat(final String pattern) {
-        final DateFormat format = new SimpleDateFormat(pattern);
+        final DateFormat format = locale == null ? new SimpleDateFormat(pattern) : new SimpleDateFormat(pattern, locale);
         if (timeZone != null) {
             format.setTimeZone(timeZone);
         }

--- a/src/test/java/org/apache/commons/beanutils2/converters/AbstractDateConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/AbstractDateConverterTest.java
@@ -269,6 +269,27 @@ public abstract class AbstractDateConverterTest<T> {
     }
 
     /**
+     * Test that a configured Locale is honored when a pattern is also set.
+     */
+    @Test
+    void testLocaleWithPattern() {
+        // Pin the default Locale to one whose month names differ from the configured Locale.
+        final Locale defaultLocale = Locale.getDefault();
+        Locale.setDefault(Locale.US);
+        try {
+            final String pattern = "dd MMMM yyyy"; // month name is Locale-sensitive
+            final DateTimeConverter<T> converter = makeConverter();
+            converter.setLocale(Locale.GERMANY);
+            converter.setPattern(pattern);
+            final String testString = "28 Oktober 2006";
+            final Object expected = toType(testString, pattern, Locale.GERMANY);
+            validConversion(converter, expected, testString);
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
+    }
+
+    /**
      * Test Converter with multiple patterns
      */
     @Test

--- a/src/test/java/org/apache/commons/beanutils2/converters/AbstractDateConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/AbstractDateConverterTest.java
@@ -42,6 +42,7 @@ import java.util.Objects;
 import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 /**
  * Abstract base for &lt;Date&gt;Converter classes.
@@ -272,21 +273,16 @@ public abstract class AbstractDateConverterTest<T> {
      * Test that a configured Locale is honored when a pattern is also set.
      */
     @Test
+    @DefaultLocale(language = "en", country = "US")
     void testLocaleWithPattern() {
-        // Pin the default Locale to one whose month names differ from the configured Locale.
-        final Locale defaultLocale = Locale.getDefault();
-        Locale.setDefault(Locale.US);
-        try {
-            final String pattern = "dd MMMM yyyy"; // month name is Locale-sensitive
-            final DateTimeConverter<T> converter = makeConverter();
-            converter.setLocale(Locale.GERMANY);
-            converter.setPattern(pattern);
-            final String testString = "28 Oktober 2006";
-            final Object expected = toType(testString, pattern, Locale.GERMANY);
-            validConversion(converter, expected, testString);
-        } finally {
-            Locale.setDefault(defaultLocale);
-        }
+        // The default Locale's month names differ from the configured Locale's.
+        final String pattern = "dd MMMM yyyy"; // month name is Locale-sensitive
+        final DateTimeConverter<T> converter = makeConverter();
+        converter.setLocale(Locale.GERMANY);
+        converter.setPattern(pattern);
+        final String testString = "28 Oktober 2006";
+        final Object expected = toType(testString, pattern, Locale.GERMANY);
+        validConversion(converter, expected, testString);
     }
 
     /**


### PR DESCRIPTION
`getFormat(String)` builds the pattern `SimpleDateFormat` with the jvm default locale and ignores the converter's configured `locale`, so a converter given both `setLocale` and a pattern parses and formats month and day names in the default locale instead of the configured one; pass `locale` when it is set, matching `DateLocaleConverter` and `StringLocaleConverter`. found auditing locale handling across the date converters.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.