### PR TITLE
Skip static methods in FluentPropertyBeanIntrospector and mapped lookup

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/FluentPropertyBeanIntrospector.java
+++ b/src/main/java/org/apache/commons/beanutils2/FluentPropertyBeanIntrospector.java
@@ -57,7 +57,7 @@ import org.apache.commons.logging.LogFactory;
  * <p>
  * This class is more tolerant with regards to the return type of a set method. It basically iterates over all methods of a class and filters them for a
  * configurable prefix (the default prefix is {@code set}). It then generates corresponding {@code PropertyDescriptor} objects for the methods found which use
- * these methods as write methods. Static methods are ignored, as they are by default introspection.
+ * these methods as write methods. Static methods are ignored, as they are by default ignored in introspection.
  * </p>
  * <p>
  * An instance of this class is intended to collaborate with a {@link DefaultBeanIntrospector} object. So best results are achieved by adding this instance as

--- a/src/main/java/org/apache/commons/beanutils2/FluentPropertyBeanIntrospector.java
+++ b/src/main/java/org/apache/commons/beanutils2/FluentPropertyBeanIntrospector.java
@@ -20,6 +20,7 @@ import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Objects;
 
 import org.apache.commons.logging.Log;
@@ -56,7 +57,7 @@ import org.apache.commons.logging.LogFactory;
  * <p>
  * This class is more tolerant with regards to the return type of a set method. It basically iterates over all methods of a class and filters them for a
  * configurable prefix (the default prefix is {@code set}). It then generates corresponding {@code PropertyDescriptor} objects for the methods found which use
- * these methods as write methods.
+ * these methods as write methods. Static methods are ignored, as they are by default introspection.
  * </p>
  * <p>
  * An instance of this class is intended to collaborate with a {@link DefaultBeanIntrospector} object. So best results are achieved by adding this instance as
@@ -128,6 +129,10 @@ public class FluentPropertyBeanIntrospector implements BeanIntrospector {
     @Override
     public void introspect(final IntrospectionContext icontext) throws IntrospectionException {
         for (final Method m : icontext.getTargetClass().getMethods()) {
+            // Static methods are not property accessors; default introspection skips them as well.
+            if (Modifier.isStatic(m.getModifiers())) {
+                continue;
+            }
             if (m.getName().startsWith(getWriteMethodPrefix())) {
                 final String propertyName = propertyName(m);
                 final PropertyDescriptor pd = icontext.getPropertyDescriptor(propertyName);

--- a/src/main/java/org/apache/commons/beanutils2/MappedPropertyDescriptor.java
+++ b/src/main/java/org/apache/commons/beanutils2/MappedPropertyDescriptor.java
@@ -181,7 +181,8 @@ public class MappedPropertyDescriptor extends PropertyDescriptor {
         }
 
         final Method method = MethodUtils.getMatchingAccessibleMethod(clazz, methodName, parameterTypes);
-        if (method != null) {
+        // skip static methods, as internalGetMethod does.
+        if (method != null && !Modifier.isStatic(method.getModifiers())) {
             return method;
         }
 

--- a/src/test/java/org/apache/commons/beanutils2/FluentPropertyBeanIntrospectorTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/FluentPropertyBeanIntrospectorTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.beanutils2;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -42,6 +43,23 @@ class FluentPropertyBeanIntrospectorTest {
 
         public void setURI(final URI theURI) {
             mURI = theURI;
+        }
+    }
+
+    public static final class StaticSetterBean {
+        private static String staticValue;
+
+        public static void setStaticOnly(final String value) {
+            staticValue = value;
+        }
+
+        public static StaticSetterBean setStaticProperty(final String value) {
+            staticValue = value;
+            return new StaticSetterBean();
+        }
+
+        public String getStaticProperty() {
+            return staticValue;
         }
     }
 
@@ -118,5 +136,20 @@ class FluentPropertyBeanIntrospectorTest {
         assertNotNull(aDescriptor.getWriteMethod(), "No write method for uri");
 
         assertNull(props.get("uRI"), "Should not find mis-capitalized property");
+    }
+
+    /**
+     * Tests that static methods are not treated as write methods.
+     */
+    @Test
+    void testIntrospectionStaticMethods() throws Exception {
+        final PropertyUtilsBean pu = new PropertyUtilsBean();
+        pu.addBeanIntrospector(new FluentPropertyBeanIntrospector());
+        final Map<String, PropertyDescriptor> props = createDescriptorMap(pu.getPropertyDescriptors(StaticSetterBean.class));
+        assertNull(props.get("staticOnly"), "Property created from static method");
+        final PropertyDescriptor pd = fetchDescriptor(props, "staticProperty");
+        assertNotNull(pd.getReadMethod(), "No read method for staticProperty");
+        assertNull(pd.getWriteMethod(), "Static method used as write method");
+        assertFalse(pu.isWriteable(new StaticSetterBean(), "staticProperty"), "staticProperty is writeable");
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/MappedPropertyTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/MappedPropertyTest.java
@@ -226,6 +226,16 @@ class MappedPropertyTest {
     }
 
     /**
+     * Test static mapped accessors are ignored
+     */
+    @Test
+    void testStaticMapped() {
+        final String property = "staticMapped";
+        final Class<?> clazz = MappedPropertyTestBean.class;
+        assertThrows(IntrospectionException.class, () -> new MappedPropertyDescriptor(property, clazz));
+    }
+
+    /**
      * Test 'protected' method in parent
      */
     @Test

--- a/src/test/java/org/apache/commons/beanutils2/MappedPropertyTestBean.java
+++ b/src/test/java/org/apache/commons/beanutils2/MappedPropertyTestBean.java
@@ -29,6 +29,14 @@ public class MappedPropertyTestBean {
     private final Map<Object, Object> map = new HashMap<>();
     private final Map<Object, Object> myMap = new HashMap<>();
 
+    public static String getStaticMapped(final String key) {
+        return "static-" + key;
+    }
+
+    public static void setStaticMapped(final String key, final String value) {
+        // empty
+    }
+
     public Long getDifferentTypes(final String key) {
         return Long.valueOf(((Number) map.get(key)).longValue());
     }


### PR DESCRIPTION
`FluentPropertyBeanIntrospector.introspect` turns every public method whose name starts with the write prefix into a write method without checking `Modifier.isStatic`, and `MappedPropertyDescriptor.getMethod` accepts the static methods `getMatchingAccessibleMethod` returns (unlike its sibling `internalGetMethod`, which already skips them), so once the fluent introspector is registered `BeanUtils.setProperty(form, "locale.default", "fr-FR")` on any bean with a `Locale` getter invokes the static `Locale.setDefault` and any public static `setX(T)` or `getX(String)`/`setX(String, T)` reachable through a nested property becomes writable from a `populate` map; found while auditing the introspectors against the JavaBeans rule `java.beans.Introspector` follows (static methods are never accessors), fixed by skipping static methods at both lookup sites, with regression tests in `FluentPropertyBeanIntrospectorTest` and `MappedPropertyTest` that fail without the runtime change.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
