### PR TITLE
Resolve column name in ResultSetIterator.set (1.X)

### DIFF
--- a/src/main/java/org/apache/commons/beanutils/ResultSetIterator.java
+++ b/src/main/java/org/apache/commons/beanutils/ResultSetIterator.java
@@ -264,7 +264,7 @@ public class ResultSetIterator implements DynaBean, Iterator<DynaBean> {
             throw new IllegalArgumentException(name);
         }
         try {
-            dynaClass.getResultSet().updateObject(name, value);
+            dynaClass.getResultSet().updateObject(dynaClass.getColumnName(name), value);
         } catch (final SQLException e) {
             throw new IllegalArgumentException("set(" + name + "): SQLException: " + e, e);
         }

--- a/src/test/java/org/apache/commons/beanutils/DynaResultSetTest.java
+++ b/src/test/java/org/apache/commons/beanutils/DynaResultSetTest.java
@@ -18,7 +18,10 @@
 package org.apache.commons.beanutils;
 
 import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicReference;
 
 import junit.framework.TestCase;
 
@@ -120,6 +123,28 @@ public class DynaResultSetTest extends TestCase {
         assertEquals("DynaClass name",
                      "org.apache.commons.beanutils.ResultSetDynaClass",
                      dynaClass.getName());
+
+    }
+
+    /**
+     * With the default {@code lowerCase} option the property name differs from the real column name, and the read path resolves it through
+     * {@code getColumnName}. Verify that {@code set} resolves it the same way, so the update targets the real column name and not the lower-cased property
+     * name.
+     */
+    public void testSetUsesColumnName() throws Exception {
+
+        final AtomicReference<String> updatedColumn = new AtomicReference<String>();
+        final ResultSet resultSet = TestResultSet.createProxy(new TestResultSet() {
+            @Override
+            public void updateObject(final String columnName, final Object value) throws SQLException {
+                updatedColumn.set(columnName);
+            }
+        });
+        final ResultSetDynaClass rsdc = new ResultSetDynaClass(resultSet);
+        final DynaBean row = rsdc.iterator().next();
+        row.set("stringproperty", "new value");
+        assertEquals("update targets the real column name",
+                     "stringProperty", updatedColumn.get());
 
     }
 


### PR DESCRIPTION
Port of #426 to 1.X. `set` passes the raw lower-cased property name to `ResultSet.updateObject` while the read path resolves it through `getColumnName` first, so under the default `lowerCase` an update to a mixed-case column targets the wrong column or throws on a case-sensitive driver.

Same one-line fix and regression test as master, with the test adapted to the JUnit 3 style on this branch (and using `AtomicReference` per the review on #426). `DynaResultSetTest.testSetUsesColumnName` fails on clean `1.X` with `expected:<string[P]roperty> but was:<string[p]roperty>` and passes with the change.

Note: as on #417, `mvn` on a clean `1.X` checkout fails `LocaleBeanificationTest#testContextClassloaderIndependence` in my environment (it passes in isolation), so no fully green default-goal run locally; the failure is identical with and without this change. `apache-rat:check` and `checkstyle:check` pass.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
