### PR TITLE
Reject out-of-range sql date/time fields in DateTimeConverter.toDate

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/converters/DateTimeConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/converters/DateTimeConverter.java
@@ -22,10 +22,16 @@ import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+import java.time.format.SignStyle;
+import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.util.Calendar;
 import java.util.Date;
@@ -84,6 +90,23 @@ import org.apache.commons.beanutils2.ConversionException;
  * @since 1.8.0
  */
 public abstract class DateTimeConverter<D> extends AbstractConverter<D> {
+
+    /** Strict validator for the JDBC {@code java.sql.Date} escape format, rejecting out-of-range fields that {@code valueOf} would roll over. */
+    private static final DateTimeFormatter SQL_DATE_FORMAT = new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+            .appendLiteral('-').appendValue(ChronoField.MONTH_OF_YEAR).appendLiteral('-').appendValue(ChronoField.DAY_OF_MONTH).toFormatter()
+            .withResolverStyle(ResolverStyle.STRICT);
+
+    /** Strict validator for the JDBC {@code java.sql.Time} escape format, rejecting out-of-range fields that {@code valueOf} would roll over. */
+    private static final DateTimeFormatter SQL_TIME_FORMAT = new DateTimeFormatterBuilder().appendValue(ChronoField.HOUR_OF_DAY).appendLiteral(':')
+            .appendValue(ChronoField.MINUTE_OF_HOUR).appendLiteral(':').appendValue(ChronoField.SECOND_OF_MINUTE).toFormatter()
+            .withResolverStyle(ResolverStyle.STRICT);
+
+    /** Strict validator for the JDBC {@code java.sql.Timestamp} escape format, rejecting out-of-range fields that {@code valueOf} would roll over. */
+    private static final DateTimeFormatter SQL_TIMESTAMP_FORMAT = new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+            .appendLiteral('-').appendValue(ChronoField.MONTH_OF_YEAR).appendLiteral('-').appendValue(ChronoField.DAY_OF_MONTH).appendLiteral(' ')
+            .appendValue(ChronoField.HOUR_OF_DAY).appendLiteral(':').appendValue(ChronoField.MINUTE_OF_HOUR).appendLiteral(':')
+            .appendValue(ChronoField.SECOND_OF_MINUTE).optionalStart().appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true).optionalEnd().toFormatter()
+            .withResolverStyle(ResolverStyle.STRICT);
 
     private String[] patterns;
     private String displayPatterns;
@@ -590,24 +613,27 @@ public abstract class DateTimeConverter<D> extends AbstractConverter<D> {
         // java.sql.Date
         if (type.equals(java.sql.Date.class)) {
             try {
+                LocalDate.parse(value, SQL_DATE_FORMAT);
                 return type.cast(java.sql.Date.valueOf(value));
-            } catch (final IllegalArgumentException e) {
+            } catch (final IllegalArgumentException | DateTimeParseException e) {
                 throw new ConversionException("String must be in JDBC format [yyyy-MM-dd] to create a java.sql.Date");
             }
         }
         // java.sql.Time
         if (type.equals(java.sql.Time.class)) {
             try {
+                LocalTime.parse(value, SQL_TIME_FORMAT);
                 return type.cast(java.sql.Time.valueOf(value));
-            } catch (final IllegalArgumentException e) {
+            } catch (final IllegalArgumentException | DateTimeParseException e) {
                 throw new ConversionException("String must be in JDBC format [HH:mm:ss] to create a java.sql.Time");
             }
         }
         // java.sql.Timestamp
         if (type.equals(java.sql.Timestamp.class)) {
             try {
+                LocalDateTime.parse(value, SQL_TIMESTAMP_FORMAT);
                 return type.cast(java.sql.Timestamp.valueOf(value));
-            } catch (final IllegalArgumentException e) {
+            } catch (final IllegalArgumentException | DateTimeParseException e) {
                 throw new ConversionException("String must be in JDBC format [yyyy-MM-dd HH:mm:ss.fffffffff] to create a java.sql.Timestamp");
             }
         }

--- a/src/main/java/org/apache/commons/beanutils2/converters/DateTimeConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/converters/DateTimeConverter.java
@@ -602,6 +602,9 @@ public abstract class DateTimeConverter<D> extends AbstractConverter<D> {
      * <li>{@link java.time.Instant}</li>
      * </ul>
      * <p>
+     * For the {@code java.sql} types the String must be in the JDBC escape format and validation is strict: out-of-range fields (for example
+     * {@code 2006-02-31} or {@code 25:70:90}) are rejected with a {@link ConversionException} instead of being rolled over.
+     * <p>
      * <strong>N.B.</strong> No default String conversion mechanism is provided for {@link java.util.Date} and {@link java.util.Calendar} type.
      *
      * @param <T>   The target type
@@ -616,7 +619,8 @@ public abstract class DateTimeConverter<D> extends AbstractConverter<D> {
                 LocalDate.parse(value, SQL_DATE_FORMAT);
                 return type.cast(java.sql.Date.valueOf(value));
             } catch (final IllegalArgumentException | DateTimeParseException e) {
-                throw new ConversionException("String must be in JDBC format [yyyy-MM-dd] to create a java.sql.Date");
+                throw new ConversionException(
+                        "String must be in JDBC format [yyyy-MM-dd] to create a java.sql.Date; validation is strict, out-of-range fields are rejected");
             }
         }
         // java.sql.Time
@@ -625,7 +629,8 @@ public abstract class DateTimeConverter<D> extends AbstractConverter<D> {
                 LocalTime.parse(value, SQL_TIME_FORMAT);
                 return type.cast(java.sql.Time.valueOf(value));
             } catch (final IllegalArgumentException | DateTimeParseException e) {
-                throw new ConversionException("String must be in JDBC format [HH:mm:ss] to create a java.sql.Time");
+                throw new ConversionException(
+                        "String must be in JDBC format [HH:mm:ss] to create a java.sql.Time; validation is strict, out-of-range fields are rejected");
             }
         }
         // java.sql.Timestamp
@@ -634,7 +639,8 @@ public abstract class DateTimeConverter<D> extends AbstractConverter<D> {
                 LocalDateTime.parse(value, SQL_TIMESTAMP_FORMAT);
                 return type.cast(java.sql.Timestamp.valueOf(value));
             } catch (final IllegalArgumentException | DateTimeParseException e) {
-                throw new ConversionException("String must be in JDBC format [yyyy-MM-dd HH:mm:ss.fffffffff] to create a java.sql.Timestamp");
+                throw new ConversionException("String must be in JDBC format [yyyy-MM-dd HH:mm:ss.fffffffff] to create a java.sql.Timestamp; "
+                        + "validation is strict, out-of-range fields are rejected");
             }
         }
         // java.time.Instant

--- a/src/test/java/org/apache/commons/beanutils2/sql/converters/SqlDateConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/sql/converters/SqlDateConverterTest.java
@@ -80,6 +80,10 @@ class SqlDateConverterTest extends AbstractDateConverterTest<Date> {
 
         // Invalid String --> java.sql.Date Conversion
         invalidConversion(converter, "01/01/2006");
+
+        // Out-of-range fields must be rejected, not silently rolled over (2006-02-31 -> 2006-03-03)
+        invalidConversion(converter, "2006-02-31");
+        invalidConversion(converter, "2006-13-01");
     }
 
     /**

--- a/src/test/java/org/apache/commons/beanutils2/sql/converters/SqlTimeConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/sql/converters/SqlTimeConverterTest.java
@@ -77,6 +77,10 @@ class SqlTimeConverterTest extends AbstractDateConverterTest<Time> {
 
         // Invalid String --> java.sql.Time Conversion
         invalidConversion(converter, "15:36");
+
+        // Out-of-range fields must be rejected, not silently rolled over (25:70:90 -> 02:11:30)
+        invalidConversion(converter, "25:70:90");
+        invalidConversion(converter, "-1:-1:-1");
     }
 
     /**

--- a/src/test/java/org/apache/commons/beanutils2/sql/converters/SqlTimestampConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/sql/converters/SqlTimestampConverterTest.java
@@ -88,6 +88,10 @@ class SqlTimestampConverterTest extends AbstractDateConverterTest<Timestamp> {
         invalidConversion(converter, "2006/09/21 15:36:01.0");
         invalidConversion(converter, "2006-10-22");
         invalidConversion(converter, "15:36:01");
+
+        // Out-of-range fields must be rejected, not silently rolled over (2006-02-31 25:70:90 -> 2006-03-04 02:11:30)
+        invalidConversion(converter, "2006-02-31 15:36:01.0");
+        invalidConversion(converter, "2006-10-23 25:70:90.0");
     }
 
     /**


### PR DESCRIPTION
`DateTimeConverter.toDate` builds `java.sql.Date`/`Time`/`Timestamp` with `valueOf`, which silently rolls over out-of-range fields (`2006-02-31` -> `2006-03-03`, `25:70:90` -> `02:11:30`, `2006-10-23 25:70:90` -> next day), so malformed input in the default `useLocaleFormat=false` path is accepted as a different value instead of rejected; found while auditing the sql converters against the strict `setLenient(false)`/`ParsePosition` check the same class already applies on its locale-format branch, and fixed by validating against strict JDBC-format `DateTimeFormatter`s (`ResolverStyle.STRICT`) before `valueOf`, leaving valid padded and single-digit input unchanged.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.