### PR TITLE
Reject trailing separators in PointConverter

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/converters/PointConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/converters/PointConverter.java
@@ -72,7 +72,7 @@ public class PointConverter extends AbstractConverter<Point> {
             }
 
             final String coordinates = stringValue.substring(1, lastCharIndex);
-            final String[] xy = POINT_SPLIT.split(coordinates);
+            final String[] xy = POINT_SPLIT.split(coordinates, -1);
 
             if (xy.length != 2) {
                 throw new IllegalArgumentException("Point must have an x coordinate, and y coordinate only, expecting the following format: (40, 200)");

--- a/src/test/java/org/apache/commons/beanutils2/converters/PointConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/PointConverterTest.java
@@ -20,9 +20,11 @@
 package org.apache.commons.beanutils2.converters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.awt.Point;
 
+import org.apache.commons.beanutils2.ConversionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -52,5 +54,11 @@ class PointConverterTest {
         final Point expected = new Point(100, 200);
         final Point actual = converter.convert(Point.class, "(100, 200)");
         assertEquals(expected, actual);
+    }
+
+    @Test
+    void testTrailingSeparatorRejected() {
+        assertThrows(ConversionException.class, () -> converter.convert(Point.class, "(100,200,)"));
+        assertThrows(ConversionException.class, () -> converter.convert(Point.class, "(100,200,,)"));
     }
 }


### PR DESCRIPTION
`PointConverter.convertToType` splits the inner coordinate string with `POINT_SPLIT.split(coordinates)`, and `String.split` with the default limit drops trailing empty tokens. A trailing separator after the two coordinates is swallowed, so `(100,200,)` and `(100,200,,)` parse to `Point(100,200)`. That is inconsistent with `(100,)`, which is already rejected because it yields a single token.

Pass `-1` as the split limit so trailing empties are kept and the existing `xy.length != 2` check rejects the malformed input. Keeping the bound in the converter means every caller gets the same validation, and valid `(x,y)` forms are unchanged. Found while auditing the awt converters alongside `ColorConverter`.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
