### PR TITLE
Fix ClassCastException in DoubleLocaleConverter when input is non-Double Number

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/DoubleLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/DoubleLocaleConverter.java
@@ -71,9 +71,9 @@ public class DoubleLocaleConverter extends DecimalLocaleConverter<Double> {
     @Override
     protected Double parse(final Object value, final String pattern) throws ParseException {
         final Number result = super.parse(value, pattern);
-        if (result instanceof Long) {
-            return Double.valueOf(result.doubleValue());
+        if (result == null || result instanceof Double) {
+            return (Double) result;
         }
-        return (Double) result;
+        return Double.valueOf(result.doubleValue());
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/converters/DoubleLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/DoubleLocaleConverterTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.beanutils2.converters;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.apache.commons.beanutils2.locale.converters.DoubleLocaleConverter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,6 +37,17 @@ class DoubleLocaleConverterTest extends AbstractLocaleConverterTest<Double> {
         super.setUp();
         defaultValue = Double.valueOf("9.99");
         expectedValue = Double.valueOf(expectedDecimalValue);
+    }
+
+    /**
+     * Passing a non-Double Number directly (e.g. Integer) must return a Double, not throw ClassCastException.
+     */
+    @Test
+    void testConvertFromNonDoubleNumber() {
+        final DoubleLocaleConverter c = DoubleLocaleConverter.builder().get();
+        assertEquals(Double.valueOf(42.0), c.convert(Double.class, Integer.valueOf(42), null));
+        assertEquals(Double.valueOf(3.14f), c.convert(Double.class, Float.valueOf(3.14f), null));
+        assertEquals(Double.valueOf(100L), c.convert(Double.class, Long.valueOf(100L), null));
     }
 
     /**


### PR DESCRIPTION
`DoubleLocaleConverter.parse()` only handled the `Long` case for non-String inputs; any other `Number` subtype (e.g. `Integer`, `Float`, `BigDecimal`) passed directly to the converter was unchecked-cast to `Double`, throwing `ClassCastException` instead of a proper conversion.