### PR TITLE
Suppress case variants of mapped names in isPropertySuppressed

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/MappedPropertyDescriptor.java
+++ b/src/main/java/org/apache/commons/beanutils2/MappedPropertyDescriptor.java
@@ -162,7 +162,7 @@ public class MappedPropertyDescriptor extends PropertyDescriptor {
      *
      * @param s The property name
      */
-    private static String capitalizePropertyName(final String s) {
+    static String capitalizePropertyName(final String s) {
         if (s.isEmpty()) {
             return s;
         }

--- a/src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java
+++ b/src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java
@@ -1068,15 +1068,21 @@ public class PropertyUtilsBean {
     /**
      * Tests whether a property name has been removed by a registered {@link SuppressPropertiesBeanIntrospector}. The mapped-descriptor fallback in
      * {@link #getPropertyDescriptor(Object, String)} bypasses the introspection pipeline, so suppressed mapped property names must be filtered explicitly.
+     * {@link MappedPropertyDescriptor} derives its accessor names from the capitalized property name, so names differing only in the case of their first
+     * character resolve the same accessors and are compared on that capitalized form here.
      *
      * @param name The property name to test.
      * @return {@code true} if the name is suppressed by an introspector.
      */
     private boolean isPropertySuppressed(final String name) {
+        final String base = MappedPropertyDescriptor.capitalizePropertyName(name);
         for (final BeanIntrospector introspector : introspectors) {
-            if (introspector instanceof SuppressPropertiesBeanIntrospector
-                    && ((SuppressPropertiesBeanIntrospector) introspector).getSuppressedProperties().contains(name)) {
-                return true;
+            if (introspector instanceof SuppressPropertiesBeanIntrospector) {
+                for (final String suppressed : ((SuppressPropertiesBeanIntrospector) introspector).getSuppressedProperties()) {
+                    if (base.equals(MappedPropertyDescriptor.capitalizePropertyName(suppressed))) {
+                        return true;
+                    }
+                }
             }
         }
         return false;

--- a/src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java
+++ b/src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java
@@ -1079,7 +1079,7 @@ public class PropertyUtilsBean {
         for (final BeanIntrospector introspector : introspectors) {
             if (introspector instanceof SuppressPropertiesBeanIntrospector) {
                 for (final String suppressed : ((SuppressPropertiesBeanIntrospector) introspector).getSuppressedProperties()) {
-                    if (base.equals(MappedPropertyDescriptor.capitalizePropertyName(suppressed))) {
+                    if (suppressed != null && base.equals(MappedPropertyDescriptor.capitalizePropertyName(suppressed))) {
                         return true;
                     }
                 }

--- a/src/test/java/org/apache/commons/beanutils2/PropertyUtilsTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/PropertyUtilsTest.java
@@ -333,6 +333,20 @@ class PropertyUtilsTest {
     }
 
     /**
+     * {@link SuppressPropertiesBeanIntrospector} only rejects a null collection, so the set of suppressed names may hold null entries. Those must be skipped
+     * rather than capitalized when the mapped-descriptor fallback is checked.
+     */
+    @Test
+    void testCustomIntrospectionSuppressedMappedPropertyNullEntry() throws Exception {
+        final PropertyUtilsBean pub = new PropertyUtilsBean();
+        pub.addBeanIntrospector(new SuppressPropertiesBeanIntrospector(Arrays.asList(null, "mappedProperty")));
+
+        assertNull(pub.getPropertyDescriptor(bean, "MappedProperty"), "Case variant of a suppressed mapped property should have no descriptor");
+        assertNull(pub.getPropertyDescriptor(bean, "mappedProperty"), "Suppressed mapped property should have no descriptor");
+        assertNotNull(pub.getPropertyDescriptor(bean, "stringProperty"), "A null suppressed entry must not hide unrelated properties");
+    }
+
+    /**
      * Test the describe() method.
      */
     @Test

--- a/src/test/java/org/apache/commons/beanutils2/PropertyUtilsTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/PropertyUtilsTest.java
@@ -316,6 +316,23 @@ class PropertyUtilsTest {
     }
 
     /**
+     * {@link MappedPropertyDescriptor} capitalizes the first character of the property name to build the accessor names, so {@code MappedProperty(key)}
+     * resolves the same {@code getMappedProperty}/{@code setMappedProperty} pair as {@code mappedProperty(key)} and must be suppressed with it.
+     */
+    @Test
+    void testCustomIntrospectionSuppressedMappedPropertyCaseVariant() throws Exception {
+        final PropertyUtilsBean pub = new PropertyUtilsBean();
+        pub.addBeanIntrospector(new SuppressPropertiesBeanIntrospector(Arrays.asList("mappedProperty")));
+
+        assertNull(pub.getPropertyDescriptor(bean, "MappedProperty"), "Case variant of a suppressed mapped property should have no descriptor");
+        assertThrows(NoSuchMethodException.class, () -> pub.getProperty(bean, "MappedProperty(First Key)"),
+                "Case variant of a suppressed mapped property must not be readable");
+        assertThrows(NoSuchMethodException.class, () -> pub.setProperty(bean, "MappedProperty(First Key)", "changed"),
+                "Case variant of a suppressed mapped property must not be writable");
+        assertEquals("First Value", bean.getMappedProperty("First Key"), "Suppressed mapped property must be unchanged");
+    }
+
+    /**
      * Test the describe() method.
      */
     @Test


### PR DESCRIPTION
`isPropertySuppressed` compares the raw expression token against the suppressed set, but the mapped-descriptor fallback it guards builds `get<Base>(String)` / `set<Base>(String, ?)` from `MappedPropertyDescriptor.capitalizePropertyName(name)`, so any name that differs only in the case of its first character resolves the same accessor pair and is never matched by the check. With `mappedProperty` suppressed, `mappedProperty(key)` is blocked but `MappedProperty(key)` still reads and writes it, including through `BeanUtilsBean.populate` with a caller-supplied parameter map. Mapped accessors are never JavaBeans property descriptors, so `data.getDescriptor(name)` is always null for them and this check is the only thing in front of the accessor.

Comparing on the same capitalized base the descriptor derives keeps the guard and the descriptor from drifting apart again; `capitalizePropertyName` drops to package-private for that. Found while re-auditing the suppression path from #413.

`PropertyUtilsTest.testCustomIntrospectionSuppressedMappedPropertyCaseVariant` fails without the runtime change (`MappedProperty` still resolves a `MappedPropertyDescriptor`) and passes with it. Full `mvn` default goal is green: 1284 tests, 0 failures.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
