### PR TITLE
[BEANUTILS-417] Refactor serialization methods to conform to Java Object Serialization Specification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .settings/
 /site-content/
 /.idea/
+*.iml
 
 # NetBeans files
 nb-configuration.xml

--- a/pom.xml
+++ b/pom.xml
@@ -104,9 +104,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
-      <artifactId>wildfly-ejb3</artifactId>
-      <version>9.0.2.Final</version>
+      <groupId>org.jboss.marshalling</groupId>
+      <artifactId>jboss-marshalling</artifactId>
+      <version>2.0.12.Final</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-ejb3</artifactId>
+      <version>9.0.2.Final</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>

--- a/src/main/java/org/apache/commons/beanutils/DynaProperty.java
+++ b/src/main/java/org/apache/commons/beanutils/DynaProperty.java
@@ -32,14 +32,14 @@ import java.util.Map;
  * for use by mapped and iterated properties.
  * A mapped or iterated property may choose to indicate the type it expects.
  * The DynaBean implementation may choose to enforce this type on its entries.
- * Alternatively, an implementatin may choose to ignore this property.
- * All keys for maps must be of type String so no meta data is needed for map keys.</p>
+ * Alternatively, an implementation may choose to ignore this property.
+ * All keys for maps must be of type String so no metadata is needed for map keys.</p>
  *
  */
 
 public class DynaProperty implements Serializable {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
     /*
      * There are issues with serializing primitive class types on certain JVM versions
      * (including java 1.3).
@@ -111,7 +111,7 @@ public class DynaProperty implements Serializable {
 
     /**
      * Checks this instance against the specified Object for equality. Overrides the
-     * default refererence test for equality provided by {@link Object#equals(Object)}
+     * default reference test for equality provided by {@link Object#equals(Object)}
      *
      * @param obj The object to compare to
      * @return {@code true} if object is a dyna property with the same name
@@ -121,9 +121,7 @@ public class DynaProperty implements Serializable {
     @Override
     public boolean equals(final Object obj) {
 
-        boolean result = false;
-
-        result = obj == this;
+        boolean result = obj == this;
 
         if (!result && obj instanceof DynaProperty) {
             final DynaProperty that = (DynaProperty) obj;
@@ -145,7 +143,7 @@ public class DynaProperty implements Serializable {
      * Therefore, this field <strong>must not be serialized using the standard methods</strong>.</p>
      *
      * @return The Class for the content type if this is an indexed {@code DynaProperty}
-     * and this feature is supported. Otherwise null.
+     * and this feature is supported. Otherwise, null.
      */
     public Class<?> getContentType() {
         return contentType;
@@ -261,7 +259,7 @@ public class DynaProperty implements Serializable {
      * @throws ClassNotFoundException Class of a serialized object cannot be found.
      */
     private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
-        // read default values
+        // read default first (as defined by the Java Object Serialization Specification)
         in.defaultReadObject();
 
         // read custom values
@@ -334,7 +332,7 @@ public class DynaProperty implements Serializable {
      * @throws IOException if I/O errors occur while writing to the underlying stream.
      */
     private void writeObject(final ObjectOutputStream out) throws IOException {
-        // write out default
+        // write out default first (as defined by the Java Object Serialization Specification)
         out.defaultWriteObject();
 
         // write custom values

--- a/src/main/java/org/apache/commons/beanutils/DynaProperty.java
+++ b/src/main/java/org/apache/commons/beanutils/DynaProperty.java
@@ -247,8 +247,7 @@ public class DynaProperty implements Serializable {
             default:
                 // something's gone wrong
                 throw new StreamCorruptedException(
-                    "Invalid primitive type. "
-                    + "Check version of beanutils used to serialize is compatible.");
+                    "Invalid primitive type. Check version of beanutils used to serialize is compatible.");
 
         }
     }
@@ -262,12 +261,14 @@ public class DynaProperty implements Serializable {
      * @throws ClassNotFoundException Class of a serialized object cannot be found.
      */
     private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+        // read default values
+        in.defaultReadObject();
+
+        // read custom values
         this.type = readAnyClass(in);
         if (isMapped() || isIndexed()) {
             this.contentType = readAnyClass(in);
         }
-        // read other values
-        in.defaultReadObject();
     }
 
     /**
@@ -333,11 +334,13 @@ public class DynaProperty implements Serializable {
      * @throws IOException if I/O errors occur while writing to the underlying stream.
      */
     private void writeObject(final ObjectOutputStream out) throws IOException {
-        writeAnyClass(this.type,out);
-        if (isMapped() || isIndexed()) {
-            writeAnyClass(this.contentType,out);
-        }
-        // write out other values
+        // write out default
         out.defaultWriteObject();
+
+        // write custom values
+        writeAnyClass(this.type, out);
+        if (isMapped() || isIndexed()) {
+            writeAnyClass(this.contentType, out);
+        }
     }
 }

--- a/src/test/java/org/apache/commons/beanutils/DynaPropertySerializationTest.java
+++ b/src/test/java/org/apache/commons/beanutils/DynaPropertySerializationTest.java
@@ -18,7 +18,7 @@
 package org.apache.commons.beanutils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -28,15 +28,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InvalidClassException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.StreamCorruptedException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jboss.marshalling.cloner.ClassLoaderClassCloner;
+import org.jboss.marshalling.cloner.ClonerConfiguration;
+import org.jboss.marshalling.cloner.ObjectCloner;
+import org.jboss.marshalling.cloner.ObjectCloners;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -277,12 +283,12 @@ class DynaPropertySerializationTest {
     }
 
     /**
-     * Verifies that {@link DynaProperty#readObject(ObjectInputStream)} throws a {@link StreamCorruptedException} when the stream contains an unrecognised
+     * Verifies that {@link DynaProperty#readObject(ObjectInputStream)} throws a {@link StreamCorruptedException} when the stream contains an unrecognized
      * primitive-type constant (i.e. an integer that is not in the range 1–8).
      * <p>
      * Strategy: serialize two {@code DynaProperty} instances whose types differ only in the primitive-type constant written by {@code writeAnyClass}
      * (BOOLEAN_TYPE=1 vs BYTE_TYPE=2). Find the first differing byte (the last byte of the 4-byte int), then replace those 4 bytes with the invalid constant 99
-     * before attempting deserialisation.
+     * after attempting deserialization.
      * </p>
      */
     @Test
@@ -300,7 +306,7 @@ class DynaPropertySerializationTest {
                 break;
             }
         }
-        assertNotNull(Integer.valueOf(diffIndex), "Streams must differ at the primitive-type int");
+        assertNotEquals(-1, diffIndex, "Streams must differ at the primitive-type int");
         // The 4-byte int starts 3 bytes before the differing byte (big-endian).
         // Overwrite all 4 bytes with the invalid constant 99 (0x00_00_00_63).
         final byte[] corrupted = booleanBytes.clone();
@@ -308,10 +314,11 @@ class DynaPropertySerializationTest {
         corrupted[diffIndex - 2] = 0x00;
         corrupted[diffIndex - 1] = 0x00;
         corrupted[diffIndex] = (byte) 99;
-        // Deserialising the corrupted stream must throw StreamCorruptedException.
-        final IOException thrown = assertThrows(IOException.class, () -> deserialize(corrupted),
+        // Deserializing the corrupted stream must throw StreamCorruptedException.
+        final StreamCorruptedException e = assertThrows(StreamCorruptedException.class,
+                () -> deserialize(corrupted),
                 "Expected StreamCorruptedException for unrecognised primitive-type constant");
-        assertInstanceOf(StreamCorruptedException.class, thrown, "Root cause must be StreamCorruptedException");
+        assertTrue(e.getMessage().contains("Invalid primitive type."));
     }
 
     /**
@@ -332,15 +339,15 @@ class DynaPropertySerializationTest {
                 break;
             }
         }
-        assertNotNull(Integer.valueOf(diffIndex), "Streams must differ at the contentType primitive-type int");
+        assertNotEquals(-1, diffIndex, "Streams must differ at the contentType primitive-type int");
         final byte[] corrupted = boolContentBytes.clone();
         corrupted[diffIndex - 3] = 0x00;
         corrupted[diffIndex - 2] = 0x00;
         corrupted[diffIndex - 1] = 0x00;
         corrupted[diffIndex] = (byte) 99;
-        final IOException thrown = assertThrows(IOException.class, () -> deserialize(corrupted),
+        final StreamCorruptedException e = assertThrows(StreamCorruptedException.class, () -> deserialize(corrupted),
                 "Expected StreamCorruptedException for unrecognised primitive contentType constant");
-        assertInstanceOf(StreamCorruptedException.class, thrown, "Root cause must be StreamCorruptedException");
+        assertTrue(e.getMessage().contains("Invalid primitive type."));
     }
 
     /**
@@ -359,17 +366,17 @@ class DynaPropertySerializationTest {
     }
 
     /**
-     * Proves that {@link DynaProperty#writeObject(ObjectOutputStream)} calls {@code writeAnyClass} (which encodes the {@code type} field) <em>before</em>
+     * Proves that {@link DynaProperty#writeObject(ObjectOutputStream)} calls {@code writeAnyClass} (which encodes the {@code type} field) <em>after</em>
      * {@code defaultWriteObject} (which encodes the {@code name} field) for <strong>primitive types</strong>.
      * <p>
-     * Strategy: serialise two {@link DynaProperty} instances that have an identical {@code name} but different primitive types. Because the name is identical,
+     * Strategy: serialize two {@link DynaProperty} instances that have an identical {@code name} but different primitive types. Because the name is identical,
      * both byte streams are the same from the class-descriptor through to the end of the default-field data. The streams diverge only at the
-     * {@code writeAnyClass} output (the primitive-type integer constant). If that divergence point is located <em>before</em> the name bytes in the stream, it
+     * {@code writeAnyClass} output (the primitive-type integer constant). If that divergence point is located <em>after</em> the name bytes in the stream, it
      * proves that {@code writeAnyClass} is called first.
      * </p>
      */
     @Test
-    void testWireFormatPrimitiveTypeDataPrecedesNameField() throws Exception {
+    void testWireFormatPrimitiveTypeDataFollowsNameField() throws Exception {
         final String sharedName = "sharedPrimitiveName";
         // Boolean.TYPE encodes as writeBoolean(true) + writeInt(BOOLEAN_TYPE=1).
         // Byte.TYPE encodes as writeBoolean(true) + writeInt(BYTE_TYPE=2).
@@ -381,7 +388,8 @@ class DynaPropertySerializationTest {
         final int namePosition = findSequence(boolBytes, nameBytes);
         assertTrue(namePosition > 0, "Property name must be present in the serialized stream");
         // The name must occupy the same position in both streams (identical name, identical class).
-        assertEquals(namePosition, findSequence(byteBytes, nameBytes), "Name must be at the same byte position in both streams");
+        assertEquals(namePosition, findSequence(byteBytes, nameBytes),
+                "Name must be at the same byte position in both streams");
         // Find the first byte where the two streams diverge: this is inside the
         // writeAnyClass output (the primitive-type integer constant differs: 1 vs 2).
         int firstDiff = -1;
@@ -393,16 +401,17 @@ class DynaPropertySerializationTest {
         }
         assertTrue(firstDiff >= 0, "Streams must diverge at the primitive-type constant");
         // CRITICAL assertion: the divergence point (type data from writeAnyClass) must
-        // come BEFORE the name field (from defaultWriteObject).
-        assertTrue(firstDiff < namePosition, "writeAnyClass must be invoked before defaultWriteObject: " + "type-data divergence at byte " + firstDiff
-                + " must precede name field at byte " + namePosition);
+        // come AFTER the name field (from defaultWriteObject).
+        assertTrue(firstDiff > namePosition,
+                "writeAnyClass must be invoked after defaultWriteObject: type-data divergence at byte " + firstDiff
+                        + " must follow name field at byte " + namePosition);
         // Sanity-check: both properties still round-trip correctly.
         assertRoundTrip(new DynaProperty(sharedName, Boolean.TYPE));
         assertRoundTrip(new DynaProperty(sharedName, Byte.TYPE));
     }
 
     /**
-     * Same proof as {@link #testWireFormatPrimitiveTypeDataPrecedesNameField()} but for <strong>object (non-primitive) types</strong>.
+     * Same proof as {@link #testWireFormatPrimitiveTypeDataFollowsNameField()} but for <strong>object (non-primitive) types</strong>.
      * <p>
      * For object types {@code writeAnyClass} emits {@code writeBoolean(false)} followed by {@code writeObject(clazz)}. Two properties with the same name but
      * different object types ({@code String.class} vs {@code Integer.class}) differ in the class object written by {@code writeAnyClass}; the shared name is
@@ -410,10 +419,10 @@ class DynaPropertySerializationTest {
      * </p>
      */
     @Test
-    void testWireFormatObjectTypeDataPrecedesNameField() throws Exception {
+    void testWireFormatObjectTypeDataFollowsNameField() throws Exception {
         final String sharedName = "sharedObjectName";
         // writeAnyClass for object type: writeBoolean(false) + writeObject(clazz).
-        // String.class and Integer.class are serialised differently, so streams diverge
+        // String.class and Integer.class are serialized differently, so streams diverge
         // at the class-object position (inside writeAnyClass output).
         final byte[] stringTypeBytes = serialize(new DynaProperty(sharedName, String.class));
         final byte[] integerTypeBytes = serialize(new DynaProperty(sharedName, Integer.class));
@@ -424,7 +433,7 @@ class DynaPropertySerializationTest {
         assertTrue(namePositionInString > 0, "Name must be present in the String-type stream");
         assertTrue(namePositionInInteger > 0, "Name must be present in the Integer-type stream");
         // Find the first byte where the streams diverge (inside writeAnyClass output,
-        // where the serialised form of String.class differs from Integer.class).
+        // where the serialized form of String.class differs from Integer.class).
         int firstDiff = -1;
         for (int i = 0; i < stringTypeBytes.length; i++) {
             if (stringTypeBytes[i] != integerTypeBytes[i]) {
@@ -433,27 +442,30 @@ class DynaPropertySerializationTest {
             }
         }
         assertTrue(firstDiff >= 0, "Streams must diverge where the class objects differ");
-        // The divergence (type class data from writeAnyClass) must precede the name
+        // The divergence (type class data from writeAnyClass) must follow the name
         // (from defaultWriteObject) in BOTH streams.
-        assertTrue(firstDiff < namePositionInString, "writeAnyClass must be invoked before defaultWriteObject (String-type stream): "
-                + "type divergence at byte " + firstDiff + " must precede name at byte " + namePositionInString);
-        assertTrue(firstDiff < namePositionInInteger, "writeAnyClass must be invoked before defaultWriteObject (Integer-type stream): "
-                + "type divergence at byte " + firstDiff + " must precede name at byte " + namePositionInInteger);
+        assertTrue(firstDiff > namePositionInString,
+                "writeAnyClass must be invoked after defaultWriteObject (String-type stream): "
+                        + "type divergence at byte " + firstDiff + " must follow name at byte " + namePositionInString);
+        assertTrue(firstDiff > namePositionInInteger,
+                "writeAnyClass must be invoked after defaultWriteObject (Integer-type stream): "
+                        + "type divergence at byte " + firstDiff + " must follow name at byte "
+                        + namePositionInInteger);
         assertRoundTrip(new DynaProperty(sharedName, String.class));
         assertRoundTrip(new DynaProperty(sharedName, Integer.class));
     }
 
     /**
      * Proves that for <strong>indexed and mapped properties</strong> the second {@code writeAnyClass} call (for {@code contentType}) also appears in the byte
-     * stream <em>before</em> the {@code name} field written by {@code defaultWriteObject}.
+     * stream <em>after</em> the {@code name} field written by {@code defaultWriteObject}.
      * <p>
      * Two mapped properties share the same name and the same {@code Map.class} type but differ in their {@code contentType} ({@code Boolean.TYPE} vs
      * {@code Byte.TYPE}). Because the type ({@code Map.class}) is identical, the streams are the same through the first {@code writeAnyClass} call. They
-     * diverge at the second {@code writeAnyClass} call (contentType constant), which must still precede the name.
+     * diverge at the second {@code writeAnyClass} call (contentType constant), which must still follow the name.
      * </p>
      */
     @Test
-    void testWireFormatContentTypeDataPrecedesNameFieldForMappedProperty() throws Exception {
+    void testWireFormatContentTypeDataFollowsNameFieldForMappedProperty() throws Exception {
         final String sharedName = "sharedMappedName";
         // Both use Map.class as the type (identical first writeAnyClass output).
         // They differ only in contentType: Boolean.TYPE (constant 1) vs Byte.TYPE (constant 2).
@@ -462,7 +474,8 @@ class DynaPropertySerializationTest {
         final byte[] nameBytes = sharedName.getBytes(StandardCharsets.UTF_8);
         final int namePosition = findSequence(boolContentBytes, nameBytes);
         assertTrue(namePosition > 0, "Name must be present in the serialized stream");
-        assertEquals(namePosition, findSequence(byteContentBytes, nameBytes), "Name must be at the same byte position in both streams");
+        assertEquals(namePosition, findSequence(byteContentBytes, nameBytes),
+                "Name must be at the same byte position in both streams");
         // The streams are identical up to (and including) the type encoding of Map.class.
         // They diverge at the contentType constant written by the second writeAnyClass call.
         int firstDiff = -1;
@@ -473,12 +486,52 @@ class DynaPropertySerializationTest {
             }
         }
         assertTrue(firstDiff >= 0, "Streams must diverge at the contentType primitive-type constant");
-        // The second writeAnyClass output (contentType) must still precede the name
-        // (defaultWriteObject), confirming that both writeAnyClass calls happen before
+        // The second writeAnyClass output (contentType) must still follow the name
+        // (defaultWriteObject), confirming that both writeAnyClass calls happen after
         // defaultWriteObject is invoked.
-        assertTrue(firstDiff < namePosition, "The second writeAnyClass call (contentType) must precede defaultWriteObject: "
-                + "content-type divergence at byte " + firstDiff + " must precede name at byte " + namePosition);
+        assertTrue(firstDiff > namePosition,
+                "The second writeAnyClass call (contentType) must follow defaultWriteObject: "
+                        + "content-type divergence at byte " + firstDiff + " must follow name at byte " + namePosition);
         assertRoundTrip(new DynaProperty(sharedName, Map.class, Boolean.TYPE));
         assertRoundTrip(new DynaProperty(sharedName, Map.class, Byte.TYPE));
+    }
+
+    /**
+     * Tests cloning mechanism via Wildfly Object Cloner.
+     */
+    @Test
+    public void testCloneViaWildflyObjectCloner() throws Exception {
+        final ClonerConfiguration paramConfig = new ClonerConfiguration();
+        paramConfig.setClassCloner(new ClassLoaderClassCloner(getClass().getClassLoader()));
+        final ObjectCloner objectCloner = ObjectCloners.getSerializingObjectClonerFactory().createCloner(paramConfig);
+
+        final DynaProperty testPropertyWithNameTypeContentType = new DynaProperty("test", List.class, Short.class);
+        final Object cloned = objectCloner.clone(testPropertyWithNameTypeContentType);
+
+        assertEquals(testPropertyWithNameTypeContentType, cloned);
+    }
+
+    /**
+     * Tests for deserializing from the old serialization mechanism of a DynaProperty.
+     */
+    @Test
+    public void testDeserializeFromOldSerialization() throws Exception {
+        final String oldPropertyWithNameTypeContentType =
+                "rO0ABXNyAClvcmcuYXBhY2hlLmNvbW1vbnMuYmVhbnV0aWxzLkR5bmFQcm9wZXJ0eQAAAAAAAAABAwABTAAEbmFtZXQAEkxqYXZhL2xhbmcvU3RyaW5nO3hwdwEAdnIADmphdmEudXRpbC5MaXN0AAAAAAAAAAAAAAB4cHcBAHZyAA9qYXZhLmxhbmcuU2hvcnRoTTcTNGDaUgIAAVMABXZhbHVleHIAEGphdmEubGFuZy5OdW1iZXKGrJUdC5TgiwIAAHhwdAAFdGVzdDN4";
+
+        final byte[] decoded = Base64.getDecoder().decode(oldPropertyWithNameTypeContentType);
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(decoded))) {
+            final InvalidClassException e = assertThrows(InvalidClassException.class, ois::readObject);
+            assertTrue(e.getMessage().contains("serialVersionUID"));
+        }
+
+        // try new serialization and make sure it is *not* equal to the old representation
+        final DynaProperty newPropertyWithNameTypeContentType = new DynaProperty("test", List.class, Byte.class);
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(buffer)) {
+            oos.writeObject(newPropertyWithNameTypeContentType);
+        }
+
+        assertNotEquals(oldPropertyWithNameTypeContentType, Base64.getEncoder().encodeToString(buffer.toByteArray()));
     }
 }

--- a/src/test/java/org/apache/commons/beanutils/DynaPropertyTest.java
+++ b/src/test/java/org/apache/commons/beanutils/DynaPropertyTest.java
@@ -16,7 +16,18 @@
  */
 package org.apache.commons.beanutils;
 
-import java.util.Collection;
+import static org.junit.Assert.assertNotEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.List;
+
+import org.jboss.marshalling.cloner.ClassLoaderClassCloner;
+import org.jboss.marshalling.cloner.ClonerConfiguration;
+import org.jboss.marshalling.cloner.ObjectCloner;
+import org.jboss.marshalling.cloner.ObjectCloners;
 
 import junit.framework.TestCase;
 
@@ -56,8 +67,8 @@ public class DynaPropertyTest extends TestCase {
         testPropertyWithNameAndType = new DynaProperty("test2", Integer.class);
         testProperty2Duplicate = new DynaProperty("test2", Integer.class);
 
-        testPropertyWithNameAndTypeAndContentType = new DynaProperty("test3", Collection.class, Short.class);
-        testProperty3Duplicate = new DynaProperty("test3", Collection.class, Short.class);
+        testPropertyWithNameAndTypeAndContentType = new DynaProperty("test3", List.class, Short.class);
+        testProperty3Duplicate = new DynaProperty("test3", List.class, Short.class);
     }
 
     /**
@@ -80,9 +91,9 @@ public class DynaPropertyTest extends TestCase {
         assertEquals(testPropertyWithName, testProperty1Duplicate);
         assertEquals(testPropertyWithNameAndType, testProperty2Duplicate);
         assertEquals(testPropertyWithNameAndTypeAndContentType, testProperty3Duplicate);
-        assertFalse(testPropertyWithName.equals(testPropertyWithNameAndType));
-        assertFalse(testPropertyWithNameAndType.equals(testPropertyWithNameAndTypeAndContentType));
-        assertFalse(testPropertyWithName.equals(null));
+        assertNotEquals(testPropertyWithName, testPropertyWithNameAndType);
+        assertNotEquals(testPropertyWithNameAndType, testPropertyWithNameAndTypeAndContentType);
+        assertNotEquals(null, testPropertyWithName);
     }
 
     /**
@@ -97,4 +108,32 @@ public class DynaPropertyTest extends TestCase {
         assertEquals(initialHashCode, testPropertyWithNameAndTypeAndContentType.hashCode());
     }
 
+    /**
+     * Tests basic serialization and deserialization mechanism.
+     */
+    public void testSerialization() throws Exception {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(buffer);
+        oos.writeObject(testPropertyWithNameAndTypeAndContentType);
+        oos.flush();
+        oos.close();
+
+        ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray()));
+        Object obj = ois.readObject();
+
+        assertEquals(testPropertyWithNameAndTypeAndContentType, obj);
+    }
+
+    /**
+     * Tests cloning mechanism via Wildfly Object Cloner.
+     */
+    public void testCloneViaWildflyObjectCloner() throws Exception {
+        final ClonerConfiguration paramConfig = new ClonerConfiguration();
+        paramConfig.setClassCloner(new ClassLoaderClassCloner(DynaPropertyTest.class.getClassLoader()));
+        final ObjectCloner objectCloner = ObjectCloners.getSerializingObjectClonerFactory().createCloner(paramConfig);
+
+        final Object cloned = objectCloner.clone(testPropertyWithNameAndTypeAndContentType);
+
+        assertEquals(testPropertyWithNameAndTypeAndContentType, cloned);
+    }
 }

--- a/src/test/java/org/apache/commons/beanutils/DynaPropertyTest.java
+++ b/src/test/java/org/apache/commons/beanutils/DynaPropertyTest.java
@@ -17,25 +17,20 @@
 
 package org.apache.commons.beanutils;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.util.List;
 
-import org.jboss.marshalling.cloner.ClassLoaderClassCloner;
-import org.jboss.marshalling.cloner.ClonerConfiguration;
-import org.jboss.marshalling.cloner.ObjectCloner;
-import org.jboss.marshalling.cloner.ObjectCloners;
-
-import junit.framework.TestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link DynaProperty}.
  */
-public class DynaPropertyTest extends TestCase {
+public class DynaPropertyTest {
 
     private DynaProperty testPropertyWithName;
 
@@ -50,20 +45,10 @@ public class DynaPropertyTest extends TestCase {
     private DynaProperty testProperty3Duplicate;
 
     /**
-     * Construct a new instance of this test case.
-     *
-     * @param name Name of the test case
-     */
-    public DynaPropertyTest(final String name) {
-        super(name);
-    }
-
-    /**
      * Set up instance variables required by this test case.
      */
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @BeforeEach
+    public void setUp() {
         testPropertyWithName = new DynaProperty("test1");
         testProperty1Duplicate = new DynaProperty("test1");
         testPropertyWithNameAndType = new DynaProperty("test2", Integer.class);
@@ -75,17 +60,17 @@ public class DynaPropertyTest extends TestCase {
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
-    protected void tearDown() throws Exception {
+    @AfterEach
+    public void tearDown() {
         testPropertyWithName = testProperty1Duplicate = null;
         testPropertyWithNameAndType = testProperty2Duplicate = null;
         testPropertyWithNameAndTypeAndContentType = testProperty3Duplicate = null;
-        super.tearDown();
     }
 
     /**
      * Class under test for boolean equals(Object)
      */
+    @Test
     public void testEqualsObject() {
         assertEquals(testPropertyWithName, testProperty1Duplicate);
         assertEquals(testPropertyWithNameAndType, testProperty2Duplicate);
@@ -98,40 +83,12 @@ public class DynaPropertyTest extends TestCase {
     /**
      * Class under test for int hashCode(Object)
      */
+    @Test
     public void testHashCode() {
         final int initialHashCode = testPropertyWithNameAndTypeAndContentType.hashCode();
         assertEquals(testPropertyWithName.hashCode(), testProperty1Duplicate.hashCode());
         assertEquals(testPropertyWithNameAndType.hashCode(), testProperty2Duplicate.hashCode());
         assertEquals(testPropertyWithNameAndTypeAndContentType.hashCode(), testProperty3Duplicate.hashCode());
         assertEquals(initialHashCode, testPropertyWithNameAndTypeAndContentType.hashCode());
-    }
-
-    /**
-     * Tests basic serialization and deserialization mechanism.
-     */
-    public void testSerialization() throws Exception {
-        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        ObjectOutputStream oos = new ObjectOutputStream(buffer);
-        oos.writeObject(testPropertyWithNameAndTypeAndContentType);
-        oos.flush();
-        oos.close();
-
-        ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray()));
-        Object obj = ois.readObject();
-
-        assertEquals(testPropertyWithNameAndTypeAndContentType, obj);
-    }
-
-    /**
-     * Tests cloning mechanism via Wildfly Object Cloner.
-     */
-    public void testCloneViaWildflyObjectCloner() throws Exception {
-        final ClonerConfiguration paramConfig = new ClonerConfiguration();
-        paramConfig.setClassCloner(new ClassLoaderClassCloner(DynaPropertyTest.class.getClassLoader()));
-        final ObjectCloner objectCloner = ObjectCloners.getSerializingObjectClonerFactory().createCloner(paramConfig);
-
-        final Object cloned = objectCloner.clone(testPropertyWithNameAndTypeAndContentType);
-
-        assertEquals(testPropertyWithNameAndTypeAndContentType, cloned);
     }
 }

--- a/src/test/java/org/apache/commons/beanutils/DynaPropertyTest.java
+++ b/src/test/java/org/apache/commons/beanutils/DynaPropertyTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.beanutils;
 
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -68,7 +68,6 @@ public class DynaPropertyTest extends TestCase {
         testProperty1Duplicate = new DynaProperty("test1");
         testPropertyWithNameAndType = new DynaProperty("test2", Integer.class);
         testProperty2Duplicate = new DynaProperty("test2", Integer.class);
-
         testPropertyWithNameAndTypeAndContentType = new DynaProperty("test3", List.class, Short.class);
         testProperty3Duplicate = new DynaProperty("test3", List.class, Short.class);
     }


### PR DESCRIPTION
The order of method calls in the serialization methods in {{DynaProperty}} must be changed to conform to the Java Object Serialization Specification. In our case EJB calls in Wildfly failed as the ObjectCloner of Wildfly was checking that the {{in.defaultReadObject}} and {{out.defaultWriteObject}} methods must be called first in the {{Serializable}}'s {{readObject}} and {{writeObject}} methods.

Here are the relevant parts of the Java Object Serialization Specification:
- https://docs.oracle.com/en/java/javase/11/docs/specs/serialization/input.html#the-readobject-method
- https://docs.oracle.com/en/java/javase/11/docs/specs/serialization/output.html#the-writeobject-method

The stacktrace we got from our Wildfly server is as follows:

``` 
java.lang.IllegalStateException: defaultWriteObject may not be called in this context
	at org.jboss.marshalling.cloner.SerializingCloner$StepObjectOutputStream.defaultWriteObject(SerializingCloner.java:612)
	at org.apache.commons.beanutils.DynaProperty.writeObject(DynaProperty.java:336)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.jboss.marshalling.reflect.SerializableClass.callWriteObject(SerializableClass.java:271)
	at org.jboss.marshalling.cloner.SerializingCloner.initSerializableClone(SerializingCloner.java:297)
	at org.jboss.marshalling.cloner.SerializingCloner.clone(SerializingCloner.java:251)
	at org.jboss.marshalling.cloner.SerializingCloner.clone(SerializingCloner.java:128)
	at org.jboss.marshalling.cloner.SerializingCloner$StepObjectInput.doReadObject(SerializingCloner.java:882)
    ...
``` 

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
