### PR TITLE
fix range checks bypassed by wraparound in number converters

### DIFF
--- a/src/main/java/org/apache/commons/beanutils2/converters/NumberConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/converters/NumberConverter.java
@@ -318,6 +318,59 @@ public abstract class NumberConverter<N extends Number> extends AbstractConverte
     }
 
     /**
+     * Converts a {@code Number} to a {@code long}, validating that its whole part is within the specified range.
+     * <p>
+     * The range test must not be performed on a narrowed copy of the value: {@code longValue()} of a {@link BigInteger} or {@link BigDecimal} keeps only the
+     * low-order 64 bits and a {@code double} cannot represent every {@code long}, so an out-of-range value can wrap or round into range before a {@code long}
+     * or {@code double} based bounds check sees it. These types are therefore compared as {@link BigDecimal}.
+     *
+     * @param sourceType The type being converted from
+     * @param targetType The Number type to convert to
+     * @param value      The Number to convert.
+     * @param min        The smallest value of the target type
+     * @param max        The largest value of the target type
+     * @return The value as a {@code long}, with any fractional part discarded.
+     * @throws ConversionException if the value is outside the specified range.
+     */
+    private long toLong(final Class<?> sourceType, final Class<?> targetType, final Number value, final long min, final long max) {
+        BigDecimal decimalValue = null;
+        if (value instanceof BigDecimal) {
+            decimalValue = (BigDecimal) value;
+        } else if (value instanceof BigInteger) {
+            decimalValue = new BigDecimal((BigInteger) value);
+        } else if (value instanceof Float || value instanceof Double) {
+            final double doubleValue = value.doubleValue();
+            if (doubleValue == Double.POSITIVE_INFINITY) {
+                throw ConversionException.format("%s value '%s' is too large for %s", toString(sourceType), value, toString(targetType));
+            }
+            if (doubleValue == Double.NEGATIVE_INFINITY) {
+                throw ConversionException.format("%s value '%s' is too small %s", toString(sourceType), value, toString(targetType));
+            }
+            if (!Double.isNaN(doubleValue)) {
+                decimalValue = new BigDecimal(doubleValue);
+            }
+        }
+        if (decimalValue != null) {
+            // Values whose whole part truncates into range stay accepted, so compare against min - 1 and max + 1.
+            if (decimalValue.compareTo(BigDecimal.valueOf(max).add(BigDecimal.ONE)) >= 0) {
+                throw ConversionException.format("%s value '%s' is too large for %s", toString(sourceType), value, toString(targetType));
+            }
+            if (decimalValue.compareTo(BigDecimal.valueOf(min).subtract(BigDecimal.ONE)) <= 0) {
+                throw ConversionException.format("%s value '%s' is too small %s", toString(sourceType), value, toString(targetType));
+            }
+            return decimalValue.longValue();
+        }
+        final long longValue = value.longValue();
+        if (longValue > max) {
+            throw ConversionException.format("%s value '%s' is too large for %s", toString(sourceType), value, toString(targetType));
+        }
+        if (longValue < min) {
+            throw ConversionException.format("%s value '%s' is too small %s", toString(sourceType), value, toString(targetType));
+        }
+        return longValue;
+    }
+
+    /**
      * Default String to Number conversion.
      * <p>
      * This method handles conversion from a String to the following types:
@@ -413,49 +466,22 @@ public abstract class NumberConverter<N extends Number> extends AbstractConverte
 
         // Byte
         if (targetType.equals(Byte.class)) {
-            final long longValue = value.longValue();
-            if (longValue > Byte.MAX_VALUE) {
-                throw ConversionException.format("%s value '%s' is too large for %s", toString(sourceType), value, toString(targetType));
-            }
-            if (longValue < Byte.MIN_VALUE) {
-                throw ConversionException.format("%s value '%s' is too small %s", toString(sourceType), value, toString(targetType));
-            }
-            return targetType.cast(Byte.valueOf(value.byteValue()));
+            return targetType.cast(Byte.valueOf((byte) toLong(sourceType, targetType, value, Byte.MIN_VALUE, Byte.MAX_VALUE)));
         }
 
         // Short
         if (targetType.equals(Short.class)) {
-            final long longValue = value.longValue();
-            if (longValue > Short.MAX_VALUE) {
-                throw ConversionException.format("%s value '%s' is too large for %s", toString(sourceType), value, toString(targetType));
-            }
-            if (longValue < Short.MIN_VALUE) {
-                throw ConversionException.format("%s value '%s' is too small %s", toString(sourceType), value, toString(targetType));
-            }
-            return targetType.cast(Short.valueOf(value.shortValue()));
+            return targetType.cast(Short.valueOf((short) toLong(sourceType, targetType, value, Short.MIN_VALUE, Short.MAX_VALUE)));
         }
 
         // Integer
         if (targetType.equals(Integer.class)) {
-            final long longValue = value.longValue();
-            if (longValue > Integer.MAX_VALUE) {
-                throw ConversionException.format("%s value '%s' is too large for %s", toString(sourceType), value, toString(targetType));
-            }
-            if (longValue < Integer.MIN_VALUE) {
-                throw ConversionException.format("%s value '%s' is too small %s", toString(sourceType), value, toString(targetType));
-            }
-            return targetType.cast(Integer.valueOf(value.intValue()));
+            return targetType.cast(Integer.valueOf((int) toLong(sourceType, targetType, value, Integer.MIN_VALUE, Integer.MAX_VALUE)));
         }
 
         // Long
         if (targetType.equals(Long.class)) {
-            if (value.doubleValue() > Long.MAX_VALUE) {
-                throw ConversionException.format("%s value '%s' is too large for %s", toString(sourceType), value, toString(targetType));
-            }
-            if (value.doubleValue() < Long.MIN_VALUE) {
-                throw ConversionException.format("%s value '%s' is too small %s", toString(sourceType), value, toString(targetType));
-            }
-            return targetType.cast(Long.valueOf(value.longValue()));
+            return targetType.cast(Long.valueOf(toLong(sourceType, targetType, value, Long.MIN_VALUE, Long.MAX_VALUE)));
         }
 
         // Float

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/ByteLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/ByteLocaleConverter.java
@@ -71,8 +71,8 @@ public class ByteLocaleConverter extends DecimalLocaleConverter<Byte> {
     @Override
     protected Byte parse(final Object value, final String pattern) throws ParseException {
         final Number parsed = super.parse(value, pattern);
-        if (parsed.longValue() != parsed.byteValue()) {
-            throw new ConversionException("Supplied number is not of type Byte: " + parsed.longValue());
+        if (parsed.longValue() != parsed.byteValue() || !inRange(parsed, Byte.MIN_VALUE, Byte.MAX_VALUE)) {
+            throw new ConversionException("Supplied number is not of type Byte: " + parsed);
         }
         // now returns property Byte
         return Byte.valueOf(checkInteger(parsed).byteValue());

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/DecimalLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/DecimalLocaleConverter.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.beanutils2.locale.converters;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
@@ -102,6 +104,36 @@ public class DecimalLocaleConverter<T extends Number> extends BaseLocaleConverte
             throw new ConversionException("Supplied number is not an integer: " + number);
         }
         return number;
+    }
+
+    /**
+     * Tests whether the whole part of the given number is within the specified range.
+     * <p>
+     * The test must not be performed on a narrowed copy of the value: {@code longValue()} of a {@link BigInteger} or {@link BigDecimal} keeps only the
+     * low-order 64 bits and a {@code double} cannot represent every {@code long}, so an out-of-range value can wrap or round into range before a narrowed
+     * bounds check sees it. These types are therefore compared as {@link BigDecimal}; other types compare their {@code longValue()}.
+     *
+     * @param number The number to test.
+     * @param min    The smallest value of the target type.
+     * @param max    The largest value of the target type.
+     * @return {@code true} if the whole part of the number is within the range.
+     */
+    boolean inRange(final Number number, final long min, final long max) {
+        BigDecimal decimalValue = null;
+        if (number instanceof BigDecimal) {
+            decimalValue = (BigDecimal) number;
+        } else if (number instanceof BigInteger) {
+            decimalValue = new BigDecimal((BigInteger) number);
+        } else if ((number instanceof Float || number instanceof Double) && Double.isFinite(number.doubleValue())) {
+            decimalValue = new BigDecimal(number.doubleValue());
+        }
+        if (decimalValue != null) {
+            // Values whose whole part truncates into range stay accepted, so compare against min - 1 and max + 1.
+            return decimalValue.compareTo(BigDecimal.valueOf(max).add(BigDecimal.ONE)) < 0
+                    && decimalValue.compareTo(BigDecimal.valueOf(min).subtract(BigDecimal.ONE)) > 0;
+        }
+        final long longValue = number.longValue();
+        return longValue <= max && longValue >= min;
     }
 
     /**

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/IntegerLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/IntegerLocaleConverter.java
@@ -71,8 +71,8 @@ public class IntegerLocaleConverter extends DecimalLocaleConverter<Integer> {
     @Override
     protected Integer parse(final Object value, final String pattern) throws ParseException {
         final Number parsed = super.parse(value, pattern);
-        if (parsed.longValue() != parsed.intValue()) {
-            throw new ConversionException("Supplied number is not of type Integer: " + parsed.longValue());
+        if (parsed.longValue() != parsed.intValue() || !inRange(parsed, Integer.MIN_VALUE, Integer.MAX_VALUE)) {
+            throw new ConversionException("Supplied number is not of type Integer: " + parsed);
         }
         return Integer.valueOf(checkInteger(parsed).intValue()); // unlike superclass it will return proper Integer
     }

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/LongLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/LongLocaleConverter.java
@@ -76,7 +76,7 @@ public class LongLocaleConverter extends DecimalLocaleConverter<Long> {
             return (Long) result;
         }
         final double doubleValue = result.doubleValue();
-        if (doubleValue < Long.MIN_VALUE || doubleValue > Long.MAX_VALUE) {
+        if (doubleValue < Long.MIN_VALUE || doubleValue > Long.MAX_VALUE || !inRange(result, Long.MIN_VALUE, Long.MAX_VALUE)) {
             throw new ConversionException("Supplied number is not of type Long: " + result);
         }
         return Long.valueOf(checkInteger(result).longValue());

--- a/src/main/java/org/apache/commons/beanutils2/locale/converters/ShortLocaleConverter.java
+++ b/src/main/java/org/apache/commons/beanutils2/locale/converters/ShortLocaleConverter.java
@@ -81,8 +81,8 @@ public class ShortLocaleConverter extends DecimalLocaleConverter<Short> {
             return (Short) result;
         }
         final Number parsed = (Number) result;
-        if (parsed.longValue() != parsed.shortValue()) {
-            throw new ConversionException("Supplied number is not of type Short: " + parsed.longValue());
+        if (parsed.longValue() != parsed.shortValue() || !inRange(parsed, Short.MIN_VALUE, Short.MAX_VALUE)) {
+            throw new ConversionException("Supplied number is not of type Short: " + parsed);
         }
         // now returns property Short
         return Short.valueOf(checkInteger(parsed).shortValue());

--- a/src/test/java/org/apache/commons/beanutils2/converters/ByteConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ByteConverterTest.java
@@ -20,6 +20,9 @@ package org.apache.commons.beanutils2.converters;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
 import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
 import org.junit.jupiter.api.AfterEach;
@@ -81,6 +84,20 @@ class ByteConverterTest extends AbstractNumberConverterTest<Byte> {
         assertThrows(ConversionException.class, () -> converter.convert(clazz, minMinusOne), "Less than minimum, expected ConversionException");
         // Too Large
         assertThrows(ConversionException.class, () -> converter.convert(clazz, maxPlusOne), "More than maximum, expected ConversionException");
+    }
+
+    /**
+     * A {@link BigInteger} or {@link BigDecimal} beyond long range wraps to its low-order 64 bits in {@code longValue()}, so it can slip through a long-based
+     * bounds check and convert to an unrelated in-range value (2^64 + 5 converted to 5); it must be rejected.
+     */
+    @Test
+    void testWrappedAmount() {
+        final Converter<Byte> converter = makeConverter();
+        final Class<Byte> clazz = Byte.class;
+        final BigInteger wrapped = BigInteger.ONE.shiftLeft(64).add(BigInteger.valueOf(5));
+        assertThrows(ConversionException.class, () -> converter.convert(clazz, wrapped), "2^64 + 5, expected ConversionException");
+        assertThrows(ConversionException.class, () -> converter.convert(clazz, new BigDecimal(wrapped)), "2^64 + 5, expected ConversionException");
+        assertThrows(ConversionException.class, () -> converter.convert(clazz, wrapped.negate()), "-(2^64 + 5), expected ConversionException");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/beanutils2/converters/ByteLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ByteLocaleConverterTest.java
@@ -17,6 +17,11 @@
 
 package org.apache.commons.beanutils2.converters;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigInteger;
+
+import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.locale.converters.ByteLocaleConverter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -204,5 +209,16 @@ class ByteLocaleConverterTest extends AbstractLocaleConverterTest<Byte> {
     void testNonIntegerRejected() {
         converter = ByteLocaleConverter.builder().setDefault(defaultValue).setLocale(defaultLocale).get();
         convertValueNoPattern(converter, "non-integer", "5.5", defaultValue);
+    }
+
+    /**
+     * A {@link BigInteger} beyond long range wraps to its low-order 64 bits in {@code longValue()}, so it can slip through a long-based range check and
+     * convert to an unrelated in-range value (2^64 + 5 converted to 5); it must be rejected.
+     */
+    @Test
+    void testWrappedOutOfRangeRejected() {
+        converter = ByteLocaleConverter.builder().setLocale(defaultLocale).get();
+        final BigInteger wrapped = BigInteger.ONE.shiftLeft(64).add(BigInteger.valueOf(5));
+        assertThrows(ConversionException.class, () -> converter.convert(wrapped), "2^64 + 5, expected ConversionException");
     }
 }

--- a/src/test/java/org/apache/commons/beanutils2/converters/IntegerConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/IntegerConverterTest.java
@@ -20,6 +20,8 @@ package org.apache.commons.beanutils2.converters;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.math.BigInteger;
+
 import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
 import org.junit.jupiter.api.AfterEach;
@@ -81,6 +83,19 @@ class IntegerConverterTest extends AbstractNumberConverterTest<Integer> {
         assertThrows(ConversionException.class, () -> converter.convert(clazz, minMinusOne), "Less than minimum, expected ConversionException");
         // Too Large
         assertThrows(ConversionException.class, () -> converter.convert(clazz, maxPlusOne), "More than maximum, expected ConversionException");
+    }
+
+    /**
+     * A {@link BigInteger} beyond long range wraps to its low-order 64 bits in {@code longValue()}, so it can slip through a long-based bounds check and
+     * convert to an unrelated in-range value (2^64 + 5 converted to 5); it must be rejected.
+     */
+    @Test
+    void testWrappedAmount() {
+        final Converter<Integer> converter = makeConverter();
+        final Class<?> clazz = Integer.class;
+        final BigInteger wrapped = BigInteger.ONE.shiftLeft(64).add(BigInteger.valueOf(5));
+        assertThrows(ConversionException.class, () -> converter.convert(clazz, wrapped), "2^64 + 5, expected ConversionException");
+        assertThrows(ConversionException.class, () -> converter.convert(clazz, wrapped.negate()), "-(2^64 + 5), expected ConversionException");
     }
 
     /**

--- a/src/test/java/org/apache/commons/beanutils2/converters/IntegerLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/IntegerLocaleConverterTest.java
@@ -18,7 +18,11 @@
 package org.apache.commons.beanutils2.converters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.math.BigInteger;
+
+import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.locale.converters.IntegerLocaleConverter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -199,6 +203,17 @@ class IntegerLocaleConverterTest extends AbstractLocaleConverterTest<Integer> {
     void testNonIntegerRejected() {
         converter = IntegerLocaleConverter.builder().setDefault(defaultValue).setLocale(defaultLocale).get();
         convertValueNoPattern(converter, "non-integer", "5.5", defaultValue);
+    }
+
+    /**
+     * A {@link BigInteger} beyond long range wraps to its low-order 64 bits in {@code longValue()}, so it can slip through a long-based range check and
+     * convert to an unrelated in-range value (2^64 + 5 converted to 5); it must be rejected.
+     */
+    @Test
+    void testWrappedOutOfRangeRejected() {
+        converter = IntegerLocaleConverter.builder().setLocale(defaultLocale).get();
+        final BigInteger wrapped = BigInteger.ONE.shiftLeft(64).add(BigInteger.valueOf(5));
+        assertThrows(ConversionException.class, () -> converter.convert(wrapped), "2^64 + 5, expected ConversionException");
     }
 
     /**

--- a/src/test/java/org/apache/commons/beanutils2/converters/LongConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/LongConverterTest.java
@@ -20,6 +20,7 @@ package org.apache.commons.beanutils2.converters;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
 
@@ -91,6 +92,37 @@ class LongConverterTest extends AbstractNumberConverterTest<Long> {
         final LongConverter converter = makeConverter();
         converter.setLocale(Locale.US);
         assertThrows(ConversionException.class, () -> converter.convert(Long.class, "99999999999999999999"), "More than maximum, expected ConversionException");
+    }
+
+    /**
+     * A locale-parsed String one past {@link Long#MAX_VALUE} comes back from {@link java.text.DecimalFormat} as the {@link Double} 2^63, which a double-based
+     * bounds check cannot distinguish from {@link Long#MAX_VALUE}; it must be rejected rather than clamped.
+     */
+    @Test
+    void testLocaleStringOutOfRangeBoundary() {
+        final LongConverter converter = makeConverter();
+        converter.setLocale(Locale.US);
+        assertThrows(ConversionException.class, () -> converter.convert(Long.class, "9223372036854775808"), "One more than maximum, expected ConversionException");
+    }
+
+    /**
+     * Values just past the long range must not wrap or round into range before the bounds check sees them: {@code longValue()} of a {@link BigInteger} keeps
+     * only the low-order 64 bits (so 2^63 becomes {@link Long#MIN_VALUE}) and {@code doubleValue()} of 2^63 equals the double representation of
+     * {@link Long#MAX_VALUE}.
+     */
+    @Test
+    void testOutOfRangeBoundary() {
+        final Converter<Long> converter = makeConverter();
+        final Class<?> clazz = Long.class;
+        final BigInteger maxPlusOne = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        final BigInteger minMinusOne = BigInteger.valueOf(Long.MIN_VALUE).subtract(BigInteger.ONE);
+        assertThrows(ConversionException.class, () -> converter.convert(clazz, maxPlusOne), "One more than maximum, expected ConversionException");
+        assertThrows(ConversionException.class, () -> converter.convert(clazz, minMinusOne), "One less than minimum, expected ConversionException");
+        assertThrows(ConversionException.class, () -> converter.convert(clazz, new BigDecimal(maxPlusOne)), "One more than maximum, expected ConversionException");
+        assertThrows(ConversionException.class, () -> converter.convert(clazz, Double.valueOf(9.223372036854775808E18)), "2^63, expected ConversionException");
+        // Boundaries still convert
+        assertEquals(Long.valueOf(Long.MAX_VALUE), converter.convert(clazz, BigInteger.valueOf(Long.MAX_VALUE)), "Maximum");
+        assertEquals(Long.valueOf(Long.MIN_VALUE), converter.convert(clazz, BigInteger.valueOf(Long.MIN_VALUE)), "Minimum");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/beanutils2/converters/LongLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/LongLocaleConverterTest.java
@@ -20,6 +20,7 @@ package org.apache.commons.beanutils2.converters;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.math.BigInteger;
 import java.text.DecimalFormat;
 
 import org.apache.commons.beanutils2.ConversionException;
@@ -207,6 +208,21 @@ class LongLocaleConverterTest extends AbstractLocaleConverterTest<Long> {
         assertEquals(Long.valueOf(Long.MIN_VALUE), converter.convert(fmt.format(Long.MIN_VALUE)), "Long.MIN_VALUE");
         assertThrows(ConversionException.class, () -> converter.convert("99999999999999999999"));
         assertThrows(ConversionException.class, () -> converter.convert("-99999999999999999999"));
+    }
+
+    /**
+     * Values just past the long range must not wrap or round into range before the range check sees them: a parsed String one past {@link Long#MAX_VALUE}
+     * comes back from {@link DecimalFormat} as the {@link Double} 2^63, which a double-based comparison cannot distinguish from {@link Long#MAX_VALUE}, and
+     * {@code longValue()} of a {@link BigInteger} keeps only the low-order 64 bits, so 2^63 becomes {@link Long#MIN_VALUE}.
+     */
+    @Test
+    void testOutOfRangeBoundaryRejected() {
+        converter = LongLocaleConverter.builder().setLocale(defaultLocale).get();
+        assertThrows(ConversionException.class, () -> converter.convert("9223372036854775808"), "One more than maximum, expected ConversionException");
+        final BigInteger maxPlusOne = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        assertThrows(ConversionException.class, () -> converter.convert(maxPlusOne), "2^63, expected ConversionException");
+        assertThrows(ConversionException.class, () -> converter.convert(BigInteger.valueOf(Long.MIN_VALUE).subtract(BigInteger.ONE)),
+                "One less than minimum, expected ConversionException");
     }
 
     /**

--- a/src/test/java/org/apache/commons/beanutils2/converters/ShortConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ShortConverterTest.java
@@ -20,6 +20,8 @@ package org.apache.commons.beanutils2.converters;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.math.BigInteger;
+
 import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.Converter;
 import org.junit.jupiter.api.AfterEach;
@@ -81,6 +83,19 @@ class ShortConverterTest extends AbstractNumberConverterTest<Short> {
         assertThrows(ConversionException.class, () -> converter.convert(clazz, minMinusOne), "Less than minimum, expected ConversionException");
         // Too Large
         assertThrows(ConversionException.class, () -> converter.convert(clazz, maxPlusOne), "More than maximum, expected ConversionException");
+    }
+
+    /**
+     * A {@link BigInteger} beyond long range wraps to its low-order 64 bits in {@code longValue()}, so it can slip through a long-based bounds check and
+     * convert to an unrelated in-range value (2^64 + 5 converted to 5); it must be rejected.
+     */
+    @Test
+    void testWrappedAmount() {
+        final Converter<Short> converter = makeConverter();
+        final Class<?> clazz = Short.class;
+        final BigInteger wrapped = BigInteger.ONE.shiftLeft(64).add(BigInteger.valueOf(5));
+        assertThrows(ConversionException.class, () -> converter.convert(clazz, wrapped), "2^64 + 5, expected ConversionException");
+        assertThrows(ConversionException.class, () -> converter.convert(clazz, wrapped.negate()), "-(2^64 + 5), expected ConversionException");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/beanutils2/converters/ShortLocaleConverterTest.java
+++ b/src/test/java/org/apache/commons/beanutils2/converters/ShortLocaleConverterTest.java
@@ -17,6 +17,11 @@
 
 package org.apache.commons.beanutils2.converters;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigInteger;
+
+import org.apache.commons.beanutils2.ConversionException;
 import org.apache.commons.beanutils2.locale.converters.ShortLocaleConverter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -197,5 +202,16 @@ class ShortLocaleConverterTest extends AbstractLocaleConverterTest<Short> {
     void testNonIntegerRejected() {
         converter = ShortLocaleConverter.builder().setDefault(defaultValue).setLocale(defaultLocale).get();
         convertValueNoPattern(converter, "non-integer", "5.5", defaultValue);
+    }
+
+    /**
+     * A {@link BigInteger} beyond long range wraps to its low-order 64 bits in {@code longValue()}, so it can slip through a long-based range check and
+     * convert to an unrelated in-range value (2^64 + 5 converted to 5); it must be rejected.
+     */
+    @Test
+    void testWrappedOutOfRangeRejected() {
+        converter = ShortLocaleConverter.builder().setLocale(defaultLocale).get();
+        final BigInteger wrapped = BigInteger.ONE.shiftLeft(64).add(BigInteger.valueOf(5));
+        assertThrows(ConversionException.class, () -> converter.convert(wrapped), "2^64 + 5, expected ConversionException");
     }
 }


### PR DESCRIPTION
the range checks in `NumberConverter.toNumber(Class, Number)` and in the byte/short/integer/long locale converters run on `longValue()`/`doubleValue()` of the source, but `longValue()` of a `BigInteger` or `BigDecimal` keeps only the low-order 64 bits and a `double` cannot represent 2^63 - 1, so out-of-range values wrap or round into range and convert to unrelated results (`BigInteger` 2^63 becomes `Long.MIN_VALUE`, 2^64 + 5 becomes `Integer` 5, and a locale-parsed `"9223372036854775808"` is clamped to `Long.MAX_VALUE`); found while checking the bounds from #404 against boundary values, fixed by comparing the exact value as `BigDecimal` before narrowing.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
  - Claude (Anthropic) was used to find the bug and to write the patch, the tests and this description. This account is responsible for what it submits.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.

