### PR TITLE
NumberConverter.toNumber(Class, Number): Preserve float and double magnitude when converting to BigInteger

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/converters/NumberConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/converters/NumberConverter.java
@@ -493,6 +493,9 @@ public abstract class NumberConverter<N extends Number> extends AbstractConverte
             if (value instanceof BigDecimal) {
                 return targetType.cast(((BigDecimal) value).toBigInteger());
             }
+            if (value instanceof Float || value instanceof Double) {
+                return targetType.cast(new BigDecimal(value.toString()).toBigInteger());
+            }
             return targetType.cast(BigInteger.valueOf(value.longValue()));
         }
 

--- a/src/test/java/org/apache/commons/beanutils2/converters/BigIntegerConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/BigIntegerConverterTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.beanutils2.converters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import org.apache.commons.beanutils2.Converter;
@@ -60,6 +61,15 @@ class BigIntegerConverterTest extends AbstractNumberConverterTest<BigInteger> {
     @AfterEach
     public void tearDown() throws Exception {
         converter = null;
+    }
+
+    @Test
+    void testLargeFloatingPointMagnitude() {
+        // A Float or Double beyond long range must keep its magnitude instead of saturating to Long.MAX_VALUE.
+        final Double bigDouble = Double.valueOf(1.0e30);
+        assertEquals(new BigDecimal(bigDouble.toString()).toBigInteger(), converter.convert(BigInteger.class, bigDouble));
+        final Float bigFloat = Float.valueOf(1.0e20f);
+        assertEquals(new BigDecimal(bigFloat.toString()).toBigInteger(), converter.convert(BigInteger.class, bigFloat));
     }
 
     @Test


### PR DESCRIPTION
`NumberConverter.toNumber(Class, Number)` converts a `Float` or `Double` source to `BigInteger` through `BigInteger.valueOf(value.longValue())`, so a floating-point magnitude past `long` range silently saturates instead of keeping its value: `converter.convert(BigInteger.class, 1e30d)` returns `9223372036854775807` and `1e20f` returns the same, not the real magnitude.

the sibling `BigDecimal` branch just above already formats `Float`/`Double` with `new BigDecimal(value.toString())` to avoid exactly this, and #401 / #408 established that `BigInteger` and `BigDecimal` conversions must preserve magnitude. this routes floating-point sources through `new BigDecimal(value.toString()).toBigInteger()`; integer sources keep the exact `longValue()` path and in-range values are unchanged. found while auditing the `toNumber` narrowing family after #404, which only added the `Long` and `Float` range checks and never touched the `BigInteger` branch.

`BigIntegerConverterTest.testLargeFloatingPointMagnitude` fails before the change (`9223372036854775807`) and passes after.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.