### PR TITLE
Clear descriptor caches when bean introspectors change

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java
+++ b/src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java
@@ -136,6 +136,7 @@ public class PropertyUtilsBean {
      */
     public void addBeanIntrospector(final BeanIntrospector introspector) {
         introspectors.add(Objects.requireNonNull(introspector, "introspector"));
+        clearDescriptorCaches();
     }
 
     /**
@@ -146,6 +147,15 @@ public class PropertyUtilsBean {
         descriptorsCache.clear();
         mappedDescriptorsCache.clear();
         Introspector.flushCaches();
+    }
+
+    /**
+     * Discards the memoized introspection results after the registered {@link BeanIntrospector} set has changed. Unlike {@link #clearDescriptors()} this leaves
+     * the JVM-global {@link Introspector} cache untouched.
+     */
+    private void clearDescriptorCaches() {
+        descriptorsCache.clear();
+        mappedDescriptorsCache.clear();
     }
 
     /**
@@ -1222,7 +1232,11 @@ public class PropertyUtilsBean {
      * @since 1.9
      */
     public boolean removeBeanIntrospector(final BeanIntrospector introspector) {
-        return introspectors.remove(introspector);
+        final boolean removed = introspectors.remove(introspector);
+        if (removed) {
+            clearDescriptorCaches();
+        }
+        return removed;
     }
 
     /**
@@ -1236,6 +1250,7 @@ public class PropertyUtilsBean {
         introspectors.add(DefaultBeanIntrospector.INSTANCE);
         introspectors.add(SuppressPropertiesBeanIntrospector.SUPPRESS_CLASS);
         introspectors.add(SuppressPropertiesBeanIntrospector.SUPPRESS_DECLARING_CLASS);
+        clearDescriptorCaches();
     }
 
     /**

--- a/src/test/java/org/apache/commons/beanutils2/PropertyUtilsTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/PropertyUtilsTest.java
@@ -347,6 +347,30 @@ class PropertyUtilsTest {
     }
 
     /**
+     * Registering a {@link SuppressPropertiesBeanIntrospector} must take effect for classes already introspected. The per-class descriptor cache was populated
+     * before the introspector was added and was never invalidated, so a property suppressed for hardening stayed readable and writable when its class had been
+     * introspected earlier (the common case with the shared {@code PropertyUtils} singleton).
+     */
+    @Test
+    void testAddBeanIntrospectorInvalidatesCache() throws Exception {
+        final PropertyUtilsBean pub = new PropertyUtilsBean();
+
+        // Warm the descriptor cache for TestBean before the suppression is configured.
+        assertNotNull(pub.getPropertyDescriptor(bean, "stringProperty"), "Property should be visible before suppression");
+
+        final SuppressPropertiesBeanIntrospector suppressor = new SuppressPropertiesBeanIntrospector(Arrays.asList("stringProperty"));
+        pub.addBeanIntrospector(suppressor);
+
+        assertNull(pub.getPropertyDescriptor(bean, "stringProperty"), "Suppressed property should have no descriptor after the introspector is added");
+        assertThrows(NoSuchMethodException.class, () -> pub.getProperty(bean, "stringProperty"), "Suppressed property must not be readable");
+        assertThrows(NoSuchMethodException.class, () -> pub.setProperty(bean, "stringProperty", "changed"), "Suppressed property must not be writable");
+
+        // Removing the introspector must likewise invalidate the cache so the property becomes visible again.
+        pub.removeBeanIntrospector(suppressor);
+        assertNotNull(pub.getPropertyDescriptor(bean, "stringProperty"), "Property should be visible again after the introspector is removed");
+    }
+
+    /**
      * Test the describe() method.
      */
     @Test

--- a/src/test/java/org/apache/commons/beanutils2/PropertyUtilsTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/PropertyUtilsTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -368,6 +369,80 @@ class PropertyUtilsTest {
         // Removing the introspector must likewise invalidate the cache so the property becomes visible again.
         pub.removeBeanIntrospector(suppressor);
         assertNotNull(pub.getPropertyDescriptor(bean, "stringProperty"), "Property should be visible again after the introspector is removed");
+    }
+
+    /**
+     * {@code resetBeanIntrospectors()} must invalidate the descriptor caches so that introspection results produced by a previously registered custom
+     * introspector are re-evaluated against the restored default set.
+     */
+    @Test
+    void testResetBeanIntrospectorsInvalidatesCache() throws Exception {
+        final PropertyUtilsBean pub = new PropertyUtilsBean();
+        pub.addBeanIntrospector(new SuppressPropertiesBeanIntrospector(Arrays.asList("stringProperty")));
+
+        // Warm the descriptor cache with the suppression in effect.
+        assertNull(pub.getPropertyDescriptor(bean, "stringProperty"), "Suppressed property should have no descriptor");
+
+        pub.resetBeanIntrospectors();
+
+        assertNotNull(pub.getPropertyDescriptor(bean, "stringProperty"), "Property should be re-evaluated and visible after the reset");
+        assertEquals(bean.getStringProperty(), pub.getProperty(bean, "stringProperty"), "Property should be readable after the reset");
+    }
+
+    /**
+     * Changing the introspector set must also invalidate the mapped descriptor cache. The suppression guard in {@code getPropertyDescriptor} already hides a
+     * suppressed mapped property, so this checks the cached {@link MappedPropertyDescriptor} itself is dropped and re-created rather than served stale.
+     */
+    @Test
+    void testIntrospectorChangeInvalidatesMappedDescriptorCache() throws Exception {
+        final PropertyUtilsBean pub = new PropertyUtilsBean();
+
+        // Warm the mapped descriptor cache for TestBean.
+        final PropertyDescriptor first = pub.getPropertyDescriptor(bean, "mappedProperty");
+        assertNotNull(first, "Mapped property should be visible before suppression");
+
+        final SuppressPropertiesBeanIntrospector suppressor = new SuppressPropertiesBeanIntrospector(Arrays.asList("mappedProperty"));
+        pub.addBeanIntrospector(suppressor);
+
+        assertNull(pub.getPropertyDescriptor(bean, "mappedProperty"), "Suppressed mapped property should have no descriptor");
+        assertThrows(NoSuchMethodException.class, () -> pub.getProperty(bean, "mappedProperty(First Key)"), "Suppressed mapped property must not be readable");
+
+        pub.removeBeanIntrospector(suppressor);
+
+        final PropertyDescriptor second = pub.getPropertyDescriptor(bean, "mappedProperty");
+        assertNotNull(second, "Mapped property should be visible again after the introspector is removed");
+        assertNotSame(first, second, "Mapped descriptor must be re-created, not served from the stale cache");
+        assertEquals("First Value", pub.getProperty(bean, "mappedProperty(First Key)"), "Mapped property should be readable again");
+    }
+
+    /**
+     * Each add and remove in a sequence of introspector changes must invalidate the caches, so the visible property set always reflects the currently
+     * registered introspectors.
+     */
+    @Test
+    void testSequentialIntrospectorChangesInvalidateCache() throws Exception {
+        final PropertyUtilsBean pub = new PropertyUtilsBean();
+        final SuppressPropertiesBeanIntrospector suppressString = new SuppressPropertiesBeanIntrospector(Arrays.asList("stringProperty"));
+        final SuppressPropertiesBeanIntrospector suppressInt = new SuppressPropertiesBeanIntrospector(Arrays.asList("intProperty"));
+
+        assertNotNull(pub.getPropertyDescriptor(bean, "stringProperty"), "stringProperty should be visible initially");
+        assertNotNull(pub.getPropertyDescriptor(bean, "intProperty"), "intProperty should be visible initially");
+
+        pub.addBeanIntrospector(suppressString);
+        assertNull(pub.getPropertyDescriptor(bean, "stringProperty"), "stringProperty should be suppressed after the first add");
+        assertNotNull(pub.getPropertyDescriptor(bean, "intProperty"), "intProperty should be unaffected by the first add");
+
+        pub.addBeanIntrospector(suppressInt);
+        assertNull(pub.getPropertyDescriptor(bean, "stringProperty"), "stringProperty should stay suppressed after the second add");
+        assertNull(pub.getPropertyDescriptor(bean, "intProperty"), "intProperty should be suppressed after the second add");
+
+        pub.removeBeanIntrospector(suppressString);
+        assertNotNull(pub.getPropertyDescriptor(bean, "stringProperty"), "stringProperty should be visible again after its introspector is removed");
+        assertNull(pub.getPropertyDescriptor(bean, "intProperty"), "intProperty should stay suppressed after the unrelated remove");
+
+        pub.removeBeanIntrospector(suppressInt);
+        assertNotNull(pub.getPropertyDescriptor(bean, "stringProperty"), "stringProperty should stay visible after the last remove");
+        assertNotNull(pub.getPropertyDescriptor(bean, "intProperty"), "intProperty should be visible again after its introspector is removed");
     }
 
     /**


### PR DESCRIPTION
`addBeanIntrospector`, `removeBeanIntrospector` and `resetBeanIntrospectors` mutate the `introspectors` list but never invalidate `descriptorsCache`, which `getIntrospectionData` fills once per bean class, so registering a `SuppressPropertiesBeanIntrospector` (the documented BEANUTILS-463 hardening) after a class has already been introspected is a no-op: `getPropertyDescriptor` returns the stale cached descriptor at its early return before it reaches the `isPropertySuppressed` guard, and the suppressed property stays readable and writable via `populate`/`getProperty`/`setProperty`. found while auditing the suppression path from #413/#431, whose own tests call `clearDescriptors()` right before `addBeanIntrospector` to work around this. clearing the descriptor caches when the introspector set changes makes the change take effect for already-cached classes; i did not reuse `clearDescriptors()` because it also flushes the JVM-global `Introspector` cache.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
