### PR TITLE
Make WrapDynaClassTest tolerate gc eviction of weak cache entries (1.X)

### DIFF
--- a/src/test/java/org/apache/commons/beanutils/WrapDynaClassTest.java
+++ b/src/test/java/org/apache/commons/beanutils/WrapDynaClassTest.java
@@ -20,6 +20,7 @@ package org.apache.commons.beanutils;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import java.lang.ref.WeakReference;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Set;
@@ -56,6 +57,10 @@ class WrapDynaClassTest {
      * The cache key is one bean class, so {@code createDynaClass} must hand back a single instance no matter how many threads race to populate the
      * per-classloader cache. With a plain {@code WeakHashMap} and an unsynchronized get/create/put sequence, concurrent callers could build and return
      * distinct instances for one key; this drives that race and fails if more than one instance escapes.
+     * <p>
+     * The cache holds its keys weakly and nothing else references them, so a GC that runs while a round is in flight may evict the freshly cached entry
+     * and a late thread then builds a second instance without any race. Each round therefore only asserts when a GC canary shows no collection happened
+     * during the round; rounds invalidated by a GC are skipped.
      */
     @Test
     void testConcurrentCreateDynaClassReturnsSameInstance() throws Exception {
@@ -65,6 +70,8 @@ class WrapDynaClassTest {
         try {
             for (int r = 0; r < rounds; r++) {
                 WrapDynaClass.clear();
+                // Cleared only if a GC ran after this point, which is the only way a cache entry can disappear mid-round.
+                final WeakReference<Object> gcCanary = new WeakReference<>(new Object());
                 final CyclicBarrier barrier = new CyclicBarrier(threads);
                 final Set<WrapDynaClass> results = Collections.newSetFromMap(new IdentityHashMap<>());
                 final Future<?>[] futures = new Future<?>[threads];
@@ -81,6 +88,9 @@ class WrapDynaClassTest {
                 for (final Future<?> f : futures) {
                     f.get();
                 }
+                if (results.size() > 1 && gcCanary.get() == null) {
+                    continue;
+                }
                 assertEquals(1, results.size(), "createDynaClass returned more than one instance for one key");
             }
         } finally {
@@ -90,13 +100,21 @@ class WrapDynaClassTest {
     }
 
     /**
-     * The single-threaded cache contract: repeated calls for one bean class return the same instance until the cache is cleared.
+     * The single-threaded cache contract: repeated calls for one bean class return the same instance until the cache is cleared. A GC between the two
+     * calls may legitimately evict the weakly held cache entry, so such attempts are retried.
      */
     @Test
     void testCreateDynaClassIsCached() {
         WrapDynaClass.clear();
-        final WrapDynaClass first = WrapDynaClass.createDynaClass(ConcurrentBean.class);
-        assertSame(first, WrapDynaClass.createDynaClass(ConcurrentBean.class));
+        WeakReference<Object> gcCanary;
+        WrapDynaClass first;
+        WrapDynaClass second;
+        do {
+            gcCanary = new WeakReference<>(new Object());
+            first = WrapDynaClass.createDynaClass(ConcurrentBean.class);
+            second = WrapDynaClass.createDynaClass(ConcurrentBean.class);
+        } while (first != second && gcCanary.get() == null);
+        assertSame(first, second);
         WrapDynaClass.clear();
     }
 }


### PR DESCRIPTION
Follow-up to #419, where `WrapDynaClassTest.testConcurrentCreateDynaClassReturnsSameInstance` failed on 1.X CI ([run](https://github.com/apache/commons-beanutils/actions/runs/29845745287/job/88685774320)).

The failure is the test asserting more than the cache guarantees, not the synchronization from #419. The per-classloader cache is weak-keyed (`WeakFastHashMap` delegates to `WeakHashMap`) and the `CacheKey` is referenced by nothing but the map, so any GC evicts the entry and the next `createDynaClass` call legitimately builds a new instance. No concurrency is needed to see it: on unmodified 1.X, `createDynaClass`, `System.gc()`, `createDynaClass` returns a distinct second instance. When a GC lands inside one of the test's rounds, a late thread misses the cache and the round observes two instances — exactly the CI failure (`expected: <1> but was: <2>`). Master is unaffected because the beanutils2 cache (`ConcurrentReferenceHashMap`) holds soft references, which survive ordinary GCs.

The fix allocates a `WeakReference` canary at the start of each round and only asserts the single-instance property when the canary shows no GC ran during the round; rounds a GC invalidated are skipped. `testCreateDynaClassIsCached` gets the same guard since it has the same sensitivity in a smaller window.

Verified locally:

- the guarded test still fails on the pre-#419 unsynchronized code, so the regression coverage is intact
- a temporary `System.gc()` hammer thread makes the unguarded test fail immediately with the CI error; the guarded test passes under the same hammer
- repeated normal runs pass

Same caveat as #419 and #416: the full default goal hits the one pre-existing failure in `LocaleBeanificationTest.testContextClassloaderIndependence` on my machine, which fails identically on unmodified `1.X`; everything else passes.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
