### PR TITLE
Resolve column name in ResultSetIterator.set

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/sql/ResultSetIterator.java
+++ b/src/main/java/org/apache/commons/beanutils2/sql/ResultSetIterator.java
@@ -249,7 +249,7 @@ public class ResultSetIterator implements DynaBean, Iterator<DynaBean> {
             throw new IllegalArgumentException(name);
         }
         try {
-            dynaClass.getResultSet().updateObject(name, value);
+            dynaClass.getResultSet().updateObject(dynaClass.getColumnName(name), value);
         } catch (final SQLException e) {
             throw new IllegalArgumentException("set(" + name + "): SQLException: " + e);
         }

--- a/src/test/java/org/apache/commons/beanutils2/sql/DynaResultSetTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/sql/DynaResultSetTest.java
@@ -25,6 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.Iterator;
 
 import org.apache.commons.beanutils2.DynaBean;
@@ -94,6 +96,26 @@ class DynaResultSetTest {
     @Test
     void testGetName() {
         assertEquals("org.apache.commons.beanutils2.sql.ResultSetDynaClass", dynaClass.getName(), "DynaClass name");
+    }
+
+    /**
+     * With the default {@code lowerCase} option the property name differs from the real column name, and the read path resolves it through
+     * {@code getColumnName}. Verify that {@code set} resolves it the same way, so the update targets the real column name and not the lower-cased property
+     * name.
+     */
+    @Test
+    void testSetUsesColumnName() throws Exception {
+        final String[] updatedColumn = new String[1];
+        final ResultSet resultSet = TestResultSet.createProxy(new TestResultSet() {
+            @Override
+            public void updateObject(final String columnName, final Object value) throws SQLException {
+                updatedColumn[0] = columnName;
+            }
+        });
+        final ResultSetDynaClass rsdc = new ResultSetDynaClass(resultSet);
+        final DynaBean row = rsdc.iterator().next();
+        row.set("stringproperty", "new value");
+        assertEquals("stringProperty", updatedColumn[0], "update targets the real column name");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/beanutils2/sql/DynaResultSetTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/sql/DynaResultSetTest.java
@@ -28,6 +28,7 @@ import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.beanutils2.DynaBean;
 import org.apache.commons.beanutils2.DynaProperty;
@@ -105,17 +106,17 @@ class DynaResultSetTest {
      */
     @Test
     void testSetUsesColumnName() throws Exception {
-        final String[] updatedColumn = new String[1];
+        final AtomicReference<String> updatedColumn = new AtomicReference<>();
         final ResultSet resultSet = TestResultSet.createProxy(new TestResultSet() {
             @Override
             public void updateObject(final String columnName, final Object value) throws SQLException {
-                updatedColumn[0] = columnName;
+                updatedColumn.set(columnName);
             }
         });
         final ResultSetDynaClass rsdc = new ResultSetDynaClass(resultSet);
         final DynaBean row = rsdc.iterator().next();
         row.set("stringproperty", "new value");
-        assertEquals("stringProperty", updatedColumn[0], "update targets the real column name");
+        assertEquals("stringProperty", updatedColumn.get(), "update targets the real column name");
     }
 
     @Test


### PR DESCRIPTION
`set` passes the raw lower-cased property name to `ResultSet.updateObject` while the read path resolves it through `getColumnName` first, so under the default `lowerCase` an update to a mixed-case column targets the wrong column or throws on a case-sensitive driver; found diffing the get and set paths against `getObject`.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
