### PR TITLE
Fix failed conversion in DoubleLocaleConverter when input is non-Double Number (1.X)

### DIFF
--- a/src/main/java/org/apache/commons/beanutils/locale/converters/DoubleLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils/locale/converters/DoubleLocaleConverter.java
@@ -169,9 +169,9 @@ public class DoubleLocaleConverter extends DecimalLocaleConverter {
     @Override
     protected Object parse(final Object value, final String pattern) throws ParseException {
         final Number result = (Number) super.parse(value, pattern);
-        if (result instanceof Long) {
-            return Double.valueOf(result.doubleValue());
+        if (result == null || result instanceof Double) {
+            return result;
         }
-        return result;
+        return Double.valueOf(result.doubleValue());
     }
 }

--- a/src/test/java/org/apache/commons/beanutils/locale/converters/DoubleLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils/locale/converters/DoubleLocaleConverterTest.java
@@ -50,6 +50,19 @@ public class DoubleLocaleConverterTest extends BaseLocaleConverterTest {
     }
 
     /**
+     * Passing a non-Double Number directly (e.g. Integer) must return a Double, not fail the conversion.
+     */
+    public void testConvertFromNonDoubleNumber() {
+
+        converter = new DoubleLocaleConverter();
+
+        assertEquals(Double.valueOf(42.0), converter.convert(Double.class, Integer.valueOf(42), null));
+        assertEquals(Double.valueOf(3.14f), converter.convert(Double.class, Float.valueOf(3.14f), null));
+        assertEquals(Double.valueOf(100L), converter.convert(Double.class, Long.valueOf(100L), null));
+
+    }
+
+    /**
      * Test Converter() constructor
      *
      * Uses the default locale, no default value


### PR DESCRIPTION
port of #422: `DoubleLocaleConverter.parse()` only special-cases `Long`; any other `Number` subtype passed directly to the converter (e.g. `Integer`, `Float`, `BigDecimal`) is returned as-is and fails in `checkConversionResult` with `ConversionException: Unsupported target type` (the 1.X symptom of the same bug — the cast lives in `BaseLocaleConverter` here rather than in `parse`). convert any non-Double `Number` via `doubleValue()` instead, matching the master fix.