### PR TITLE
Floor pre-epoch Timestamp seconds in DateTimeConverter.convertToType

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/converters/DateTimeConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/converters/DateTimeConverter.java
@@ -200,7 +200,7 @@ public abstract class DateTimeConverter<D> extends AbstractConverter<D> {
             // didn't include the milliseconds. The following code
             // ensures it works consistently across JDK versions
             final java.sql.Timestamp timestamp = (java.sql.Timestamp) value;
-            long timeInMillis = timestamp.getTime() / 1000 * 1000;
+            long timeInMillis = Math.floorDiv(timestamp.getTime(), 1000) * 1000;
             timeInMillis += timestamp.getNanos() / 1000000;
             return toDate(targetType, timeInMillis);
         }

--- a/src/test/java/org/apache/commons/beanutils2/converters/DateConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/DateConverterTest.java
@@ -83,4 +83,17 @@ class DateConverterTest extends AbstractDateConverterTest<Date> {
         final Timestamp timestamp = new Timestamp(-500L);
         assertEquals(-500L, makeConverter().convert(getExpectedType(), timestamp).getTime());
     }
+
+    /**
+     * For {@code getTime()} in {@code [Long.MIN_VALUE, Long.MIN_VALUE + 807]} the whole-second term
+     * {@code Math.floorDiv(getTime(), 1000) * 1000} wraps around {@link Long#MIN_VALUE}, but adding the non-negative
+     * {@code getNanos() / 1_000_000} wraps it back: the two terms reconstruct {@code getTime()} exactly in
+     * two's-complement arithmetic, so no overflow guard is needed.
+     */
+    @Test
+    void testConvertExtremePreEpochSqlTimestamp() {
+        assertEquals(Long.MIN_VALUE, makeConverter().convert(getExpectedType(), new Timestamp(Long.MIN_VALUE)).getTime());
+        // last value whose whole-second term still wraps
+        assertEquals(Long.MIN_VALUE + 807, makeConverter().convert(getExpectedType(), new Timestamp(Long.MIN_VALUE + 807)).getTime());
+    }
 }

--- a/src/test/java/org/apache/commons/beanutils2/converters/DateConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/DateConverterTest.java
@@ -17,8 +17,13 @@
 
 package org.apache.commons.beanutils2.converters;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Date;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Case for the DateConverter class.
@@ -65,5 +70,17 @@ class DateConverterTest extends AbstractDateConverterTest<Date> {
     @Override
     protected Date toType(final Calendar value) {
         return value.getTime();
+    }
+
+    /**
+     * A pre-epoch {@link Timestamp} carries a non-negative sub-second part in {@code getNanos()}, so decomposing
+     * {@code getTime()} into whole seconds must floor: integer division truncates toward zero for negative values and
+     * gains a whole second.
+     */
+    @Test
+    void testConvertPreEpochSqlTimestamp() {
+        // 1969-12-31T23:59:59.500Z: getTime() == -500, getNanos() == 500_000_000
+        final Timestamp timestamp = new Timestamp(-500L);
+        assertEquals(-500L, makeConverter().convert(getExpectedType(), timestamp).getTime());
     }
 }


### PR DESCRIPTION
`DateTimeConverter.convertToType` decomposes a `java.sql.Timestamp` into whole seconds with `timestamp.getTime() / 1000 * 1000` and adds the sub-second part back via `timestamp.getNanos() / 1000000`, but integer division truncates toward zero while `getNanos()` is always in `[0, 999999999]` (the JDK constructor borrows a second to normalize a negative fraction), so a pre-epoch timestamp with a non-zero fraction rounds the whole-second term up toward zero and then adds a non-negative nanos term, gaining a full second: `new java.sql.Timestamp(-500L)` (1969-12-31T23:59:59.500Z) converts to epoch millis `500` instead of `-500`. `Math.floorDiv` makes the whole-second term floor so it agrees with the nanos term; every date/time converter inherits this one path and post-epoch values are unchanged. Found auditing the date/time converters; the existing tests only feed positive `System.currentTimeMillis()`, so they never hit it.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
